### PR TITLE
Changing the default values for polling interval and maximum number of tablets

### DIFF
--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -502,11 +502,11 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     protected static final int DEFAULT_MAX_RETRIES = 6;
     protected static final int DEFAULT_MASTER_PORT = 7100;
     protected static final String DEFAULT_MASTER_ADDRESS = "127.0.0.1:7100";
-    protected static final int DEFAULT_MAX_NUM_TABLETS = 10;
+    protected static final int DEFAULT_MAX_NUM_TABLETS = 100;
     protected static final long DEFAULT_ADMIN_OPERATION_TIMEOUT_MS = 60000;
     protected static final long DEFAULT_OPERATION_TIMEOUT_MS = 60000;
     protected static final long DEFAULT_SOCKET_READ_TIMEOUT_MS = 60000;
-    protected static final long DEFAULT_CDC_POLL_INTERVAL_MS = 200;
+    protected static final long DEFAULT_CDC_POLL_INTERVAL_MS = 500;
 
     @Override
     public Configuration getJdbcConfig() {


### PR DESCRIPTION
The following configuration's default values have been changed as mentioned:
* table.max.num.tablets --> old: 10, new: 100
* cdc.poll.interval.ms --> old: 200, new: 500