### PR TITLE
Fix to properly filter out tables not a part of the specified database

### DIFF
--- a/debezium-connector-yugabytedb2/pom.xml
+++ b/debezium-connector-yugabytedb2/pom.xml
@@ -41,12 +41,12 @@
         <dependency>
             <groupId>org.yb</groupId>
             <artifactId>yb-client</artifactId>
-            <version>0.8.16-SNAPSHOT</version>
+            <version>0.8.17-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.yb</groupId>
             <artifactId>yb-client</artifactId>
-            <version>0.8.16-SNAPSHOT</version>
+            <version>0.8.17-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/Filters.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/Filters.java
@@ -58,6 +58,7 @@ public class Filters {
                 .excludeTables(tableExcludeList)
                 .includeSchemas(config.schemaIncludeList())
                 .excludeSchemas(schemaExcludeList)
+                .includeDatabases(config.databaseName())
                 .build());
     }
 

--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/Filters.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/Filters.java
@@ -58,7 +58,6 @@ public class Filters {
                 .excludeTables(tableExcludeList)
                 .includeSchemas(config.schemaIncludeList())
                 .excludeSchemas(schemaExcludeList)
-                .includeDatabases(config.databaseName())
                 .build());
     }
 

--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
@@ -379,6 +379,10 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
                 GetDBStreamInfoResponse dbStreamInfoResponse = this.ybClient.getDBStreamInfo(yugabyteDBConnectorConfig.streamId());
 
                 if (yugabyteDBConnectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId)) {
+                    // just checking
+                    if (!yugabyteDBConnectorConfig.databaseFilter().isIncluded(tableId)) {
+                        LOGGER.info("The table {} is not included in the list", tableId);
+                    }
                     // Throw an exception if the table in the include list is not a part of DB stream ID
                     if (!isTableIncludedInStreamId(dbStreamInfoResponse, tableInfo.getId().toStringUtf8())) {
                         String warningMessage = "The table " + tableId + " is not a part of the stream ID " + yugabyteDBConnectorConfig.streamId();
@@ -391,6 +395,8 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
 
                     LOGGER.info(String.format("Adding table %s for streaming (%s)", tableInfo.getId().toStringUtf8(), fqlTableName));
                     tIds.add(tableInfo.getId().toStringUtf8());
+                } else {
+                    LOGGER.info("Skipping the table {} because it was not included in the filter", tableId);
                 }
             }
         }

--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
@@ -378,11 +378,8 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
                 // Retrieve the list of tables in the stream ID,
                 GetDBStreamInfoResponse dbStreamInfoResponse = this.ybClient.getDBStreamInfo(yugabyteDBConnectorConfig.streamId());
 
-                if (yugabyteDBConnectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId)) {
-                    // just checking
-                    if (!yugabyteDBConnectorConfig.databaseFilter().isIncluded(tableId)) {
-                        LOGGER.info("The table {} is not included in the list", tableId);
-                    }
+                if (yugabyteDBConnectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId)
+                    && yugabyteDBConnectorConfig.databaseFilter().isIncluded(tableId)) {
                     // Throw an exception if the table in the include list is not a part of DB stream ID
                     if (!isTableIncludedInStreamId(dbStreamInfoResponse, tableInfo.getId().toStringUtf8())) {
                         String warningMessage = "The table " + tableId + " is not a part of the stream ID " + yugabyteDBConnectorConfig.streamId();
@@ -396,7 +393,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
                     LOGGER.info(String.format("Adding table %s for streaming (%s)", tableInfo.getId().toStringUtf8(), fqlTableName));
                     tIds.add(tableInfo.getId().toStringUtf8());
                 } else {
-                    LOGGER.info("Skipping the table {} because it was not included in the filter", tableId);
+                    LOGGER.debug("Filtering out the table {} since it was not in the include list", tableId);
                 }
             }
         }

--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnector.java
@@ -393,7 +393,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
                     LOGGER.info(String.format("Adding table %s for streaming (%s)", tableInfo.getId().toStringUtf8(), fqlTableName));
                     tIds.add(tableInfo.getId().toStringUtf8());
                 } else {
-                    LOGGER.debug("Filtering out the table {} since it was not in the include list", tableId);
+                    LOGGER.warn("Filtering out the table {} since it was not in the include list", tableId);
                 }
             }
         }

--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -977,7 +977,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     private final SnapshotMode snapshotMode;
     private final SchemaRefreshMode schemaRefreshMode;
 
-    private final TableFilter databaseFilterPredicate;
+    private final TableFilter databaseFilter;
 
     public YugabyteDBConnectorConfig(Configuration config) {
         super(
@@ -995,7 +995,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
         this.snapshotMode = SnapshotMode.parse(config.getString(SNAPSHOT_MODE));
         this.schemaRefreshMode = SchemaRefreshMode.parse(config.getString(SCHEMA_REFRESH_MODE));
 
-        this.databaseFilterPredicate = new DatabasePredicate();
+        this.databaseFilter = new DatabasePredicate();
     }
 
     protected String hostname() {
@@ -1115,7 +1115,7 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     }
 
     protected TableFilter databaseFilter() {
-        return this.databaseFilterPredicate;
+        return this.databaseFilter;
     }
 
     /*
@@ -1227,18 +1227,15 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
 
         @Override
         public boolean isIncluded(TableId t) {
-            LOGGER.info("This is being called: ", new Exception());
             return !SYSTEM_SCHEMAS.contains(t.schema().toLowerCase());
         }
     }
 
-    private static class DatabasePredicate implements TableFilter {
+    private class DatabasePredicate implements TableFilter {
         @Override
         public boolean isIncluded(TableId tableId) {
-            // todo Vaibhav: see how this condition can be modified to cover database.include.list
-            //  if it's possible at all
-            return tableId.catalog() == "api";
-        //   return Objects.equals(tableId.catalog(), );
+            // todo: see if this can be used to handle database.include.list in future
+            return Objects.equals(tableId.catalog(), getConfig().getString(DATABASE_NAME));
         }
     }
 }

--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBConnectorConfig.java
@@ -1234,7 +1234,6 @@ public class YugabyteDBConnectorConfig extends RelationalDatabaseConnectorConfig
     private class DatabasePredicate implements TableFilter {
         @Override
         public boolean isIncluded(TableId tableId) {
-            // todo: see if this can be used to handle database.include.list in future
             return Objects.equals(tableId.catalog(), getConfig().getString(DATABASE_NAME));
         }
     }


### PR DESCRIPTION
This PR aims to address the issue where say `db1` and `db2` had the same table named `test` and if the connector was supplied a configuration with the database `db1`, it was throwing an exception for the other `db1` saying that `The table db2.public.test is not a part of the stream id <stream-id>`.

As a part of this PR, the filter is modified to check for the database name also, so that if a table is common in 2 or more databases, we should just pick up the one in the specified database.

Also changed in this PR:
* yb-client version from 0.8.16 to 0.8.17