### PR TITLE
Workflow for including debezium server 1.9.5 in build

### DIFF
--- a/.github/workflows/voyager-debezium-workflow.yml
+++ b/.github/workflows/voyager-debezium-workflow.yml
@@ -65,7 +65,22 @@ jobs:
       - name: Build Debezium Server
         run: |
           sh buildDebeziumServer.sh
-          mv debezium-server/debezium-server-dist/target/debezium-server-dist-2.2.0-SNAPSHOT.tar.gz "debezium-server/debezium-server-dist/target/${DIST_NAME}.tar.gz"
+      - name: Package Debezium Server
+        run: |
+          cd debezium-server/debezium-server-dist/target/debezium-server
+          # get latest 1.9.5 version of debezium
+          wget https://github.com/yugabyte/debezium/releases/download/voyager-debezium/debezium-server-latest-1.9.5.tar.gz
+          tar -xvzf  debezium-server-latest-1.9.5.tar.gz
+          rm debezium-server-latest-1.9.5.tar.gz
+          mv debezium-server debezium-server-fall-forward
+          # include the yugabytedb connector
+          cd debezium-server-fall-forward/lib
+          wget https://github.com/yugabyte/debezium-connector-yugabytedb/releases/download/v1.9.5.y.31/debezium-connector-yugabytedb-1.9.5.y.31.jar
+          
+          # package
+          cd debezium-server/debezium-server-dist/target
+          tar -zcvf ${DIST_NAME}.tar.gz debezium-server
+#          mv debezium-server/debezium-server-dist/target/debezium-server-dist-2.2.0-SNAPSHOT.tar.gz "debezium-server/debezium-server-dist/target/${DIST_NAME}.tar.gz"
 
       - name: Publish to voyager-debezium release
         run: |

--- a/.github/workflows/voyager-debezium-workflow.yml
+++ b/.github/workflows/voyager-debezium-workflow.yml
@@ -69,16 +69,16 @@ jobs:
         run: |
           cd debezium-server/debezium-server-dist/target/debezium-server
           # get latest 1.9.5 version of debezium
-          wget https://github.com/yugabyte/debezium/releases/download/voyager-debezium/debezium-server-latest-1.9.5.tar.gz
+          wget -nv https://github.com/yugabyte/debezium/releases/download/voyager-debezium/debezium-server-latest-1.9.5.tar.gz
           tar -xvzf  debezium-server-latest-1.9.5.tar.gz
           rm debezium-server-latest-1.9.5.tar.gz
           mv debezium-server debezium-server-fall-forward
           # include the yugabytedb connector
           cd debezium-server-fall-forward/lib
-          wget https://github.com/yugabyte/debezium-connector-yugabytedb/releases/download/v1.9.5.y.31/debezium-connector-yugabytedb-1.9.5.y.31.jar
+          wget -nv https://github.com/yugabyte/debezium-connector-yugabytedb/releases/download/v1.9.5.y.31/debezium-connector-yugabytedb-1.9.5.y.31.jar
           
           # package
-          cd debezium-server/debezium-server-dist/target
+          cd ${GITHUB_WORKSPACE}/debezium-server/debezium-server-dist/target
           tar -zcvf ${DIST_NAME}.tar.gz debezium-server
 #          mv debezium-server/debezium-server-dist/target/debezium-server-dist-2.2.0-SNAPSHOT.tar.gz "debezium-server/debezium-server-dist/target/${DIST_NAME}.tar.gz"
 

--- a/.github/workflows/voyager-debezium-workflow.yml
+++ b/.github/workflows/voyager-debezium-workflow.yml
@@ -68,19 +68,16 @@ jobs:
       - name: Package Debezium Server
         run: |
           cd debezium-server/debezium-server-dist/target/debezium-server
-          # get latest 1.9.5 version of debezium
+          
+          # get latest 1.9.5 version of debezium. Change this during release to point to exact 1.9.5 release.
           wget -nv https://github.com/yugabyte/debezium/releases/download/voyager-debezium/debezium-server-latest-1.9.5.tar.gz
           tar -xvzf  debezium-server-latest-1.9.5.tar.gz
           rm debezium-server-latest-1.9.5.tar.gz
-          mv debezium-server debezium-server-fall-forward
-          # include the yugabytedb connector
-          cd debezium-server-fall-forward/lib
-          wget -nv https://github.com/yugabyte/debezium-connector-yugabytedb/releases/download/v1.9.5.y.31/debezium-connector-yugabytedb-1.9.5.y.31.jar
+          mv debezium-server debezium-server-1.9.5
           
           # package
           cd ${GITHUB_WORKSPACE}/debezium-server/debezium-server-dist/target
           tar -zcvf ${DIST_NAME}.tar.gz debezium-server
-#          mv debezium-server/debezium-server-dist/target/debezium-server-dist-2.2.0-SNAPSHOT.tar.gz "debezium-server/debezium-server-dist/target/${DIST_NAME}.tar.gz"
 
       - name: Publish to voyager-debezium release
         run: |

--- a/Makefile
+++ b/Makefile
@@ -4,26 +4,26 @@ VERSION=2.2.0
 DEBEZIUM_SERVER_LIB=debezium-server/debezium-server-dist/target/debezium-server/lib/
 
 debezium:
-	mvn clean install -Dquick -Pquick
+	mvn -ntp clean install -Dquick -Pquick
 
 debezium-server:
 	cd debezium-server/debezium-server-dist; \
-	mvn clean install -Passembly; \
+	mvn -ntp clean install -Passembly; \
 	cd target; \
 	tar -xvzf debezium-server-dist-$(VERSION)-SNAPSHOT.tar.gz;
 
 debezium-server-core:
-	mvn clean install -Dquick -Pquick -pl :debezium-server-core; \
+	mvn -ntp clean install -Dquick -Pquick -pl :debezium-server-core; \
 	cp debezium-server/debezium-server-core/target/debezium-server-core-$(VERSION)-SNAPSHOT.jar $(DEBEZIUM_SERVER_LIB);
 
 yb-exporter:
-	mvn clean install -Dquick -Pquick -pl :debezium-server-ybexporter; \
+	mvn -ntp clean install -Dquick -Pquick -pl :debezium-server-ybexporter; \
 	cp debezium-server/debezium-server-ybexporter/target/debezium-server-ybexporter-$(VERSION)-SNAPSHOT.jar $(DEBEZIUM_SERVER_LIB);
 
 postgres-connector:
-	mvn clean install -Dquick -Pquick -pl :debezium-connector-postgres; \
+	mvn -ntp clean install -Dquick -Pquick -pl :debezium-connector-postgres; \
 	cp debezium-connector-postgres/target/debezium-connector-postgres-$(VERSION)-SNAPSHOT.jar $(DEBEZIUM_SERVER_LIB);
 
 debezium-core:
-	mvn clean install -Dquick -Pquick -pl :debezium-core; \
+	mvn -ntp clean install -Dquick -Pquick -pl :debezium-core; \
 	cp debezium-core/target/debezium-core-$(VERSION)-SNAPSHOT.jar $(DEBEZIUM_SERVER_LIB);


### PR DESCRIPTION
This modifies the build procedure to include the debezium-server-1.9.5 (from branch `voyager-main-1.9.5` branch) along with the yugabyte connector under dir `debezium-server/debezium-server-fall-forward`.

Overall workflow:
- We maintain two branches (`voyager-main` and `voyager-main-1.9.5`). Every merge has to go to both the branches. 
- On every build of the `voyager-main` it picks up the latest build of the `voyager-main-1.9.5` and includes it in the tar.(along with the yb connector).

During release, we can create separate releases for each, and modify the build workflow to pick up exact builds. 