### PR TITLE
Bug fixes

### DIFF
--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
@@ -15,6 +15,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,8 +36,8 @@ public class ExportStatus {
     private static ExportStatus instance;
     private static ObjectMapper mapper = new ObjectMapper(new JsonFactory());
     private String dataDir;
-    private Map<String, Long> sequenceMax;
-    private Map<Table, TableExportStatus> tableExportStatusMap = new LinkedHashMap<>();
+    private ConcurrentMap<String, Long> sequenceMax;
+    private ConcurrentMap<Table, TableExportStatus> tableExportStatusMap = new ConcurrentHashMap<>();
     private ExportMode mode;
     private ObjectWriter ow;
     private File f;
@@ -93,11 +95,11 @@ public class ExportStatus {
         mode = modeEnum;
     }
 
-    public void setSequenceMaxMap(Map<String, Long> sequenceMax){
+    public void setSequenceMaxMap(ConcurrentMap<String, Long> sequenceMax){
         this.sequenceMax = sequenceMax;
     }
 
-    public Map<String, Long> getSequenceMaxMap(){
+    public ConcurrentMap<String, Long> getSequenceMaxMap(){
         return this.sequenceMax;
     }
 
@@ -169,7 +171,7 @@ public class ExportStatus {
             }
             var sequencesJson = exportStatusJson.get("sequences");
             var sequencesIterator = sequencesJson.fields();
-            HashMap<String, Long> sequenceMaxMap = new HashMap<>();
+            ConcurrentHashMap<String, Long> sequenceMaxMap = new ConcurrentHashMap<>();
             while (sequencesIterator.hasNext()){
                 var entry = sequencesIterator.next();
                 sequenceMaxMap.put(entry.getKey(), Long.valueOf(entry.getValue().asText()));

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
@@ -15,8 +15,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,8 +34,8 @@ public class ExportStatus {
     private static ExportStatus instance;
     private static ObjectMapper mapper = new ObjectMapper(new JsonFactory());
     private String dataDir;
-    private ConcurrentMap<String, Long> sequenceMax;
-    private ConcurrentMap<Table, TableExportStatus> tableExportStatusMap = new ConcurrentHashMap<>();
+    private Map<String, Long> sequenceMax;
+    private Map<Table, TableExportStatus> tableExportStatusMap = new LinkedHashMap<>();
     private ExportMode mode;
     private ObjectWriter ow;
     private File f;
@@ -95,11 +93,11 @@ public class ExportStatus {
         mode = modeEnum;
     }
 
-    public void setSequenceMaxMap(ConcurrentMap<String, Long> sequenceMax){
+    public void setSequenceMaxMap(Map<String, Long> sequenceMax){
         this.sequenceMax = sequenceMax;
     }
 
-    public ConcurrentMap<String, Long> getSequenceMaxMap(){
+    public Map<String, Long> getSequenceMaxMap(){
         return this.sequenceMax;
     }
 
@@ -171,7 +169,7 @@ public class ExportStatus {
             }
             var sequencesJson = exportStatusJson.get("sequences");
             var sequencesIterator = sequencesJson.fields();
-            ConcurrentHashMap<String, Long> sequenceMaxMap = new ConcurrentHashMap<>();
+            HashMap<String, Long> sequenceMaxMap = new HashMap<>();
             while (sequencesIterator.hasNext()){
                 var entry = sequencesIterator.next();
                 sequenceMaxMap.put(entry.getKey(), Long.valueOf(entry.getValue().asText()));

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/KafkaConnectRecordParser.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/KafkaConnectRecordParser.java
@@ -43,7 +43,6 @@ class KafkaConnectRecordParser implements RecordParser {
             Struct value = (Struct) ((SourceRecord) valueObj).value();
             Struct key = (Struct) ((SourceRecord) valueObj).key();
 
-
             if (value == null) {
                 // Ideally, we should have config tombstones.on.delete=false. In case that is not set correctly,
                 // we will get those events where value field = null. Skipping those events.

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/KafkaConnectRecordParser.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/KafkaConnectRecordParser.java
@@ -43,6 +43,7 @@ class KafkaConnectRecordParser implements RecordParser {
             Struct value = (Struct) ((SourceRecord) valueObj).value();
             Struct key = (Struct) ((SourceRecord) valueObj).key();
 
+
             if (value == null) {
                 // Ideally, we should have config tombstones.on.delete=false. In case that is not set correctly,
                 // we will get those events where value field = null. Skipping those events.

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/SequenceObjectUpdater.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/SequenceObjectUpdater.java
@@ -12,21 +12,23 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class SequenceObjectUpdater {
     private static final Logger LOGGER = LoggerFactory.getLogger(SequenceObjectUpdater.class);
     public static String propertyName = "column_sequence.map";
     String dataDirStr;
     Map<String, Map<String, Map<String, String>>> columnSequenceMap; // Schema:table:column -> sequence
-    Map<String, Long> sequenceMax;
+    ConcurrentMap<String, Long> sequenceMax;
     ExportStatus es;
-    public SequenceObjectUpdater(String dataDirStr, String columnSequenceMapString, Map<String, Long> sequenceMax){
+    public SequenceObjectUpdater(String dataDirStr, String columnSequenceMapString, ConcurrentMap<String, Long> sequenceMax){
         this.dataDirStr = dataDirStr;
         this.columnSequenceMap = new HashMap<>();
 
         es = ExportStatus.getInstance(dataDirStr);
         if (sequenceMax == null){
-           this.sequenceMax = new HashMap<>();
+           this.sequenceMax = new ConcurrentHashMap<>();
         }
         else{
             this.sequenceMax = sequenceMax;

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/SequenceObjectUpdater.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/SequenceObjectUpdater.java
@@ -12,23 +12,21 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 public class SequenceObjectUpdater {
     private static final Logger LOGGER = LoggerFactory.getLogger(SequenceObjectUpdater.class);
     public static String propertyName = "column_sequence.map";
     String dataDirStr;
     Map<String, Map<String, Map<String, String>>> columnSequenceMap; // Schema:table:column -> sequence
-    ConcurrentMap<String, Long> sequenceMax;
+    Map<String, Long> sequenceMax;
     ExportStatus es;
-    public SequenceObjectUpdater(String dataDirStr, String columnSequenceMapString, ConcurrentMap<String, Long> sequenceMax){
+    public SequenceObjectUpdater(String dataDirStr, String columnSequenceMapString, Map<String, Long> sequenceMax){
         this.dataDirStr = dataDirStr;
         this.columnSequenceMap = new HashMap<>();
 
         es = ExportStatus.getInstance(dataDirStr);
         if (sequenceMax == null){
-           this.sequenceMax = new ConcurrentHashMap<>();
+           this.sequenceMax = new HashMap<>();
         }
         else{
             this.sequenceMax = sequenceMax;

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YugabyteDialectConverter.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YugabyteDialectConverter.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import io.debezium.data.VariableScaleDecimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +44,6 @@ public class YugabyteDialectConverter {
         if (fieldValue == null) {
             return fieldValue;
         }
-
         // The below types are not supported by debezium's postgres connector.
         // Therefore, we interpret the actual source column type (set by config datatype.propagate.source.type)
         // and then handle them.
@@ -120,10 +120,9 @@ public class YugabyteDialectConverter {
         Type type = field.schema().type();
         switch (type) {
             case BYTES:
-                StringBuilder hexString = new StringBuilder();
-                hexString.append("\\x");
+                String hexPrefix = "\\x";
                 byte[] byteArr = ((ByteBuffer) fieldValue).array();
-                return bytesToHex(byteArr);
+                return hexPrefix + bytesToHex(byteArr);
             case MAP:
                 StringBuilder mapString = new StringBuilder();
                 for (Map.Entry<String, String> entry : ((HashMap<String, String>) fieldValue).entrySet()) {

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YugabyteDialectConverter.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YugabyteDialectConverter.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import io.debezium.data.VariableScaleDecimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema.Type;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
1. `file.renameTo(file2)` seems to be a platform-dependent implementation. It was not working on @sanyamsinghal 's machine. Docs of renameTo also suggests - `Note that the java.nio.file.Files class defines the move method to move or rename a file in a platform independent manner.` which is what this PR does.
2. Using concurrentHashMap instead of HashMap to be able to avoid `java.util.ConcurrentModificationException`
3. bug fix for byte array type.