### PR TITLE
Fix bug in recovering vsn if latest segment is empty

### DIFF
--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/EventQueue.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/EventQueue.java
@@ -73,6 +73,10 @@ public class EventQueue implements RecordWriter {
      * Then it retrieves the index number from the paths, and then finds
      * the max index - which is the latest queue segment that was written to.
      * If no files are found, we just return.
+     * TODO handle edge case: even if the  latest queue segment was already closed (i.e. EOF marker was written),
+     * we would still consider it to be the latest and open it. when the next write arrives, we will rotate the
+     * queue segment, which would again write an EOF marker, leading to two EOF markers sequentially.
+     * Voyager import data will proceed to next segment upon seeing the first EOF so it's not a concern.
      */
     private void recoverLatestQueueSegment(){
         // read dir to find all queue files

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/EventQueue.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/EventQueue.java
@@ -85,6 +85,7 @@ public class EventQueue implements RecordWriter {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
+            LOGGER.info("advancing sequence number to {}", nextSequenceNumber);
             sng.advanceTo(nextSequenceNumber);
         }
     }

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/EventQueue.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/EventQueue.java
@@ -64,7 +64,23 @@ public class EventQueue implements RecordWriter {
         recoverLatestQueueSegment();
         // recover sequence numberof last written record and resume
         if (currentQueueSegment != null){
-            sng.advanceTo(currentQueueSegment.getSequenceNumberOfLastRecord() + 1);
+            long lastRecordSequenceNumber = currentQueueSegment.getSequenceNumberOfLastRecord();
+            long nextSequenceNumber;
+            if (lastRecordSequenceNumber == -1){
+                // current queue segment is empty, we need to look at the second last segment
+                if (currentQueueSegmentIndex == 0){
+                    // there is no second last segment, start from 1
+                    nextSequenceNumber = 1;
+                }
+                else {
+                    QueueSegment secondLastQueueSegment = new QueueSegment(getFilePathWithIndex(currentQueueSegmentIndex-1));
+                    nextSequenceNumber = secondLastQueueSegment.getSequenceNumberOfLastRecord() + 1;
+                }
+            }
+            else {
+                nextSequenceNumber = lastRecordSequenceNumber + 1;
+            }
+            sng.advanceTo(nextSequenceNumber);
         }
     }
 

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/QueueSegment.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/QueueSegment.java
@@ -35,7 +35,7 @@ import java.util.Objects;
 public class QueueSegment {
     private static final Logger LOGGER = LoggerFactory.getLogger(QueueSegment.class);
 
-    private static final String EOF_MARKER = "\\.\n\n";
+    private static final String EOF_MARKER = "\\.";
     private String filePath;
     private FileOutputStream fos;
     private FileDescriptor fd;
@@ -104,6 +104,8 @@ public class QueueSegment {
     public void close() throws IOException {
         LOGGER.info("Closing queue file {}", filePath);
         writer.write(EOF_MARKER);
+        writer.write("\n");
+        writer.write("\n");
         writer.flush();
         sync();
         writer.close();
@@ -121,6 +123,9 @@ public class QueueSegment {
         try {
             input = new BufferedReader(new FileReader(filePath));
             while ((line = input.readLine()) != null) {
+                if (line.equals(EOF_MARKER)){
+                    break;
+                }
                 last = line;
             }
             if (last != null){

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/QueueSegment.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/QueueSegment.java
@@ -117,7 +117,7 @@ public class QueueSegment {
 
     public long getSequenceNumberOfLastRecord(){
         ObjectMapper mapper = new ObjectMapper(new JsonFactory());
-        long vsn = 0;
+        long vsn = -1;
         String last = null, line;
         BufferedReader input;
         try {


### PR DESCRIPTION
If latest segment is empty while recovering, we have to read the last record in the second latest segment to get the vsn to resume from.