### PR TITLE
Sequence Numbers for streaming events

### DIFF
--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
@@ -89,6 +89,8 @@ public class ExportStatus {
     }
 
     public void flushToDisk() {
+        // TODO: if already written once, save the structure, and then update only what is expected
+        // to change, before writing to disk.
         HashMap<String, Object> exportStatusMap = new HashMap<>();
         List<HashMap<String, Object>> tablesInfo = new ArrayList<>();
         for (Table t : tableExportStatusMap.keySet()) {

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/SequenceNumberGenerator.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/SequenceNumberGenerator.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.ybexporter;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SequenceNumberGenerator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SequenceNumberGenerator.class);
+    String datadir;
+    String name;
+    int start;
+    long currentSequenceNumber;
+    long range;
+    long borrowedSequenceNumbersEndRange;
+    String filename;
+
+    public SequenceNumberGenerator(String datadir, String name, int start, long range) {
+        this.datadir = datadir;
+        this.name = name;
+        this.start = start;
+        if (range < 1) {
+            throw new RuntimeException("Range too small");
+        }
+        this.range = range;
+        this.currentSequenceNumber = start;
+        this.borrowedSequenceNumbersEndRange = start - 1; // to start with we haven't borrowed any.
+        this.filename = datadir + "/" + name;
+        readStateFromDisk();
+    }
+
+    private void borrowIfRequired() {
+        if (currentSequenceNumber > borrowedSequenceNumbersEndRange) {
+            borrowedSequenceNumbersEndRange += range;
+            persistStateToDisk();
+            LOGGER.info("borrowed till {}", borrowedSequenceNumbersEndRange);
+        }
+    }
+
+    private void persistStateToDisk() {
+        try {
+            FileOutputStream fos = new FileOutputStream(filename);
+            FileWriter fw = new FileWriter(fos.getFD());
+            fw.write(String.valueOf(borrowedSequenceNumbersEndRange));
+            fos.getFD().sync();
+            fw.close();
+        }
+        catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void readStateFromDisk() {
+        try {
+            File file = new File(filename);
+            FileReader fr = new FileReader(file);
+            BufferedReader br = new BufferedReader(fr);
+            String borrowedSequenceNumbersEndRangeStr = br.readLine();
+            borrowedSequenceNumbersEndRange = Long.parseLong(borrowedSequenceNumbersEndRangeStr);
+            currentSequenceNumber = borrowedSequenceNumbersEndRange + 1; // start from next set.
+
+        }
+        catch (FileNotFoundException e) {
+            LOGGER.info("File does not exist. No state to read");
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public long getNext() {
+        borrowIfRequired();
+        return currentSequenceNumber++;
+    }
+}

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/StreamingWriterJson.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/StreamingWriterJson.java
@@ -27,6 +27,7 @@ public class StreamingWriterJson implements RecordWriter {
     private ObjectWriter ow;
     private FileOutputStream fos;
     private FileDescriptor fd;
+    private SequenceNumberGenerator seqNumGen;
 
     public StreamingWriterJson(String datadirStr) {
         dataDir = datadirStr;
@@ -43,6 +44,7 @@ public class StreamingWriterJson implements RecordWriter {
             throw new RuntimeException(e);
         }
         ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        seqNumGen = new SequenceNumberGenerator(dataDir, "streaming", 1, 3);
     }
 
     @Override
@@ -60,6 +62,7 @@ public class StreamingWriterJson implements RecordWriter {
 
     private HashMap<String, Object> generateCdcMessageForRecord(Record r) {
         // TODO: optimize, don't create objects every time.
+        long seqNum = seqNumGen.getNext();
         HashMap<String, Object> key = new HashMap<>();
         HashMap<String, Object> fields = new HashMap<>();
 
@@ -79,6 +82,7 @@ public class StreamingWriterJson implements RecordWriter {
         cdcInfo.put("table_name", r.t.tableName);
         cdcInfo.put("key", key);
         cdcInfo.put("fields", fields);
+        cdcInfo.put("sequence_number", seqNum);
         return cdcInfo;
     }
 

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/StreamingWriterJson.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/StreamingWriterJson.java
@@ -44,7 +44,7 @@ public class StreamingWriterJson implements RecordWriter {
             throw new RuntimeException(e);
         }
         ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
-        seqNumGen = new SequenceNumberGenerator(dataDir, "streaming", 1, 3);
+        seqNumGen = new SequenceNumberGenerator(dataDir, "streaming", 1);
     }
 
     @Override

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
@@ -126,7 +126,7 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
      * The last record we recieve will have the snapshot field='last'.
      * We interpret this to mean that snapshot phase is complete, and move on to streaming phase
      */
-    private void checkIfSnapshotComplete(Record r){
+    private void checkIfSnapshotComplete(Record r) {
         if ((r.snapshot != null) && (r.snapshot.equals("last"))) {
             handleSnapshotComplete();
         }
@@ -143,8 +143,8 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
      * Note that this method would have to be called before the record is written.
      * @param r
      */
-    private void checkIfSnapshotAlreadyComplete(Record r){
-        if ((exportStatus.getMode() == ExportMode.SNAPSHOT) && (r.snapshot == null)){
+    private void checkIfSnapshotAlreadyComplete(Record r) {
+        if ((exportStatus.getMode() == ExportMode.SNAPSHOT) && (r.snapshot == null)) {
             LOGGER.debug("Interpreting snapshot as complete since snapshot field of record is null");
             handleSnapshotComplete();
         }
@@ -164,7 +164,7 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
         snapshotWriters.clear();
     }
 
-    private void handleBatchComplete(){
+    private void handleBatchComplete() {
         flushSyncStreamingData();
     }
 


### PR DESCRIPTION
Generates sequence numbers with a requirement that they are always in increasing order, but may not be contiguous.
The generator is resistant to process crashes. This is achieved by simulating a process of borrowing sequence numbers. The generator effectively borrows numbers before it can give them out, and the last borrowed sequence number is persisted to disk. In the event of a restart, it restores the state from disk (based on the name given), and starts giving out sequence numbers from the next borrowed set.