### PR TITLE
Fix to bootstrap the tablet when it has <-1,-1> as checkpoint

### DIFF
--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -249,7 +249,7 @@ public class YugabyteDBStreamingChangeEventSource implements
         long term = getCheckpointResponse.getTerm();
         long index = getCheckpointResponse.getIndex();
         LOGGER.info("Checkpoint for tablet {} before going to bootstrap: {}.{}", tabletId, term, index);
-        if (term == 0 && index == 0) {
+        if (term == -1 && index == -1) {
             LOGGER.info("Bootstrapping the tablet {}", tabletId);
             this.syncClient.bootstrapTablet(table, connectorConfig.streamId(), tabletId, 0, 0, true, true);
         } else {


### PR DESCRIPTION
Earlier, the Debezium Connector for YugabyteDB was going to bootstrap the tablets when the tablets returned a checkpoint `<0,0>` 

That logic has now been changes on the server side, so now if no record has been polled yet for a tablet, the server would send `<-1,-1>` as the checkpoint. This PR aims to appreciate the same on the connector side as well, so now the connector will only go to bootstrap if the checkpoint returned from the server is `<-1,-1>`