### PR TITLE
Capture max of sequences in order to update after migration

### DIFF
--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
@@ -95,7 +95,7 @@ public class ExportStatus {
         this.sequenceMax = sequenceMax;
     }
 
-    public Map<String, Long> getSequenceMap(){
+    public Map<String, Long> getSequenceMaxMap(){
         return this.sequenceMax;
     }
 

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
@@ -168,9 +168,7 @@ public class ExportStatus {
                 tes.exportedRowCountSnapshot = tableJson.get("exported_row_count_snapshot").asInt();
                 es.tableExportStatusMap.put(t, tes);
             }
-            Thread.sleep(3000);
             var sequencesJson = exportStatusJson.get("sequences");
-            LOGGER.info("sequencesjson - " + sequencesJson.getClass().getName());
             var sequencesIterator = sequencesJson.fields();
             HashMap<String, Long> sequenceMaxMap = new HashMap<>();
             while (sequencesIterator.hasNext()){
@@ -182,8 +180,6 @@ public class ExportStatus {
             return es;
         }
         catch (IOException e) {
-            throw new RuntimeException(e);
-        } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
     }

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/SequenceObjectUpdater.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/SequenceObjectUpdater.java
@@ -88,14 +88,11 @@ public class SequenceObjectUpdater {
         if (r.op.equals("d")){
             // not processing delete events because the max would have already been updated in the
             // prior create/update events.
-            // TODO: question: should we also update the max to the second-max value if the row with max is deleted??
             return;
         }
         for(int i = 0; i < r.valueColumns.size(); i++){
-//            String fullyQualifiedColumnName = r.t.schemaName+"."+r.t.tableName+"."+r.valueColumns.get(i);
             String seqName = getFromColumnSequenceMap(r.t.schemaName, r.t.tableName, r.valueColumns.get(i));
             if (seqName != null){
-//                String seqName = columnSequenceMap.get(fullyQualifiedColumnName);
                 Long columnValue = Long.valueOf(r.valueValues.get(i).toString());
                 sequenceMax.put(seqName, Math.max(sequenceMax.get(seqName), columnValue));
             }

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/SequenceObjectUpdater.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/SequenceObjectUpdater.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server.ybexporter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SequenceObjectUpdater {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SequenceObjectUpdater.class);
+    String dataDirStr;
+    Map<String, String> columnSequenceMap;
+    Map<String, Long> sequenceMax;
+    ExportStatus es;
+    public SequenceObjectUpdater(String dataDirStr, Map<String, String> columnSequenceMap, Map<String, Long> sequenceMax){
+        this.dataDirStr = dataDirStr;
+        this.columnSequenceMap = columnSequenceMap;
+        es = ExportStatus.getInstance(dataDirStr);
+        if (sequenceMax == null){
+           this.sequenceMax = new HashMap<>();
+            for (String seq : this.columnSequenceMap.values()) {
+                this.sequenceMax.put(seq, (long) 0);
+            }
+        }
+        else{
+            this.sequenceMax = sequenceMax;
+        }
+        es.setSequenceMaxMap(this.sequenceMax);
+    }
+
+    public void processRecord(Record r){
+        if (r.op.equals("d")){
+            // not processing delete events because the max would have already been updated in the
+            // prior create/update events.
+            // TODO: question: should we also update the max to the second-max value if the row with max is deleted??
+            return;
+        }
+        for(int i = 0; i < r.valueColumns.size(); i++){
+            String fullyQualifiedColumnName = r.t.schemaName+"."+r.t.tableName+"."+r.valueColumns.get(i);
+            if (columnSequenceMap.get(fullyQualifiedColumnName) != null){
+                String seqName = columnSequenceMap.get(fullyQualifiedColumnName);
+                Long columnValue = Long.valueOf(r.valueValues.get(i).toString());
+                sequenceMax.put(seqName, Math.max(sequenceMax.get(seqName), columnValue));
+            }
+        }
+
+    }
+
+}

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/SequenceObjectUpdater.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/SequenceObjectUpdater.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 public class SequenceObjectUpdater {
     private static final Logger LOGGER = LoggerFactory.getLogger(SequenceObjectUpdater.class);
+    public static String propertyName = "column_sequence.map";
     String dataDirStr;
     Map<String, Map<String, Map<String, String>>> columnSequenceMap; // Schema:table:column -> sequence
     Map<String, Long> sequenceMax;
@@ -45,7 +46,7 @@ public class SequenceObjectUpdater {
             String fullyQualifiedColumnName = colSequence[0];
             String sequenceName = colSequence[1];
 
-            String columnSplit[] = fullyQualifiedColumnName.split("\\.");
+            String[] columnSplit = fullyQualifiedColumnName.split("\\.");
             if (columnSplit.length != 3){
                 throw new RuntimeException("Incorrect format for column name in config param -" + columnSequenceStr +
                         ". Use <schema>.<table>.<column> instead.");

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/SequenceObjectUpdater.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/SequenceObjectUpdater.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.server.ybexporter;
 
+import org.eclipse.microprofile.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,23 +16,72 @@ import java.util.Map;
 public class SequenceObjectUpdater {
     private static final Logger LOGGER = LoggerFactory.getLogger(SequenceObjectUpdater.class);
     String dataDirStr;
-    Map<String, String> columnSequenceMap;
+    Map<String, Map<String, Map<String, String>>> columnSequenceMap; // Schema:table:column -> sequence
     Map<String, Long> sequenceMax;
     ExportStatus es;
-    public SequenceObjectUpdater(String dataDirStr, Map<String, String> columnSequenceMap, Map<String, Long> sequenceMax){
+    public SequenceObjectUpdater(String dataDirStr, String columnSequenceMapString, Map<String, Long> sequenceMax){
         this.dataDirStr = dataDirStr;
-        this.columnSequenceMap = columnSequenceMap;
+        this.columnSequenceMap = new HashMap<>();
+
         es = ExportStatus.getInstance(dataDirStr);
         if (sequenceMax == null){
            this.sequenceMax = new HashMap<>();
-            for (String seq : this.columnSequenceMap.values()) {
-                this.sequenceMax.put(seq, (long) 0);
-            }
         }
         else{
             this.sequenceMax = sequenceMax;
         }
+        initColumnSequenceMap(columnSequenceMapString);
         es.setSequenceMaxMap(this.sequenceMax);
+    }
+
+    public void initColumnSequenceMap(String columnSequenceMapString){
+        String[] columnSequenceItems = columnSequenceMapString.split(",");
+        for (String columnSequenceStr: columnSequenceItems) {
+            String[] colSequence = columnSequenceStr.split(":");
+            if (colSequence.length != 2) {
+                throw new RuntimeException("Incorrect config. Please provide comma separated list of " +
+                        "'col:seq' with their fully qualified names.");
+            }
+            String fullyQualifiedColumnName = colSequence[0];
+            String sequenceName = colSequence[1];
+
+            String columnSplit[] = fullyQualifiedColumnName.split("\\.");
+            if (columnSplit.length != 3){
+                throw new RuntimeException("Incorrect format for column name in config param -" + columnSequenceStr +
+                        ". Use <schema>.<table>.<column> instead.");
+            }
+            insertIntoColumnSequenceMap(columnSplit[0], columnSplit[1], columnSplit[2], sequenceName);
+            // add a base entry to sequenceMax. If already populated, do not update.
+            this.sequenceMax.put(sequenceName, this.sequenceMax.getOrDefault(sequenceName, (long)0));
+        }
+    }
+
+    private void insertIntoColumnSequenceMap(String schema, String table, String column, String sequence){
+        Map<String, Map<String, String>> schemaMap = this.columnSequenceMap.get(schema);
+        if (schemaMap == null){
+            schemaMap = new HashMap<>();
+            this.columnSequenceMap.put(schema, schemaMap);
+        }
+
+        Map<String, String> schemaTableMap = schemaMap.get(table);
+        if (schemaTableMap == null){
+            schemaTableMap = new HashMap<>();
+            schemaMap.put(table, schemaTableMap);
+        }
+        schemaTableMap.put(column, sequence);
+    }
+
+    private String getFromColumnSequenceMap(String schema, String table, String column){
+        Map<String, Map<String, String>> schemaMap = this.columnSequenceMap.get(schema);
+        if (schemaMap == null){
+            return null;
+        }
+
+        Map<String, String> schemaTableMap = schemaMap.get(table);
+        if (schemaTableMap == null){
+            return null;
+        }
+        return schemaTableMap.get(column);
     }
 
     public void processRecord(Record r){
@@ -42,9 +92,10 @@ public class SequenceObjectUpdater {
             return;
         }
         for(int i = 0; i < r.valueColumns.size(); i++){
-            String fullyQualifiedColumnName = r.t.schemaName+"."+r.t.tableName+"."+r.valueColumns.get(i);
-            if (columnSequenceMap.get(fullyQualifiedColumnName) != null){
-                String seqName = columnSequenceMap.get(fullyQualifiedColumnName);
+//            String fullyQualifiedColumnName = r.t.schemaName+"."+r.t.tableName+"."+r.valueColumns.get(i);
+            String seqName = getFromColumnSequenceMap(r.t.schemaName, r.t.tableName, r.valueColumns.get(i));
+            if (seqName != null){
+//                String seqName = columnSequenceMap.get(fullyQualifiedColumnName);
                 Long columnValue = Long.valueOf(r.valueValues.get(i).toString());
                 sequenceMax.put(seqName, Math.max(sequenceMax.get(seqName), columnValue));
             }

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
@@ -48,11 +48,6 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
     @PostConstruct
     void connect() throws URISyntaxException {
         LOGGER.info("connect() called: dataDir = {}", dataDir);
-        try {
-            Thread.sleep(5000);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
 
         final Config config = ConfigProvider.getConfig();
 
@@ -67,7 +62,7 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
         else {
             exportStatus.updateMode(ExportMode.SNAPSHOT);
         }
-        String propertyVal = PROP_PREFIX + "column_sequence.map";
+        String propertyVal = PROP_PREFIX + SequenceObjectUpdater.propertyName;
         String columnSequenceMapString = config.getOptionalValue(propertyVal, String.class).orElse(null);
         sequenceObjectUpdater = new SequenceObjectUpdater(dataDir, columnSequenceMapString, exportStatus.getSequenceMaxMap());
 

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
@@ -69,7 +69,7 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
         }
         String propertyVal = PROP_PREFIX + "column_sequence.map";
         String columnSequenceMapString = config.getOptionalValue(propertyVal, String.class).orElse(null);
-        sequenceObjectUpdater = new SequenceObjectUpdater(dataDir, columnSequenceMapString, exportStatus.getSequenceMap());
+        sequenceObjectUpdater = new SequenceObjectUpdater(dataDir, columnSequenceMapString, exportStatus.getSequenceMaxMap());
 
         flusherThread = new Thread(this::flush);
         flusherThread.setDaemon(true);


### PR DESCRIPTION
https://yugabyte.atlassian.net/browse/DB-5927

Implementation:
- The config value debezium.sink.ybexporter.column_sequence.map needs to be provided which will have a value of the format  `"<column1>:<sequence1>,<column2>:<sequence2>"`
- A new class SequenceObjectUpdater that keeps track of the max value for each sequence. Each record is processed by this class.
- The ExportStatus has a reference to the map object and keeps updating the value in the json file. 
