### PR TITLE
Use Metronome utility instead of sleeping

### DIFF
--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -289,15 +289,16 @@ public class YugabyteDBStreamingChangeEventSource implements
         }
         LOGGER.debug("The init tabletSourceInfo is " + offsetContext.getTabletSourceInfo());
 
-        final Metronome metronome = Metronome.parker(Duration.ofMillis(connectorConfig.connectorRetryDelayMs()), Clock.SYSTEM);
+        final Metronome pollIntervalMetronome = Metronome.parker(Duration.ofMillis(connectorConfig.cdcPollIntervalms()), Clock.SYSTEM);
+        final Metronome retryMetronome = Metronome.parker(Duration.ofMillis(connectorConfig.connectorRetryDelayMs()), Clock.SYSTEM);
+        
         short retryCount = 0;
         while (retryCount <= connectorConfig.maxConnectorRetries()) {
             try { 
                 while (context.isRunning() && (offsetContext.getStreamingStoppingLsn() == null ||
                         (lastCompletelyProcessedLsn.compareTo(offsetContext.getStreamingStoppingLsn()) < 0))) {
-                    // The following will specify the connector polling interval at which
-                    // yb-client will ask the database for changes
-                    Thread.sleep(connectorConfig.cdcPollIntervalms());
+                    // Pause for the specified duration before asking for a new set of changes from the server
+                    pollIntervalMetronome.pause();
 
                     for (Pair<String, String> entry : tabletPairList) {
                         final String tabletId = entry.getValue();
@@ -444,7 +445,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                         retryCount, connectorConfig.maxConnectorRetries(), connectorConfig.connectorRetryDelayMs(), e.getMessage());
                 
                 try {
-                    metronome.pause();
+                    retryMetronome.pause();
                 } catch (InterruptedException ie) {
                     LOGGER.warn("Connector retry sleep interrupted by exception: {}", ie);
                     Thread.currentThread().interrupt();

--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -298,6 +298,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                 while (context.isRunning() && (offsetContext.getStreamingStoppingLsn() == null ||
                         (lastCompletelyProcessedLsn.compareTo(offsetContext.getStreamingStoppingLsn()) < 0))) {
                     // Pause for the specified duration before asking for a new set of changes from the server
+                    LOGGER.debug("Pausing for {} milliseconds before polling further", connectorConfig.cdcPollIntervalms());
                     pollIntervalMetronome.pause();
 
                     for (Pair<String, String> entry : tabletPairList) {


### PR DESCRIPTION
This PR aims to remove the `Thread.sleep()` and use a Debezium's utility class named `Metronome` which provides the `pause()` function to pause the execution for the specified duration.