### PR TITLE
Patch to log the number of records in a transactional block

### DIFF
--- a/debezium-connector-yugabytedb2/pom.xml
+++ b/debezium-connector-yugabytedb2/pom.xml
@@ -41,12 +41,12 @@
         <dependency>
             <groupId>org.yb</groupId>
             <artifactId>yb-client</artifactId>
-            <version>0.8.15-SNAPSHOT</version>
+            <version>0.8.17-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.yb</groupId>
             <artifactId>yb-client</artifactId>
-            <version>0.8.15-SNAPSHOT</version>
+            <version>0.8.17-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -154,7 +154,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.1.1</version>
                 <configuration>
-                    <finalName>debezium-connector-yugabytedb-1.3.5-BETA</finalName>
+                    <finalName>debezium-connector-yugabytedb-1.3.6-BETA</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/debezium-connector-yugabytedb2/pom.xml
+++ b/debezium-connector-yugabytedb2/pom.xml
@@ -41,12 +41,12 @@
         <dependency>
             <groupId>org.yb</groupId>
             <artifactId>yb-client</artifactId>
-            <version>0.8.17-SNAPSHOT</version>
+            <version>0.8.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.yb</groupId>
             <artifactId>yb-client</artifactId>
-            <version>0.8.17-SNAPSHOT</version>
+            <version>0.8.15-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -249,7 +249,7 @@ public class YugabyteDBStreamingChangeEventSource implements
         long term = getCheckpointResponse.getTerm();
         long index = getCheckpointResponse.getIndex();
         LOGGER.info("Checkpoint for tablet {} before going to bootstrap: {}.{}", tabletId, term, index);
-        if (term == -1 && index == -1) {
+        if (term == 0 && index == 0) {
             LOGGER.info("Bootstrapping the tablet {}", tabletId);
             this.syncClient.bootstrapTablet(table, connectorConfig.streamId(), tabletId, 0, 0, true, true);
         } else {

--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -249,7 +249,7 @@ public class YugabyteDBStreamingChangeEventSource implements
         long term = getCheckpointResponse.getTerm();
         long index = getCheckpointResponse.getIndex();
         LOGGER.info("Checkpoint for tablet {} before going to bootstrap: {}.{}", tabletId, term, index);
-        if (term == 0 && index == 0) {
+        if (term == -1 && index == -1) {
             LOGGER.info("Bootstrapping the tablet {}", tabletId);
             this.syncClient.bootstrapTablet(table, connectorConfig.streamId(), tabletId, 0, 0, true, true);
         } else {


### PR DESCRIPTION
This PR aims to add a patch which is to log the number of records coming out in a transaction block between the `BEGIN` and `COMMIT` change records. A warning will be logged if the record count is 0.