### PR TITLE
Export status improvements

### DIFF
--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
@@ -30,7 +30,7 @@ public class ExportStatus {
     private static final String EXPORT_STATUS_FILE_NAME = "export_status.json";
     private static ExportStatus instance;
     private String dataDir;
-    private Map<Table, TableExportStatus> tableExportStatusMap = new HashMap<>();
+    private Map<Table, TableExportStatus> tableExportStatusMap = new HashMap<>(); // TODO: use linked hash map?
     private ExportMode mode;
     private ObjectWriter ow;
     private File f;
@@ -90,8 +90,10 @@ public class ExportStatus {
     }
 
     public void flushToDisk() {
+        // TODO: do not create fresh objects every time, just reuse.
         HashMap<String, Object> exportStatusMap = new HashMap<>();
         List<HashMap<String, Object>> tablesInfo = new ArrayList<>();
+        // TODO: better iteration, get value
         for (Table t : tableExportStatusMap.keySet()) {
             HashMap<String, Object> tableInfo = new HashMap<>();
             tableInfo.put("database_name", t.dbName);
@@ -116,6 +118,7 @@ public class ExportStatus {
 
     private static ExportStatus loadFromDisk(String datadirStr) {
         try {
+            // TODO: func for getting file path
             Path p = Paths.get(datadirStr + "/export_status.json");
             File f = new File(p.toUri());
             if (!f.exists()) {
@@ -123,6 +126,7 @@ public class ExportStatus {
             }
 
             String fileContent = Files.readString(p);
+            // TODO: remove unnecessary var for factory
             JsonFactory factory = new JsonFactory();
             ObjectMapper mapper = new ObjectMapper(factory);
             var exportStatusJson = mapper.readTree(fileContent);
@@ -150,6 +154,7 @@ public class ExportStatus {
     }
 }
 
+// TODO: make vars private and add proper constructor
 class TableExportStatus {
     Integer sno;
     Integer exportedRowCountSnapshot;

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
@@ -77,6 +77,7 @@ public class ExportStatus {
         TableExportStatus tableExportStatus = new TableExportStatus();
         tableExportStatus.snapshotFilename = tblFilename;
         tableExportStatus.exportedRowCountSnapshot = 0;
+        tableExportStatus.sno = tableExportStatusMap.size();
         tableExportStatusMap.put(t, tableExportStatus);
     }
 
@@ -97,7 +98,8 @@ public class ExportStatus {
             tableInfo.put("schema_name", t.schemaName);
             tableInfo.put("table_name", t.tableName);
             tableInfo.put("file_name", tableExportStatusMap.get(t).snapshotFilename);
-            tableInfo.put("exported_row_count", tableExportStatusMap.get(t).exportedRowCountSnapshot);
+            tableInfo.put("exported_row_count_snapshot", tableExportStatusMap.get(t).exportedRowCountSnapshot);
+            tableInfo.put("sno", tableExportStatusMap.get(t).sno);
             tablesInfo.add(tableInfo);
         }
 
@@ -135,7 +137,8 @@ public class ExportStatus {
                 Table t = new Table(tableJson.get("database_name").asText(), tableJson.get("schema_name").asText(), tableJson.get("table_name").asText());
 
                 TableExportStatus tes = new TableExportStatus();
-                tes.exportedRowCountSnapshot = tableJson.get("exported_row_count").asInt();
+                tes.exportedRowCountSnapshot = tableJson.get("exported_row_count_snapshot").asInt();
+                tes.sno = tableJson.get("sno").asInt();
                 tes.snapshotFilename = tableJson.get("file_name").asText();
                 es.tableExportStatusMap.put(t, tes);
             }
@@ -148,6 +151,7 @@ public class ExportStatus {
 }
 
 class TableExportStatus {
+    Integer sno;
     Integer exportedRowCountSnapshot;
     String snapshotFilename;
 }


### PR DESCRIPTION
- include a serial number for the tables which will enable the implementation of a progress bar for the exporter process
- Atomic write of the export_status.json by writing first to a temp file and then renaming to the correct path