### PR TITLE
Fixes for export - status

### DIFF
--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
@@ -103,7 +103,7 @@ public class ExportStatus {
         return this.sequenceMax;
     }
 
-    public void flushToDisk() {
+    public synchronized void flushToDisk() {
         // TODO: do not create fresh objects every time, just reuse.
         HashMap<String, Object> exportStatusMap = new HashMap<>();
         List<HashMap<String, Object>> tablesInfo = new ArrayList<>();
@@ -141,8 +141,8 @@ public class ExportStatus {
         return String.format("%s/%s", dataDirStr, EXPORT_STATUS_FILE_NAME);
     }
 
-    private static String getTempFilePath(){
-        return getFilePath("/tmp");
+    private String getTempFilePath(){
+        return getFilePath(dataDir) + ".tmp";
     }
 
     private static ExportStatus loadFromDisk(String datadirStr) {


### PR DESCRIPTION
1. Synchronized flushToDisk function to avoid race conditions. - https://github.com/yugabyte/yb-voyager/actions/runs/4990955819/jobs/8936812690
2. Changed tmp file path of exportStatus from `/tmp/export_status.json` to `/exportDir/export_status.json.tmp`