### PR TITLE
Throw exception on wrong table include list

### DIFF
--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
@@ -390,8 +390,8 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
             }
         }
         catch (DebeziumException de) {
-            // We do not want to catch this exception since this will be thrown while initializing the connector
-            // and at this point if this exception is thrown, we should not proceed forward with the connector
+            // We are ultimately throwing this exception since this will be thrown while initializing the connector
+            // and at this point if this exception is thrown, we should not proceed forward with the connector.
             throw de;
         }
         catch (Exception e) {

--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
@@ -381,7 +381,12 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
                 if (yugabyteDBConnectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId)) {
                     // Throw an exception if the table in the include list is not a part of DB stream ID
                     if (!isTableIncludedInStreamId(dbStreamInfoResponse, tableInfo.getId().toStringUtf8())) {
-                        throw new DebeziumException("The table " + tableId + " is not a part of the stream ID " + yugabyteDBConnectorConfig.streamId());
+                        String warningMessage = "The table " + tableId + " is not a part of the stream ID " + yugabyteDBConnectorConfig.streamId();
+                        if (yugabyteDBConnectorConfig.ignoreExceptions()) {
+                            LOGGER.warn(warningMessage + ". Ignoring the table.");
+                            continue;
+                        }
+                        throw new DebeziumException(warningMessage);
                     }
 
                     LOGGER.info(String.format("Adding table %s for streaming (%s)", tableInfo.getId().toStringUtf8(), fqlTableName));

--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yb.client.*;
 import org.yb.master.MasterDdlOuterClass;
+import org.yb.master.MasterReplicationOuterClass;
 import org.yb.master.MasterTypes;
 
 import com.google.common.net.HostAndPort;
@@ -338,6 +339,17 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
         }
     }
 
+    private boolean isTableIncludedInStreamId(GetDBStreamInfoResponse resp, String tableId) {
+        for (MasterReplicationOuterClass.GetCDCDBStreamInfoResponsePB.TableInfo tableInfo : resp.getTableInfoList()) {
+            if (Objects.equals(tableId, tableInfo.getTableId().toStringUtf8())) {
+                return true;
+            }
+        }
+
+        // This signifies that the table ID we have provided is not a part of the stream ID
+        return false;
+    }
+
     private Set<String> fetchTabletList() {
         LOGGER.debug("Fetching tables");
         Set<String> tIds = new HashSet<>();
@@ -362,11 +374,25 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
 
                 String fqlTableName = tableInfo.getNamespace().getName() + "." + tableInfo.getPgschemaName() + "." + tableInfo.getName();
                 TableId tableId = YugabyteDBSchema.parseWithSchema(fqlTableName, tableInfo.getPgschemaName());
+
+                // Retrieve the list of tables in the stream ID,
+                GetDBStreamInfoResponse dbStreamInfoResponse = this.ybClient.getDBStreamInfo(yugabyteDBConnectorConfig.streamId());
+
                 if (yugabyteDBConnectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId)) {
+                    // Throw an exception if the table in the include list is not a part of DB stream ID
+                    if (!isTableIncludedInStreamId(dbStreamInfoResponse, tableInfo.getId().toStringUtf8())) {
+                        throw new DebeziumException("The table " + tableId + " is not a part of the stream ID " + yugabyteDBConnectorConfig.streamId());
+                    }
+
                     LOGGER.info(String.format("Adding table %s for streaming (%s)", tableInfo.getId().toStringUtf8(), fqlTableName));
                     tIds.add(tableInfo.getId().toStringUtf8());
                 }
             }
+        }
+        catch (DebeziumException de) {
+            // We do not want to catch this exception since this will be thrown while initializing the connector
+            // and at this point if this exception is thrown, we should not proceed forward with the connector
+            throw de;
         }
         catch (Exception e) {
             e.printStackTrace();

--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -576,6 +576,12 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
             .withDefault(DEFAULT_CDC_POLL_INTERVAL_MS)
             .withDescription("The poll interval in milliseconds at which the client will request for changes from the database");
 
+    public static final Field IGNORE_EXCEPTIONS = Field.create("ignore.exceptions")
+            .withDisplayName("Flag to ignore exceptions which do not cause an issue while execution")
+            .withType(Type.BOOLEAN)
+            .withImportance(Importance.LOW)
+            .withDefault(false);
+
     public static final Field AUTO_CREATE_STREAM = Field.create("auto.create.stream")
             .withDisplayName("Specify whether to create a stream by default")
             .withType(Type.BOOLEAN)
@@ -993,6 +999,10 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
 
     public boolean autoCreateStream() {
         return getConfig().getBoolean(AUTO_CREATE_STREAM);
+    }
+
+    public boolean ignoreExceptions() {
+        return getConfig().getBoolean(IGNORE_EXCEPTIONS;
     }
 
     public int maxNumTablets() {

--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -1002,7 +1002,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     }
 
     public boolean ignoreExceptions() {
-        return getConfig().getBoolean(IGNORE_EXCEPTIONS;
+        return getConfig().getBoolean(IGNORE_EXCEPTIONS);
     }
 
     public int maxNumTablets() {

--- a/debezium-connector-yugabytedb2/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBWrongIncludeListTest.java
+++ b/debezium-connector-yugabytedb2/src/test/java/io/debezium/connector/yugabytedb/YugabyteDBWrongIncludeListTest.java
@@ -1,0 +1,15 @@
+public class YugabyteDBWrongIncludeListTest {
+  // These comments are here only for the time being and the listed steps need to be performed
+  // to test the functionality
+
+  /*
+   * 1. Create a table test
+   * 2. Create stream ID using yb-admin, let's call it STREAM_ID
+   * 3. Now create another table test2, this won't be a part of STREAM_ID
+   * 4. Now deploy the connector with STREAM_ID and include test and test2 in table.include.list
+   * 5. The connector will throw a warning that table test2 is not a part of STREAM_ID
+   * 6. Delete the connector and deploy it again after adding "ignore.exceptions":"false"
+   * 7. This time the connector will just log a warning and move ahead with processing the changes
+   *    for the table test.
+   */
+}


### PR DESCRIPTION
If a table is not a part of the stream ID we provide to the DBZ connector configuration, and if it is provided in the `table.include.list` then the connector fails.

The ask is to throw an exception if the above condition is encountered. This PR aims to address the same issue.

There's another flag which is added in this PR i.e. `ignore.exceptions` - the default value for this flag is `false` and if it is set to `true`, the connector will log warnings instead of exceptions.