### PR TITLE
Raise exception in main thread if helper thread dies

### DIFF
--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
@@ -42,6 +42,7 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
     private Map<Table, RecordWriter> snapshotWriters = new HashMap<>();
     private RecordWriter streamingWriter;
     private ExportStatus exportStatus;
+    Thread helperThread;
 
     @PostConstruct
     void connect() throws URISyntaxException {
@@ -61,9 +62,9 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
             exportStatus.updateMode(ExportMode.SNAPSHOT);
         }
 
-        Thread t = new Thread(this::flush);
-        t.setDaemon(true);
-        t.start();
+        helperThread = new Thread(this::flush);
+        helperThread.setDaemon(true);
+        helperThread.start();
     }
 
     void retrieveSourceType(Config config){
@@ -102,6 +103,7 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
     public void handleBatch(List<ChangeEvent<Object, Object>> changeEvents, DebeziumEngine.RecordCommitter<ChangeEvent<Object, Object>> committer)
             throws InterruptedException {
         LOGGER.info("Processing batch with {} records", changeEvents.size());
+        checkIfHelperThreadAlive();
         for (ChangeEvent<Object, Object> event : changeEvents) {
             Object objKey = event.key();
             Object objVal = event.value();
@@ -213,5 +215,13 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
 
     private void openCDCWriter() {
         streamingWriter = new StreamingWriterJson(dataDir);
+    }
+
+    private void checkIfHelperThreadAlive(){
+        if (!helperThread.isAlive()){
+            // if helper thread dies, export status will stop being updated,
+            // so interrupting main thread as well.
+            throw new RuntimeException("Helper Thread exited.");
+        }
     }
 }

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
@@ -42,7 +42,7 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
     private Map<Table, RecordWriter> snapshotWriters = new HashMap<>();
     private RecordWriter streamingWriter;
     private ExportStatus exportStatus;
-    Thread helperThread;
+    Thread flusherThread;
 
     @PostConstruct
     void connect() throws URISyntaxException {
@@ -62,9 +62,9 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
             exportStatus.updateMode(ExportMode.SNAPSHOT);
         }
 
-        helperThread = new Thread(this::flush);
-        helperThread.setDaemon(true);
-        helperThread.start();
+        flusherThread = new Thread(this::flush);
+        flusherThread.setDaemon(true);
+        flusherThread.start();
     }
 
     void retrieveSourceType(Config config){
@@ -218,10 +218,10 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
     }
 
     private void checkIfHelperThreadAlive(){
-        if (!helperThread.isAlive()){
-            // if helper thread dies, export status will stop being updated,
+        if (!flusherThread.isAlive()){
+            // if the flusher thread dies, export status will stop being updated,
             // so interrupting main thread as well.
-            throw new RuntimeException("Helper Thread exited.");
+            throw new RuntimeException("Flusher Thread exited unexpectedly.");
         }
     }
 }


### PR DESCRIPTION
**Current behaviour**: If there is an unhandled exception in the helper thread, it dies silently(with err in stderr), but main exporter thread continues to run. This is problematic, because the helper thread performs important functions such as keeping exportStatus up-to-date. 

**After this change**: If there is an unhandled exception in the helper thread, the main thread also raises an exception as soon as possible(in the next batch of records received).