### PR TITLE
Shifting bootstrap function inside retry logic for the connector

### DIFF
--- a/debezium-connector-yugabytedb2/pom.xml
+++ b/debezium-connector-yugabytedb2/pom.xml
@@ -154,7 +154,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.1.1</version>
                 <configuration>
-                    <finalName>debezium-connector-yugabytedb-1.3.6-BETA</finalName>
+                    <finalName>debezium-connector-yugabytedb-1.3.7-BETA</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -325,7 +325,7 @@ public class YugabyteDBStreamingChangeEventSource implements
                     ++retryCountForBootstrapping;
 
                     if (retryCountForBootstrapping > connectorConfig.maxConnectorRetries()) {
-                        LOGGER.error("Failed to bootstrap all the tablet {} after {} retries", entry.getValue(), connectorConfig.maxConnectorRetries());
+                        LOGGER.error("Failed to bootstrap the tablet {} after {} retries", entry.getValue(), connectorConfig.maxConnectorRetries());
                         throw e;
                     }
 

--- a/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
+++ b/debezium-connector-yugabytedb2/src/main/java/io/debezium/connector/yugabytedb/YugabyteDBStreamingChangeEventSource.java
@@ -299,9 +299,6 @@ public class YugabyteDBStreamingChangeEventSource implements
         Map<String, Boolean> schemaStreamed = new HashMap<>();
         for (Pair<String, String> entry : tabletPairList) {
             schemaStreamed.put(entry.getValue(), Boolean.TRUE);
-
-            // Iterate over the tablets and bootstrap them
-            bootstrapTablet(this.syncClient.openTableByUUID(entry.getKey()), entry.getValue());
         }
 
         for (Pair<String, String> entry : tabletPairList) {
@@ -321,6 +318,12 @@ public class YugabyteDBStreamingChangeEventSource implements
         short retryCount = 0;
         while (retryCount <= connectorConfig.maxConnectorRetries()) {
             try { 
+                // Iterate over all the tablets to bootstrap them
+                for (Pair<String, String> entry : tabletPairList) {
+                    // entry is a Pair<tableId, tabletId>
+                    bootstrapTablet(this.syncClient.openTableByUUID(entry.getKey()), entry.getValue());
+                }
+
                 while (context.isRunning() && (offsetContext.getStreamingStoppingLsn() == null ||
                         (lastCompletelyProcessedLsn.compareTo(offsetContext.getStreamingStoppingLsn()) < 0))) {
                     // Pause for the specified duration before asking for a new set of changes from the server


### PR DESCRIPTION
This PR aims to make the following amendment:
* Shifting the bootstrap function inside the block for connector retry so that is there's a failure at the bootstrap level, the connector should go for retry.