### PR TITLE
release automation 

### DIFF
--- a/.github/workflows/voyager-debezium-workflow.yml
+++ b/.github/workflows/voyager-debezium-workflow.yml
@@ -58,7 +58,7 @@ jobs:
           RELEASE_VERSION=$(echo $GITHUB_REF | cut -d / -f 3 )
           BRANCH_NAME=$(git branch -r --contains $GITHUB_REF | cut -d / -f 2 | sed 's/-dev//')
           echo "DIST_NAME=debezium-server-${RELEASE_VERSION}" >> "$GITHUB_ENV" 
-          echo "RELEASE_NAME=debezium-${BRANCH_NAME}" >> "$GITHUB_ENV"
+          echo "RELEASE_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
 
       - name: Build Debezium Server
         run: |

--- a/.github/workflows/voyager-debezium-workflow.yml
+++ b/.github/workflows/voyager-debezium-workflow.yml
@@ -56,7 +56,7 @@ jobs:
         if: ${{ github.event_name == 'push' }} && startsWith(github.ref, 'refs/tags/debezium-')
         run: |
           RELEASE_VERSION=$(echo $GITHUB_REF | cut -d / -f 3 | sed 's/debezium-//')
-          BRANCH_NAME=$(git branch -r --contains $GITHUB_REF | cut -d / -f 2 )
+          BRANCH_NAME=$(git branch -r --contains $GITHUB_REF | cut -d / -f 2 | sed 's/rel-//')
           echo "DIST_NAME=debezium-server-${RELEASE_VERSION}" >> "$GITHUB_ENV" 
           echo "RELEASE_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/voyager-debezium-workflow.yml
+++ b/.github/workflows/voyager-debezium-workflow.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout Action
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Java 17
         uses: actions/setup-java@v2

--- a/.github/workflows/voyager-debezium-workflow.yml
+++ b/.github/workflows/voyager-debezium-workflow.yml
@@ -12,6 +12,8 @@ on:
   push:
     branches:
       - voyager-main
+    tags:
+      - 'debezium-*.*.*-voyager-*.*.*'
   pull_request:
     branches:
       - voyager-main
@@ -41,11 +43,20 @@ jobs:
       - name: Compute dist name (push) # debezium-server-latest in case it is a push to voyager-main
         if : ${{ github.event_name == 'push' }}
         run: |
+          echo "RELEASE_NAME=voyager-debezium" >> "$GITHUB_ENV"
           echo "DIST_NAME=debezium-server-latest" >> "$GITHUB_ENV"
       - name: Compute dist name (PR) # debezium-server-<branch_name> (with / converted to _) in case it is a PR event
         if : ${{ github.event_name == 'pull_request' }}
         run: |
-          echo "DIST_NAME=debezium-server-${GITHUB_HEAD_REF//\//_}" >> "$GITHUB_ENV" 
+          echo "RELEASE_NAME=voyager-debezium" >> "$GITHUB_ENV"
+          echo "DIST_NAME=debezium-server-${GITHUB_HEAD_REF//\//_}" >> "$GITHUB_ENV"
+      - name: Compute dist name (RELEASE)
+        if: ${{ github.event_name == 'push' }} && startsWith(github.ref, 'refs/tags/debezium-')
+        run: |
+          RELEASE_VERSION=$(echo $GITHUB_REF | cut -d / -f 3 | sed 's/debezium-//')
+          BRANCH_NAME=$(git branch -r --contains $GITHUB_REF | cut -d / -f 2 )
+          echo "DIST_NAME=debezium-server-${RELEASE_VERSION}" >> "$GITHUB_ENV" 
+          echo "RELEASE_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
 
       - name: Build Debezium Server
         run: |
@@ -54,6 +65,6 @@ jobs:
 
       - name: Publish to voyager-debezium release
         run: |
-          gh release upload voyager-debezium debezium-server/debezium-server-dist/target/${{ env.DIST_NAME }}.tar.gz --clobber # clobber is to overwrite
+          gh release upload ${{ env.RELEASE_NAME }} debezium-server/debezium-server-dist/target/${{ env.DIST_NAME }}.tar.gz --clobber # clobber is to overwrite
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/voyager-debezium-workflow.yml
+++ b/.github/workflows/voyager-debezium-workflow.yml
@@ -53,7 +53,7 @@ jobs:
           echo "RELEASE_NAME=voyager-debezium" >> "$GITHUB_ENV"
           echo "DIST_NAME=debezium-server-${GITHUB_HEAD_REF//\//_}" >> "$GITHUB_ENV"
       - name: Compute dist name (RELEASE)
-        if: ${{ github.event_name == 'push' }} && startsWith(github.ref, 'refs/tags/')
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
         run: |
           RELEASE_VERSION=$(echo $GITHUB_REF | cut -d / -f 3 )
           BRANCH_NAME=$(git branch -r --contains $GITHUB_REF | cut -d / -f 2 | sed 's/-dev//')

--- a/.github/workflows/voyager-debezium-workflow.yml
+++ b/.github/workflows/voyager-debezium-workflow.yml
@@ -6,6 +6,8 @@
 #   where the dist name is debezium-server-latest
 # - PRs opened against "voyaager-main"
 #   where the dist name is debezium-server-<branch_name> (with / converted to _)
+# - Tag is pushed with format *.*.*-*.*.*. This will be pushed only in a release branch of name *.*.*-*.*.*-dev
+#   where the release name is the <branch_name>(without the -dev) and dist name is debezium-server-<tag>
 name: Build Debezium Server
 
 on:
@@ -42,17 +44,17 @@ jobs:
           restore-keys: |
             maven-debezium-test-build-${{ hashFiles('**/pom.xml') }}
 
-      - name: Compute dist name (push) # debezium-server-latest in case it is a push to voyager-main
+      - name: Compute release vars (PUSH) # debezium-server-latest in case it is a push to voyager-main
         if : ${{ github.event_name == 'push' }}
         run: |
           echo "RELEASE_NAME=voyager-debezium" >> "$GITHUB_ENV"
           echo "DIST_NAME=debezium-server-latest" >> "$GITHUB_ENV"
-      - name: Compute dist name (PR) # debezium-server-<branch_name> (with / converted to _) in case it is a PR event
+      - name: Compute release vars (PR) # debezium-server-<branch_name> (with / converted to _) in case it is a PR event
         if : ${{ github.event_name == 'pull_request' }}
         run: |
           echo "RELEASE_NAME=voyager-debezium" >> "$GITHUB_ENV"
           echo "DIST_NAME=debezium-server-${GITHUB_HEAD_REF//\//_}" >> "$GITHUB_ENV"
-      - name: Compute dist name (RELEASE)
+      - name: Compute release vars (RELEASE)
         if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
         run: |
           RELEASE_VERSION=$(echo $GITHUB_REF | cut -d / -f 3 )

--- a/.github/workflows/voyager-debezium-workflow.yml
+++ b/.github/workflows/voyager-debezium-workflow.yml
@@ -13,7 +13,7 @@ on:
     branches:
       - voyager-main
     tags:
-      - 'debezium-*.*.*-voyager-*.*.*'
+      - '*.*.*-*.*.*'
   pull_request:
     branches:
       - voyager-main
@@ -53,12 +53,12 @@ jobs:
           echo "RELEASE_NAME=voyager-debezium" >> "$GITHUB_ENV"
           echo "DIST_NAME=debezium-server-${GITHUB_HEAD_REF//\//_}" >> "$GITHUB_ENV"
       - name: Compute dist name (RELEASE)
-        if: ${{ github.event_name == 'push' }} && startsWith(github.ref, 'refs/tags/debezium-')
+        if: ${{ github.event_name == 'push' }} && startsWith(github.ref, 'refs/tags/')
         run: |
-          RELEASE_VERSION=$(echo $GITHUB_REF | cut -d / -f 3 | sed 's/debezium-//')
-          BRANCH_NAME=$(git branch -r --contains $GITHUB_REF | cut -d / -f 2 | sed 's/rel-//')
+          RELEASE_VERSION=$(echo $GITHUB_REF | cut -d / -f 3 )
+          BRANCH_NAME=$(git branch -r --contains $GITHUB_REF | cut -d / -f 2 | sed 's/-dev//')
           echo "DIST_NAME=debezium-server-${RELEASE_VERSION}" >> "$GITHUB_ENV" 
-          echo "RELEASE_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
+          echo "RELEASE_NAME=debezium-${BRANCH_NAME}" >> "$GITHUB_ENV"
 
       - name: Build Debezium Server
         run: |

--- a/debezium-server/debezium-server-dist/src/main/resources/distro/run.sh
+++ b/debezium-server/debezium-server-dist/src/main/resources/distro/run.sh
@@ -26,7 +26,7 @@ if [ -z "$JAVA_HOME" ]; then
 else
   JAVA_BINARY="$JAVA_HOME/bin/java"
 fi
-MIN_REQUIRED_MAJOR_VERSION='17'
+MIN_REQUIRED_MAJOR_VERSION='11'
 JAVA_MAJOR_VER=$(${JAVA_BINARY} -version 2>&1 | awk -F '"' '/version/ {print $2}' | awk -F. '{print $1}')
 if ([ -n "$JAVA_MAJOR_VER" ] && (( 10#${JAVA_MAJOR_VER} >= 10#${MIN_REQUIRED_MAJOR_VERSION} )) ) #integer compare of versions.
 then


### PR DESCRIPTION
GH workflow for release automation 

As a result of this automation. the release steps would be:
- create release branch from voyager-main 2.2.0-1.3.0-dev
- create release manually with target = 2.2.0-1.3.0-dev, tag = 2.2.0-1.3.0, prerelease=true
    - automation will kick in which should build debezium, and then upload debezium-server as an asset to that release. 
    - mark prerelease=false.
