### PR TITLE
Debezium Plugin to read switch request(trigger) from MetaDB instead o…

### DIFF
--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/ExportStatus.java
@@ -30,6 +30,7 @@ import org.apache.kafka.connect.data.Field;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.graalvm.collections.Pair;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,9 +44,11 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 /**
  * Singleton class that is used to update the status of the export process.
  */
+
 public class ExportStatus {
     private static final Logger LOGGER = LoggerFactory.getLogger(ExportStatus.class);
     private static final String EXPORT_STATUS_FILE_NAME = "export_status.json";
+    private String MIGRATION_STATUS_KEY = "migration_status";
     private static ExportStatus instance;
     private static ObjectMapper mapper = new ObjectMapper(new JsonFactory());
     private String dataDir;
@@ -64,6 +67,7 @@ public class ExportStatus {
     private static String QUEUE_SEGMENT_META_TABLE_NAME = "queue_segment_meta";
     private static String EVENT_STATS_TABLE_NAME = "exported_events_stats";
     private static String EVENT_STATS_PER_TABLE_TABLE_NAME = "exported_events_stats_per_table";
+    private static String JSON_OBJECTS_TABLE_NAME = "json_objects";
 
 
     /**
@@ -298,6 +302,29 @@ public class ExportStatus {
             metadataDBConn.setAutoCommit(oldAutoCommit);
         }
 
+    }
+
+    public boolean checkIfSwitchOperationRequested(String operation) throws SQLException {
+        Statement selectStmt = metadataDBConn.createStatement();
+        String query = String.format("SELECT json_text from %s where key = '%s'",
+            JSON_OBJECTS_TABLE_NAME, MIGRATION_STATUS_KEY);
+        try {
+            ResultSet rs = selectStmt.executeQuery(query);
+            while (rs.next()) {
+                MigrationStatusRecord msr = MigrationStatusRecord.fromJsonString(rs.getString("json_text"));
+                switch(operation.toString()) {
+                    case "cutover":
+                        return msr.CutoverRequested;
+                    case "fallforward":
+                        return msr.FallForwardSwitchRequested;
+                }
+            }
+        } catch (SQLException e) {
+            throw e;
+        } finally {
+            selectStmt.close();
+        }
+        return false;
     }
 
     private void updateEventsStats(Connection conn, Map<Pair<String, String>, Map<String, Long>> eventCountDeltaPerTable) throws SQLException {

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/MigrationStatusRecord.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/MigrationStatusRecord.java
@@ -1,0 +1,35 @@
+package io.debezium.server.ybexporter;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+public class MigrationStatusRecord {
+    public String MigrationUUID;
+    public String SourceDBType;
+    public String ExportType;
+    public boolean FallForwarDBExists;
+    public List<String> TableListExportedFromSource;
+    public boolean CutoverRequested;
+    public boolean CutoverProcessedBySourceExporter;
+    public boolean CutoverProcessedByTargetImporter;
+    public boolean FallForwardSyncStarted;
+    public boolean FallForwardSwitchRequested;
+    public boolean FallForwardSwitchProcessedByTargetExporter;
+    public boolean FallForwardSwitchProcessedByFFImporter;
+    public boolean ExportSchemaDone;
+    public boolean ExportDataDone;
+
+    public static MigrationStatusRecord fromJsonString(String jsonString) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        try {
+            return objectMapper.readValue(jsonString, MigrationStatusRecord.class);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
+++ b/debezium-server/debezium-server-ybexporter/src/main/java/io/debezium/server/ybexporter/YbExporterConsumer.java
@@ -5,9 +5,8 @@
  */
 package io.debezium.server.ybexporter;
 
-import java.io.File;
 import java.net.URISyntaxException;
-import java.nio.file.Path;
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +39,6 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
     String snapshotMode;
     @ConfigProperty(name = PROP_PREFIX + "dataDir")
     String dataDir;
-    String triggersDir;
     String sourceType;
     String exporterRole;
     private Map<String, Table> tableMap = new HashMap<>();
@@ -60,7 +58,6 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
 
         snapshotMode = config.getOptionalValue("debezium.source.snapshot.mode", String.class).orElse("");
         retrieveSourceType(config);
-        triggersDir = config.getValue(PROP_PREFIX + "triggers.dir", String.class);
         exporterRole = config.getValue("debezium.sink.ybexporter.exporter.role", String.class);
 
         exportStatus = ExportStatus.getInstance(dataDir);
@@ -141,11 +138,15 @@ public class YbExporterConsumer extends BaseChangeConsumer implements DebeziumEn
     }
 
     private void checkForSwitchOperationAndHandle(String operation){
-        File switchTriggerFile = new File(Path.of(triggersDir, operation).toString());
-        if (!switchTriggerFile.exists()){
-            return;
+        try {
+            if (!exportStatus.checkIfSwitchOperationRequested(operation)) {
+                return;
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
         }
-        LOGGER.info("Observed {} trigger file. Cutting over...", operation);
+
+        LOGGER.info("Observed {} trigger present in metadb. Cutting over...", operation);
         Record switchOperationRecord = new Record();
         switchOperationRecord.op = operation;
         switchOperationRecord.t = new Table(null, null,null); // just to satisfy being a proper Record object.


### PR DESCRIPTION
…f flag files (#92)

- Introduced a new class MigrationStatusRecord to store and deal with all the details and methods related to Mig Status in metaDB json_objects tables
- Removed the requirement for metainfo/triggers directory