### PR TITLE
Make run.sh runnable from anywhere

### DIFF
--- a/debezium-server/debezium-server-dist/src/main/resources/distro/run.sh
+++ b/debezium-server/debezium-server-dist/src/main/resources/distro/run.sh
@@ -7,6 +7,16 @@
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+if [ -z "$1" ]; then
+    echo "Argument missing. Provide application.properties file path as argument";
+    exit 1;
+fi
+PROPERTIES_FILE_PATH="$1"
+if [ ! -f "$PROPERTIES_FILE_PATH" ]; then
+    echo "$PROPERTIES_FILE_PATH does not exist."
+    exit 1;
+fi
+
 if [ -z "$JAVA_HOME" ]; then
   JAVA_BINARY="java"
 else
@@ -27,5 +37,6 @@ if [[ "${ENABLE_DEBEZIUM_SCRIPTING}" == "true" ]]; then
     LIB_PATH=$LIB_PATH$PATH_SEP"$SCRIPT_DIR/lib_opt/*"
 fi
 
+
 DEBUGGER="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
-exec "$JAVA_BINARY" $DEBEZIUM_OPTS $JAVA_OPTS -cp "$RUNNER"$PATH_SEP"conf"$PATH_SEP$LIB_PATH "$DEBUGGER" io.debezium.server.Main
+exec "$JAVA_BINARY" $DEBEZIUM_OPTS $JAVA_OPTS -cp "$RUNNER"$PATH_SEP"conf"$PATH_SEP$LIB_PATH -Dquarkus.config.locations=$PROPERTIES_FILE_PATH "$DEBUGGER" io.debezium.server.Main

--- a/debezium-server/debezium-server-dist/src/main/resources/distro/run.sh
+++ b/debezium-server/debezium-server-dist/src/main/resources/distro/run.sh
@@ -17,12 +17,16 @@ else
   PATH_SEP=":"
 fi
 
-RUNNER=$(ls debezium-server-*runner.jar)
+if [ -z "$DEBEZIUM_DIST_DIR" ]; then
+    DEBEZIUM_DIST_DIR="./"
+fi
+
+RUNNER=$(ls "$DEBEZIUM_DIST_DIR"/debezium-server-*runner.jar)
 
 ENABLE_DEBEZIUM_SCRIPTING=${ENABLE_DEBEZIUM_SCRIPTING:-false}
-LIB_PATH="lib/*"
+LIB_PATH="$DEBEZIUM_DIST_DIR/lib/*"
 if [[ "${ENABLE_DEBEZIUM_SCRIPTING}" == "true" ]]; then
-    LIB_PATH=$LIB_PATH$PATH_SEP"lib_opt/*"
+    LIB_PATH=$LIB_PATH$PATH_SEP"$DEBEZIUM_DIST_DIR/lib_opt/*"
 fi
 
 

--- a/debezium-server/debezium-server-dist/src/main/resources/distro/run.sh
+++ b/debezium-server/debezium-server-dist/src/main/resources/distro/run.sh
@@ -5,6 +5,8 @@
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 if [ -z "$JAVA_HOME" ]; then
   JAVA_BINARY="java"
 else
@@ -17,18 +19,13 @@ else
   PATH_SEP=":"
 fi
 
-if [ -z "$DEBEZIUM_DIST_DIR" ]; then
-    DEBEZIUM_DIST_DIR="./"
-fi
-
-RUNNER=$(ls "$DEBEZIUM_DIST_DIR"/debezium-server-*runner.jar)
+RUNNER=$(ls "$SCRIPT_DIR"/debezium-server-*runner.jar)
 
 ENABLE_DEBEZIUM_SCRIPTING=${ENABLE_DEBEZIUM_SCRIPTING:-false}
-LIB_PATH="$DEBEZIUM_DIST_DIR/lib/*"
+LIB_PATH="$SCRIPT_DIR/lib/*"
 if [[ "${ENABLE_DEBEZIUM_SCRIPTING}" == "true" ]]; then
-    LIB_PATH=$LIB_PATH$PATH_SEP"$DEBEZIUM_DIST_DIR/lib_opt/*"
+    LIB_PATH=$LIB_PATH$PATH_SEP"$SCRIPT_DIR/lib_opt/*"
 fi
-
 
 DEBUGGER="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
 exec "$JAVA_BINARY" $DEBEZIUM_OPTS $JAVA_OPTS -cp "$RUNNER"$PATH_SEP"conf"$PATH_SEP$LIB_PATH "$DEBUGGER" io.debezium.server.Main


### PR DESCRIPTION
This will enable https://yugabyte.atlassian.net/browse/DB-6092

Example
```

/Users/amakala/Documents/debezium/debezium-server/debezium-server-dist/target/debezium-server/run_dbzm_server.sh dbzmservertest/conf/application.properties

```

basically
1. Pass the properties file as a first argument to the run.sh file. 
2. the run.sh file now can be run from anywhere. It figures out the absolute path and adds the required lib/ . 