### PR TITLE
Bug fixes in delete events

### DIFF
--- a/debezium-server/debezium-server-dist/src/main/resources/distro/conf/application.properties.mysql
+++ b/debezium-server/debezium-server-dist/src/main/resources/distro/conf/application.properties.mysql
@@ -10,6 +10,7 @@ debezium.source.topic.naming.strategy=io.debezium.server.ybexporter.DummyTopicNa
 #debezium.source.snapshot.mode=initial_only
 debezium.source.offset.storage.file.filename=data/offsets.dat
 debezium.source.offset.flush.interval.ms=0
+debezium.source.tombstones.on.delete=false
 
 debezium.source.database.hostname=localhost
 debezium.source.database.port=3306

--- a/debezium-server/debezium-server-dist/src/main/resources/distro/conf/application.properties.oracle
+++ b/debezium-server/debezium-server-dist/src/main/resources/distro/conf/application.properties.oracle
@@ -10,6 +10,7 @@ debezium.source.topic.naming.strategy=io.debezium.server.ybexporter.DummyTopicNa
 #debezium.source.snapshot.mode=initial_only
 debezium.source.offset.storage.file.filename=data/offsets.dat
 debezium.source.offset.flush.interval.ms=0
+debezium.source.tombstones.on.delete=false
 
 debezium.source.database.hostname=0.0.0.0
 debezium.source.database.port=1521

--- a/debezium-server/debezium-server-dist/src/main/resources/distro/conf/application.properties.postgres
+++ b/debezium-server/debezium-server-dist/src/main/resources/distro/conf/application.properties.postgres
@@ -11,6 +11,7 @@ debezium.source.topic.naming.strategy=io.debezium.server.ybexporter.DummyTopicNa
 #debezium.source.snapshot.mode=initial_only
 debezium.source.offset.storage.file.filename=data/offsets.dat
 debezium.source.offset.flush.interval.ms=0
+debezium.source.tombstones.on.delete=false
 
 debezium.source.database.hostname=localhost
 debezium.source.database.port=5432

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/KafkaConnectRecordParser.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/KafkaConnectRecordParser.java
@@ -86,8 +86,12 @@ class KafkaConnectRecordParser implements RecordParser {
             t = new Table(dbName, schemaName, tableName);
 
             // parse fields
-            Struct afterStruct = value.getStruct("after");
-            for (Field f : afterStruct.schema().fields()) {
+            Struct structWithAllFields = value.getStruct("after");
+            if (structWithAllFields == null) {
+                // in case of delete events the after field is empty, and the before field is populated.
+                structWithAllFields = value.getStruct("before");
+            }
+            for (Field f : structWithAllFields.schema().fields()) {
                 t.fieldSchemas.put(f.name(), f);
             }
 

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/KafkaConnectRecordParser.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/KafkaConnectRecordParser.java
@@ -31,14 +31,8 @@ class KafkaConnectRecordParser implements RecordParser {
     }
 
     /**
-     * Note: This uses the org.apache.kafka.connect.json.JsonConverter to convert from json
-     * to KafkaConnect objects (which is what is serialized to the json that the ChangeConsumer receives)
-     * This deserialization process will most likely be heavier as compared to a simple
-     * json deserializer, but this comes with the added advantages of converting the json values to
-     * java native object types (for example, of type bytes to bytearray, of type bool to java boolean, etc).
-     * Furthermore, there is a way in future to not deal with ser-de at all, by tweaking debezium-server
-     * format.value=connect, wherein it gives a KafkaConnect object directly to the ChangeConsumer.
-     * Therefore, this approach is used for now.
+     * This parser parses a kafka connect SourceRecord object to a Record object
+     * that contains the relevant field schemas and values.
      */
     @Override
     public Record parseRecord(Object keyObj, Object valueObj) {
@@ -65,8 +59,6 @@ class KafkaConnectRecordParser implements RecordParser {
 
             // Parse key and values
             if (key != null) {
-                // SchemaAndValue keyConnectObject = jsonConverter.toConnectData("", jsonKey.getBytes());
-                // Struct key = (Struct) keyConnectObject.value();
                 parseKeyFields(key, r);
             }
             parseValueFields(value, r);

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/KafkaConnectRecordParser.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/KafkaConnectRecordParser.java
@@ -49,6 +49,13 @@ class KafkaConnectRecordParser implements RecordParser {
             Struct value = (Struct) ((SourceRecord) valueObj).value();
             Struct key = (Struct) ((SourceRecord) valueObj).key();
 
+            if (value == null) {
+                // Ideally, we should have config tombstones.on.delete=false. In case that is not set correctly,
+                // we will get those events where value field = null. Skipping those events.
+                LOGGER.warn("Empty value field in event. Assuming tombstone event. Skipping - {}", valueObj);
+                r.op = "unsupported";
+                return r;
+            }
             Struct source = value.getStruct("source");
             r.op = value.getString("op");
             r.snapshot = source.getString("snapshot");

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/Record.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/Record.java
@@ -29,6 +29,10 @@ public class Record {
         valueValues.clear();
     }
 
+    public boolean isUnsupported() {
+        return op.equals("unsupported");
+    }
+
     public String getTableIdentifier() {
         return t.toString();
     }

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
@@ -78,20 +78,19 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
     }
 
     @Override
-    public void handleBatch(List<ChangeEvent<Object, Object>> records, DebeziumEngine.RecordCommitter<ChangeEvent<Object, Object>> committer)
+    public void handleBatch(List<ChangeEvent<Object, Object>> changeEvents, DebeziumEngine.RecordCommitter<ChangeEvent<Object, Object>> committer)
             throws InterruptedException {
-        LOGGER.info("Processing batch with {} records", records.size());
-        for (ChangeEvent<Object, Object> record : records) {
-            Object objKey = record.key();
-            Object objVal = record.value();
-            if (objVal == null) {
-                // tombstone event
-                // TODO: handle this better. try using the config to avoid altogether
-                continue;
-            }
+        LOGGER.info("Processing batch with {} records", changeEvents.size());
+        for (ChangeEvent<Object, Object> event : changeEvents) {
+            Object objKey = event.key();
+            Object objVal = event.value();
 
             // PARSE
             var r = parser.parseRecord(objKey, objVal);
+            if (r.isUnsupported()) {
+                committer.markProcessed(event);
+                continue;
+            }
             // LOGGER.info("Processing record {} => {}", r.getTableIdentifier(), r.getValueFieldValues());
             checkIfSnapshotAlreadyComplete(r);
 
@@ -101,7 +100,7 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
             // Handle snapshot->cdc transition
             checkIfSnapshotComplete(r);
 
-            committer.markProcessed(record);
+            committer.markProcessed(event);
         }
         handleBatchComplete();
         committer.markBatchFinished();
@@ -126,7 +125,7 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
      * The last record we recieve will have the snapshot field='last'.
      * We interpret this to mean that snapshot phase is complete, and move on to streaming phase
      */
-    private void checkIfSnapshotComplete(Record r){
+    private void checkIfSnapshotComplete(Record r) {
         if ((r.snapshot != null) && (r.snapshot.equals("last"))) {
             handleSnapshotComplete();
         }
@@ -143,8 +142,8 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
      * Note that this method would have to be called before the record is written.
      * @param r
      */
-    private void checkIfSnapshotAlreadyComplete(Record r){
-        if ((exportStatus.getMode() == ExportMode.SNAPSHOT) && (r.snapshot == null)){
+    private void checkIfSnapshotAlreadyComplete(Record r) {
+        if ((exportStatus.getMode() == ExportMode.SNAPSHOT) && (r.snapshot == null)) {
             LOGGER.debug("Interpreting snapshot as complete since snapshot field of record is null");
             handleSnapshotComplete();
         }
@@ -164,7 +163,7 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
         snapshotWriters.clear();
     }
 
-    private void handleBatchComplete(){
+    private void handleBatchComplete() {
         flushSyncStreamingData();
     }
 


### PR DESCRIPTION
Fixes two bugs:
1. If tombstone events are passed, then the sink plugin was failing to ignore/skip those events.
2. If delete is the first event after debezium restart, it was failing to fetch table metadata.