### PR TITLE
[DB-5842] Fix: Correct file names for non public postgres tables.

### DIFF
--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/TableSnapshotWriterCSV.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/TableSnapshotWriterCSV.java
@@ -21,15 +21,17 @@ import org.slf4j.LoggerFactory;
 public class TableSnapshotWriterCSV implements RecordWriter {
     private static final Logger LOGGER = LoggerFactory.getLogger(TableSnapshotWriterCSV.class);
     private ExportStatus es;
+    private String sourceType;
     private String dataDir;
     private Table t;
     private CSVPrinter csvPrinter;
     private FileOutputStream fos;
     private FileDescriptor fd;
 
-    public TableSnapshotWriterCSV(String datadirStr, Table tbl) {
+    public TableSnapshotWriterCSV(String datadirStr, Table tbl, String sourceType) {
         dataDir = datadirStr;
         t = tbl;
+        this.sourceType = sourceType;
 
         var fileName = getFullFileNameForTable();
         try {
@@ -65,7 +67,11 @@ public class TableSnapshotWriterCSV implements RecordWriter {
     }
 
     private String getFilenameForTable() {
-        return t.tableName + "_data.sql";
+        String fileName =  t.tableName + "_data.sql";
+        if ((sourceType.equals("postgres")) && (!t.schemaName.equals("public"))){
+            fileName = t.schemaName + "." + fileName;
+        }
+        return fileName;
     }
 
     private String getFullFileNameForTable() {

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/TableSnapshotWriterCSV.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/TableSnapshotWriterCSV.java
@@ -68,7 +68,7 @@ public class TableSnapshotWriterCSV implements RecordWriter {
 
     private String getFilenameForTable() {
         String fileName =  t.tableName + "_data.sql";
-        if ((sourceType.equals("postgres")) && (!t.schemaName.equals("public"))){
+        if ((sourceType.equals("postgresql")) && (!t.schemaName.equals("public"))){
             fileName = t.schemaName + "." + fileName;
         }
         return fileName;

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
@@ -36,6 +36,7 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
     @ConfigProperty(name = PROP_PREFIX + "dataDir")
     String dataDir;
 
+    String sourceType;
     private Map<String, Table> tableMap = new HashMap<>();
     private RecordParser parser;
     private Map<Table, RecordWriter> snapshotWriters = new HashMap<>();
@@ -49,6 +50,7 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
         final Config config = ConfigProvider.getConfig();
 
         snapshotMode = config.getOptionalValue("debezium.source.snapshot.mode", String.class).orElse("");
+        retrieveSourceType(config);
 
         parser = new KafkaConnectRecordParser(tableMap);
         exportStatus = ExportStatus.getInstance(dataDir);
@@ -62,6 +64,18 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
         Thread t = new Thread(this::flush);
         t.setDaemon(true);
         t.start();
+    }
+
+    void retrieveSourceType(Config config){
+        String sourceConnector = config.getValue("debezium.source.connector.class", String.class);
+        switch (sourceConnector){
+            case "io.debezium.connector.postgresql.PostgresConnector":
+                sourceType = "postgres"; break;
+            case "io.debezium.connector.oracle.OracleConnector":
+                sourceType = "oracle"; break;
+            case "io.debezium.connector.mysql.MySqlConnector":
+                sourceType = "mysql"; break;
+        }
     }
 
     void flush() {
@@ -118,7 +132,7 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
         if (exportStatus.getMode() == ExportMode.SNAPSHOT) {
             RecordWriter writer = snapshotWriters.get(r.t);
             if (writer == null) {
-                writer = new TableSnapshotWriterCSV(dataDir, r.t);
+                writer = new TableSnapshotWriterCSV(dataDir, r.t, sourceType);
                 snapshotWriters.put(r.t, writer);
             }
             return writer;

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
@@ -70,7 +70,7 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
         String sourceConnector = config.getValue("debezium.source.connector.class", String.class);
         switch (sourceConnector){
             case "io.debezium.connector.postgresql.PostgresConnector":
-                sourceType = "postgres"; break;
+                sourceType = "postgresql"; break;
             case "io.debezium.connector.oracle.OracleConnector":
                 sourceType = "oracle"; break;
             case "io.debezium.connector.mysql.MySqlConnector":


### PR DESCRIPTION
This PR implements expected behaviour by voyager:

for all source types, it is `<table>_data.sql`
only for non-public schemas in postgres, it is `<schema>.<table>_data.sql`

JIRA: https://yugabyte.atlassian.net/browse/DB-5842