### PR TITLE
TEXT format instead of CSV

### DIFF
--- a/debezium-server/debezium-server-ybexporter/pom.xml
+++ b/debezium-server/debezium-server-ybexporter/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
-            <version>1.9.0</version>
+            <version>1.10.0</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/TableSnapshotWriterCSV.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/TableSnapshotWriterCSV.java
@@ -39,7 +39,7 @@ public class TableSnapshotWriterCSV implements RecordWriter {
             fd = fos.getFD();
             var f = new FileWriter(fd);
             var bufferedWriter = new BufferedWriter(f);
-            CSVFormat fmt = CSVFormat.POSTGRESQL_CSV;
+            CSVFormat fmt = CSVFormat.POSTGRESQL_TEXT;
             csvPrinter = new CSVPrinter(bufferedWriter, fmt);
             ArrayList<String> cols = t.getColumns();
             String header = String.join(fmt.getDelimiterString(), cols) + fmt.getRecordSeparator();


### PR DESCRIPTION
Exporting snapshot in TEXT format because it's easier to parse, and the default format for pg COPY