### PR TITLE
fix bug during recovery of vsn if latest segment is full

### DIFF
--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/EventQueue.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/EventQueue.java
@@ -73,6 +73,10 @@ public class EventQueue implements RecordWriter {
      * Then it retrieves the index number from the paths, and then finds
      * the max index - which is the latest queue segment that was written to.
      * If no files are found, we just return.
+     * TODO handle edge case: even if the  latest queue segment was already closed (i.e. EOF marker was written),
+     * we would still consider it to be the latest and open it. when the next write arrives, we will rotate the
+     * queue segment, which would again write an EOF marker, leading to two EOF markers sequentially.
+     * Voyager import data will proceed to next segment upon seeing the first EOF so it's not a concern.
      */
     private void recoverLatestQueueSegment(){
         // read dir to find all queue files

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/QueueSegment.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/QueueSegment.java
@@ -35,7 +35,7 @@ import java.util.Objects;
 public class QueueSegment {
     private static final Logger LOGGER = LoggerFactory.getLogger(QueueSegment.class);
 
-    private static final String EOF_MARKER = "\\.\n\n";
+    private static final String EOF_MARKER = "\\.";
     private String filePath;
     private FileOutputStream fos;
     private FileDescriptor fd;
@@ -104,6 +104,8 @@ public class QueueSegment {
     public void close() throws IOException {
         LOGGER.info("Closing queue file {}", filePath);
         writer.write(EOF_MARKER);
+        writer.write("\n");
+        writer.write("\n");
         writer.flush();
         sync();
         writer.close();
@@ -121,6 +123,9 @@ public class QueueSegment {
         try {
             input = new BufferedReader(new FileReader(filePath));
             while ((line = input.readLine()) != null) {
+                if (line.equals(EOF_MARKER)){
+                    break;
+                }
                 last = line;
             }
             if (last != null){


### PR DESCRIPTION
Scenario: process exits after writing EOF marker of a segment, but before creating next segment file.
on resume, it will try to read the last event json, to get the resume-vsn.

Bug:  Last line is EOF marker, which was causing dbzm to error out.

Fix: Break after EOF marker to get the last event
