### PR TITLE
[DBZ-PGYB] Use YugabyteDB smart driver instead of vanilla Postgres JDBC driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes are documented in this file. Release numbers follow [Semantic Versioning](http://semver.org)
 
-## 2.5.2.Final
+## 2.5.2.Final-SNAPSHOT
 February 27th 2024 [Detailed release notes](https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12317320&version=12422552)
 
 ### New features since 2.5.1.Final

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes are documented in this file. Release numbers follow [Semantic Versioning](http://semver.org)
 
-## 2.5.2.Final-SNAPSHOT
+## 2.5.2.Final
 February 27th 2024 [Detailed release notes](https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12317320&version=12422552)
 
 ### New features since 2.5.1.Final

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN rm -rf debezium-connector-oracle
 RUN rm -rf debezium-connector-spanner
 RUN rm -rf debezium-connector-sqlserver
 RUN rm -rf debezium-connector-vitess
+RUN rm -f debezium-connector-postgres/debezium-core-2.5.2.Final.jar
 WORKDIR /
 
 # Copy the Debezium Connector for Postgres adapted for YugabyteDB
@@ -24,8 +25,10 @@ COPY debezium-core/target/debezium-core-*.jar $KAFKA_CONNECT_PLUGINS_DIR/debeziu
 ENV KAFKA_OPTS="-Djdk.tls.client.protocols=TLSv1.2"
 
 # Add the required jar files to be packaged with the base connector
-RUN cd $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres && curl -sLo kafka-connect-jdbc-10.6.5.jar https://github.com/yugabyte/kafka-connect-jdbc/releases/download/10.6.5-CUSTOM/kafka-connect-jdbc-10.6.5.jar
+RUN cd $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres && curl -sLo kafka-connect-jdbc-10.6.5.jar https://github.com/yugabyte/kafka-connect-jdbc/releases/download/10.6.5-CUSTOM.4/kafka-connect-jdbc-10.6.5-CUSTOM.4.jar
 RUN cd $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres && curl -sLo jdbc-yugabytedb-42.3.5-yb-1.jar https://repo1.maven.org/maven2/com/yugabyte/jdbc-yugabytedb/42.3.5-yb-1/jdbc-yugabytedb-42.3.5-yb-1.jar
+RUN cd $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres && curl -sLo transforms-for-apache-kafka-connect-1.5.0.zip https://github.com/Aiven-Open/transforms-for-apache-kafka-connect/releases/download/v1.5.0/transforms-for-apache-kafka-connect-1.5.0.zip
+RUN cd $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres && unzip transforms-for-apache-kafka-connect-1.5.0.zip
 
 # Add Jmx agent and metrics pattern file to expose the metrics info
 RUN mkdir /kafka/etc && cd /kafka/etc && curl -so jmx_prometheus_javaagent-0.17.2.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.17.2/jmx_prometheus_javaagent-0.17.2.jar
@@ -33,4 +36,7 @@ RUN mkdir /kafka/etc && cd /kafka/etc && curl -so jmx_prometheus_javaagent-0.17.
 ADD metrics.yml /etc/jmx-exporter/
 
 ENV CLASSPATH=$KAFKA_HOME
+
+# properties file having instructions to roll over log files in case the size exceeds a given limit
+COPY log4j.properties $KAFKA_HOME/config/log4j.properties
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,20 @@ FROM debezium/connect:2.5.2.Final
 
 WORKDIR $KAFKA_CONNECT_PLUGINS_DIR
 RUN rm -f debezium-connector-postgres/debezium-connector-postgres-*.jar
+RUN rm -rf debezium-connector-db2
+RUN rm -rf debezium-connector-informix
+RUN rm -rf debezium-connector-mongodb
+RUN rm -rf debezium-connector-jdbc
+RUN rm -rf debezium-connector-mysql
+RUN rm -rf debezium-connector-oracle
+RUN rm -rf debezium-connector-spanner
+RUN rm -rf debezium-connector-sqlserver
+RUN rm -rf debezium-connector-vitess
 WORKDIR /
 
 # Copy the Debezium Connector for Postgres adapted for YugabyteDB
 COPY debezium-connector-postgres/target/debezium-connector-postgres-*.jar $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres
+COPY debezium-core/target/debezium-core-*.jar $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres
 
 # Set the TLS version to be used by Kafka processes
 ENV KAFKA_OPTS="-Djdk.tls.client.protocols=TLSv1.2"

--- a/debezium-api/pom.xml
+++ b/debezium-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-api/pom.xml
+++ b/debezium-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-api/pom.xml
+++ b/debezium-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-assembly-descriptors/pom.xml
+++ b/debezium-assembly-descriptors/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-assembly-descriptors/pom.xml
+++ b/debezium-assembly-descriptors/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-assembly-descriptors/pom.xml
+++ b/debezium-assembly-descriptors/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connect-rest-extension/pom.xml
+++ b/debezium-connect-rest-extension/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-parent</artifactId>
-    <version>2.5.2.Final</version>
+    <version>2.5.2.Final-SNAPSHOT</version>
     <relativePath>../debezium-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/debezium-connect-rest-extension/pom.xml
+++ b/debezium-connect-rest-extension/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-parent</artifactId>
-    <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+    <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
     <relativePath>../debezium-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/debezium-connect-rest-extension/pom.xml
+++ b/debezium-connect-rest-extension/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-parent</artifactId>
-    <version>2.5.2.Final-SNAPSHOT</version>
+    <version>2.5.2.ybpg.20241-SNAPSHOT</version>
     <relativePath>../debezium-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-postgres/YB_DEV_NOTES.md
+++ b/debezium-connector-postgres/YB_DEV_NOTES.md
@@ -2,10 +2,10 @@
 
 ## Compiling code
 
-The following command will quickly build the postgres connector code with all the required dependencies and proto files:
+Since the smart driver changes require us to build the debezium core as well, build can be completed using:
 
 ```bash
-./mvnw clean install -Dquick -pl debezium-connector-postgres -am 
+./mvnw clean install -Dquick
 ```
 
 ## Running tests

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.yugabyte</groupId>
+            <artifactId>jdbc-yugabytedb</artifactId>
+            <version>42.3.5-yb-4</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
         </dependency>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PgOid.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PgOid.java
@@ -6,10 +6,10 @@
 
 package io.debezium.connector.postgresql;
 
-import org.postgresql.core.Oid;
+import com.yugabyte.core.Oid;
 
 /**
- * Extension to the {@link org.postgresql.core.Oid} class which contains Postgres specific datatypes not found currently in the
+ * Extension to the {@link com.yugabyte.core.Oid} class which contains Postgres specific datatypes not found currently in the
  * JDBC driver implementation classes.
  *
  * @author Horia Chiorean (hchiorea@redhat.com)

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.postgresql.core.BaseConnection;
+import com.yugabyte.core.BaseConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -1141,11 +1141,16 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         return 0;
     }
 
+    /**
+     * Method to get the connection factory depending on the provided hostname value.
+     * @param hostName the host(s) for the PostgreSQL/YugabyteDB instance
+     * @return a {@link io.debezium.jdbc.JdbcConnection.ConnectionFactory} instance
+     */
     public static JdbcConnection.ConnectionFactory getConnectionFactory(String hostName) {
         return hostName.contains(":")
                  ? JdbcConnection.patternBasedFactory(PostgresConnection.MULTI_HOST_URL_PATTERN, com.yugabyte.Driver.class.getName(),
                     PostgresConnection.class.getClassLoader(), JdbcConfiguration.PORT.withDefault(PostgresConnectorConfig.PORT.defaultValueAsString()))
-                 : JdbcConnection.patternBasedFactory(PostgresConnection.URL_PATTERN, com.yugabyte.Driver.class.getName(),
+                 : JdbcConnection.patternBasedFactory(PostgresConnection.URL_PATTERN, org.yugabyte.Driver.class.getName(),
                     PostgresConnection.class.getClassLoader(), JdbcConfiguration.PORT.withDefault(PostgresConnectorConfig.PORT.defaultValueAsString()));
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -1143,9 +1143,9 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     public JdbcConnection.ConnectionFactory getConnectionFactory() {
         String hostName = getJdbcConfig().getHostname();
         return hostName.contains(":")
-                 ? JdbcConnection.patternBasedFactory(PostgresConnection.MULTI_HOST_URL_PATTERN, org.postgresql.Driver.class.getName(),
+                 ? JdbcConnection.patternBasedFactory(PostgresConnection.MULTI_HOST_URL_PATTERN, com.yugabyte.Driver.class.getName(),
                     PostgresConnection.class.getClassLoader(), JdbcConfiguration.PORT.withDefault(PostgresConnectorConfig.PORT.defaultValueAsString()))
-                 : JdbcConnection.patternBasedFactory(PostgresConnection.URL_PATTERN, org.postgresql.Driver.class.getName(),
+                 : JdbcConnection.patternBasedFactory(PostgresConnection.URL_PATTERN, com.yugabyte.Driver.class.getName(),
                     PostgresConnection.class.getClassLoader(), JdbcConfiguration.PORT.withDefault(PostgresConnectorConfig.PORT.defaultValueAsString()));
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -1150,7 +1150,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         return hostName.contains(":")
                  ? JdbcConnection.patternBasedFactory(PostgresConnection.MULTI_HOST_URL_PATTERN, com.yugabyte.Driver.class.getName(),
                     PostgresConnection.class.getClassLoader(), JdbcConfiguration.PORT.withDefault(PostgresConnectorConfig.PORT.defaultValueAsString()))
-                 : JdbcConnection.patternBasedFactory(PostgresConnection.URL_PATTERN, org.yugabyte.Driver.class.getName(),
+                 : JdbcConnection.patternBasedFactory(PostgresConnection.URL_PATTERN, com.yugabyte.Driver.class.getName(),
                     PostgresConnection.class.getClassLoader(), JdbcConfiguration.PORT.withDefault(PostgresConnectorConfig.PORT.defaultValueAsString()));
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -1193,4 +1193,6 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                     !t.schema().startsWith(TEMP_TABLE_SCHEMA_PREFIX);
         }
     }
+
+
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -491,6 +491,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     public static final Field PORT = RelationalDatabaseConnectorConfig.PORT
             .withDefault(DEFAULT_PORT);
 
+
     public static final Field PLUGIN_NAME = Field.create("plugin.name")
             .withDisplayName("Plugin")
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED_REPLICATION, 0))
@@ -1140,8 +1141,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         return 0;
     }
 
-    public JdbcConnection.ConnectionFactory getConnectionFactory() {
-        String hostName = getJdbcConfig().getHostname();
+    public static JdbcConnection.ConnectionFactory getConnectionFactory(String hostName) {
         return hostName.contains(":")
                  ? JdbcConnection.patternBasedFactory(PostgresConnection.MULTI_HOST_URL_PATTERN, com.yugabyte.Driver.class.getName(),
                     PostgresConnection.class.getClassLoader(), JdbcConfiguration.PORT.withDefault(PostgresConnectorConfig.PORT.defaultValueAsString()))
@@ -1193,6 +1193,8 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                     !t.schema().startsWith(TEMP_TABLE_SCHEMA_PREFIX);
         }
     }
+
+
 
 
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -12,7 +12,7 @@ import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.connect.errors.ConnectException;
-import org.postgresql.core.BaseConnection;
+import com.yugabyte.core.BaseConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -48,7 +48,6 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
      * trigger a "WAL backlog growing" warning.
      */
     private static final int GROWING_WAL_WARNING_LOG_INTERVAL = 10_000;
-
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgresStreamingChangeEventSource.class);
 
     // PGOUTPUT decoder sends the messages with larger time gaps than other decoders

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresType.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresType.java
@@ -8,8 +8,8 @@ package io.debezium.connector.postgresql;
 import java.util.List;
 import java.util.Objects;
 
-import org.postgresql.core.Oid;
-import org.postgresql.core.TypeInfo;
+import com.yugabyte.core.Oid;
+import com.yugabyte.core.TypeInfo;
 
 /**
  * A class that binds together a PostgresSQL OID, JDBC type id and the string name of the type.

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -41,12 +41,12 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.postgresql.PGStatement;
-import org.postgresql.geometric.PGpoint;
-import org.postgresql.jdbc.PgArray;
-import org.postgresql.util.HStoreConverter;
-import org.postgresql.util.PGInterval;
-import org.postgresql.util.PGobject;
+import com.yugabyte.PGStatement;
+import com.yugabyte.geometric.PGpoint;
+import com.yugabyte.jdbc.PgArray;
+import com.yugabyte.util.HStoreConverter;
+import com.yugabyte.util.PGInterval;
+import com.yugabyte.util.PGobject;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -700,7 +700,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
     /**
      * Returns an Hstore field as string in the form of {@code "key 1"=>"value1", "key_2"=>"val 1"}; i.e. the given byte
      * array is NOT the byte representation returned by {@link HStoreConverter#toBytes(Map,
-     * org.postgresql.core.Encoding))}, but the String based representation
+     * com.yugabyte.core.Encoding))}, but the String based representation
      */
     private String asHstoreString(byte[] data) {
         return new String(data, databaseCharset);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -19,9 +19,9 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.kafka.connect.errors.ConnectException;
-import org.postgresql.core.BaseConnection;
-import org.postgresql.core.TypeInfo;
-import org.postgresql.jdbc.PgDatabaseMetaData;
+import com.yugabyte.core.BaseConnection;
+import com.yugabyte.core.TypeInfo;
+import com.yugabyte.jdbc.PgDatabaseMetaData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -431,7 +431,7 @@ public class TypeRegistry {
     private static class SqlTypeMapper {
 
         /**
-         * Based on org.postgresql.jdbc.TypeInfoCache.getSQLType(String). To emulate the original statement's behavior
+         * Based on com.yugabyte.jdbc.TypeInfoCache.getSQLType(String). To emulate the original statement's behavior
          * (which works for single types only), PG's DISTINCT ON extension is used to just return the first entry should a
          * type exist in multiple schemas.
          */

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractColumnValue.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractColumnValue.java
@@ -14,16 +14,16 @@ import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
 import org.apache.kafka.connect.errors.ConnectException;
-import org.postgresql.geometric.PGbox;
-import org.postgresql.geometric.PGcircle;
-import org.postgresql.geometric.PGline;
-import org.postgresql.geometric.PGlseg;
-import org.postgresql.geometric.PGpath;
-import org.postgresql.geometric.PGpoint;
-import org.postgresql.geometric.PGpolygon;
-import org.postgresql.jdbc.PgArray;
-import org.postgresql.util.PGInterval;
-import org.postgresql.util.PGtokenizer;
+import com.yugabyte.geometric.PGbox;
+import com.yugabyte.geometric.PGcircle;
+import com.yugabyte.geometric.PGline;
+import com.yugabyte.geometric.PGlseg;
+import com.yugabyte.geometric.PGpath;
+import com.yugabyte.geometric.PGpoint;
+import com.yugabyte.geometric.PGpolygon;
+import com.yugabyte.jdbc.PgArray;
+import com.yugabyte.util.PGInterval;
+import com.yugabyte.util.PGtokenizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/Lsn.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/Lsn.java
@@ -7,11 +7,11 @@ package io.debezium.connector.postgresql.connection;
 
 import java.nio.ByteBuffer;
 
-import org.postgresql.replication.LogSequenceNumber;
+import com.yugabyte.replication.LogSequenceNumber;
 
 /**
  * Abstraction of PostgreSQL log sequence number, adapted from
- * {@link org.postgresql.replication.LogSequenceNumber}.
+ * {@link com.yugabyte.replication.LogSequenceNumber}.
  *
  * @author Jiri Pechanec
  *

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoder.java
@@ -10,7 +10,7 @@ import java.nio.ByteBuffer;
 import java.sql.SQLException;
 import java.util.function.Function;
 
-import org.postgresql.replication.fluent.logical.ChainedLogicalStreamBuilder;
+import com.yugabyte.replication.fluent.logical.ChainedLogicalStreamBuilder;
 
 import io.debezium.connector.postgresql.TypeRegistry;
 import io.debezium.connector.postgresql.connection.ReplicationStream.ReplicationMessageProcessor;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -97,6 +97,7 @@ public class PostgresConnection extends JdbcConnection {
      * @param config {@link Configuration} instance, may not be null.
      * @param valueConverterBuilder supplies a configured {@link PostgresValueConverter} for a given {@link TypeRegistry}
      * @param connectionUsage a symbolic name of the connection to be tracked in monitoring tools
+     * @param factory a {@link io.debezium.jdbc.JdbcConnection.ConnectionFactory} instance
      */
     public PostgresConnection(JdbcConfiguration config, PostgresValueConverterBuilder valueConverterBuilder, String connectionUsage, ConnectionFactory factory) {
         super(addDefaultSettings(config, connectionUsage), factory, PostgresConnection::validateServerVersion, "\"", "\"");
@@ -600,7 +601,7 @@ public class PostgresConnection extends JdbcConnection {
 
     public Charset getDatabaseCharset() {
         try {
-            return Charset.forName(((com.yugabyte.jdbc.PgConnection) connection()).getEncoding().name());
+            return Charset.forName(((BaseConnection) connection()).getEncoding().name());
         }
         catch (SQLException e) {
             throw new DebeziumException("Couldn't obtain encoding for database " + database(), e);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -70,7 +70,7 @@ public class PostgresConnection extends JdbcConnection {
     private static final Pattern EXPRESSION_DEFAULT_PATTERN = Pattern.compile("\\(+(?:.+(?:[+ - * / < > = ~ ! @ # % ^ & | ` ?] ?.+)+)+\\)");
     private static Logger LOGGER = LoggerFactory.getLogger(PostgresConnection.class);
 
-    public static final String MULTI_HOST_URL_PATTERN = "jdbc:postgresql://${" + JdbcConfiguration.HOSTNAME + "}/${" + JdbcConfiguration.DATABASE + "}";
+    public static final String MULTI_HOST_URL_PATTERN = "jdbc:yugabytedb://${" + JdbcConfiguration.HOSTNAME + "}/${" + JdbcConfiguration.DATABASE + "}";
     public static final String URL_PATTERN = "jdbc:yugabytedb://${" + JdbcConfiguration.HOSTNAME + "}:${"
             + JdbcConfiguration.PORT + "}/${" + JdbcConfiguration.DATABASE + "}";
     protected static ConnectionFactory FACTORY = JdbcConnection.patternBasedFactory(URL_PATTERN,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -117,9 +117,7 @@ public class PostgresConnection extends JdbcConnection {
     }
 
     public PostgresConnection(JdbcConfiguration config, PostgresValueConverterBuilder valueConverterBuilder, String connectionUsage) {
-        this(config, valueConverterBuilder, connectionUsage,
-             config.getHostname().contains(":") ? JdbcConnection.patternBasedFactory(MULTI_HOST_URL_PATTERN, com.yugabyte.Driver.class.getName(), PostgresConnection.class.getClassLoader(), JdbcConfiguration.PORT.withDefault(PostgresConnectorConfig.PORT.defaultValueAsString()))
-                                                    : JdbcConnection.patternBasedFactory(URL_PATTERN, com.yugabyte.Driver.class.getName(), PostgresConnection.class.getClassLoader(), JdbcConfiguration.PORT.withDefault(PostgresConnectorConfig.PORT.defaultValueAsString())));
+        this(config, valueConverterBuilder, connectionUsage, PostgresConnectorConfig.getConnectionFactory(config.getHostname()));
     }
 
     /**
@@ -145,7 +143,7 @@ public class PostgresConnection extends JdbcConnection {
     }
 
     public PostgresConnection(PostgresConnectorConfig config, TypeRegistry typeRegistry, String connectionUsage) {
-        this(config, typeRegistry, connectionUsage, config.getConnectionFactory());
+        this(config, typeRegistry, connectionUsage, PostgresConnectorConfig.getConnectionFactory(config.getJdbcConfig().getHostname()));
     }
 
     /**
@@ -608,7 +606,7 @@ public class PostgresConnection extends JdbcConnection {
         }
     }
 
-    public com.yugabyte.jdbc.TimestampUtils getTimestampUtils() {
+    public TimestampUtils getTimestampUtils() {
         try {
             return ((com.yugabyte.jdbc.PgConnection) this.connection()).getTimestampUtils();
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresDefaultValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresDefaultValueConverter.java
@@ -21,8 +21,8 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
-import org.postgresql.jdbc.TimestampUtils;
-import org.postgresql.util.PGInterval;
+import com.yugabyte.jdbc.TimestampUtils;
+import com.yugabyte.util.PGInterval;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -28,12 +28,12 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.errors.ConnectException;
-import org.postgresql.core.BaseConnection;
-import org.postgresql.core.ServerVersion;
-import org.postgresql.replication.PGReplicationStream;
-import org.postgresql.replication.fluent.logical.ChainedLogicalStreamBuilder;
-import org.postgresql.util.PSQLException;
-import org.postgresql.util.PSQLState;
+import com.yugabyte.core.BaseConnection;
+import com.yugabyte.core.ServerVersion;
+import com.yugabyte.replication.PGReplicationStream;
+import com.yugabyte.replication.fluent.logical.ChainedLogicalStreamBuilder;
+import com.yugabyte.util.PSQLException;
+import com.yugabyte.util.PSQLState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
@@ -10,7 +10,7 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Optional;
 
-import org.postgresql.replication.PGReplicationStream;
+import com.yugabyte.replication.PGReplicationStream;
 
 import io.debezium.annotation.NotThreadSafe;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
@@ -52,7 +52,7 @@ public interface ReplicationConnection extends AutoCloseable {
      * @param offset a value representing the WAL sequence number where replication should start from; if the value
      * is {@code null} or negative, this behaves exactly like {@link #startStreaming()}.
      * @return a {@link PGReplicationStream} from which data is read; never null
-     * @see org.postgresql.replication.LogSequenceNumber
+     * @see com.yugabyte.replication.LogSequenceNumber
      * @throws SQLException if anything fails
      */
     ReplicationStream startStreaming(Lsn offset, WalPositionLocator walPosition) throws SQLException, InterruptedException;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
@@ -13,12 +13,12 @@ import java.time.OffsetTime;
 import java.util.List;
 import java.util.OptionalLong;
 
-import org.postgresql.geometric.PGbox;
-import org.postgresql.geometric.PGcircle;
-import org.postgresql.geometric.PGline;
-import org.postgresql.geometric.PGpath;
-import org.postgresql.geometric.PGpoint;
-import org.postgresql.geometric.PGpolygon;
+import com.yugabyte.geometric.PGbox;
+import com.yugabyte.geometric.PGcircle;
+import com.yugabyte.geometric.PGline;
+import com.yugabyte.geometric.PGpath;
+import com.yugabyte.geometric.PGpoint;
+import com.yugabyte.geometric.PGpolygon;
 
 import io.debezium.connector.postgresql.PostgresStreamingChangeEventSource;
 import io.debezium.connector.postgresql.PostgresStreamingChangeEventSource.PgConnectionSupplier;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationStream.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationStream.java
@@ -9,7 +9,7 @@ package io.debezium.connector.postgresql.connection;
 import java.sql.SQLException;
 import java.util.concurrent.ExecutorService;
 
-import org.postgresql.replication.PGReplicationStream;
+import com.yugabyte.replication.PGReplicationStream;
 
 /**
  * A stream from which messages sent by a logical decoding plugin can be consumed over a replication connection.

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
-import org.postgresql.replication.fluent.logical.ChainedLogicalStreamBuilder;
+import com.yugabyte.replication.fluent.logical.ChainedLogicalStreamBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoColumnValue.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoColumnValue.java
@@ -17,8 +17,8 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 
-import org.postgresql.geometric.PGpoint;
-import org.postgresql.jdbc.PgArray;
+import com.yugabyte.geometric.PGpoint;
+import com.yugabyte.jdbc.PgArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoMessageDecoder.java
@@ -12,7 +12,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import org.apache.kafka.connect.errors.ConnectException;
-import org.postgresql.replication.fluent.logical.ChainedLogicalStreamBuilder;
+import com.yugabyte.replication.fluent.logical.ChainedLogicalStreamBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -54,7 +54,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
-import org.postgresql.jdbc.PgStatement;
+import com.yugabyte.jdbc.PgStatement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -60,7 +60,7 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
-import org.postgresql.util.PSQLState;
+import com.yugabyte.util.PSQLState;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -1337,7 +1337,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
 
         // YB Note: Separating the ALTER commands as they were causing transaction abortion in YB
         // if run collectively, the error being:
-        // java.lang.RuntimeException: org.postgresql.util.PSQLException: ERROR: Unknown transaction, could be recently aborted: 3273ed66-13c6-4d73-8c6e-014389e5081e
+        // java.lang.RuntimeException: com.yugabyte.util.PSQLException: ERROR: Unknown transaction, could be recently aborted: 3273ed66-13c6-4d73-8c6e-014389e5081e
         TestHelper.execute(SETUP_TABLES_STMT);
         TestHelper.execute("CREATE TABLE s1.b (pk SERIAL, aa integer, bb integer, PRIMARY KEY(pk));");
         TestHelper.execute("ALTER TABLE s1.a ADD COLUMN bb integer;");
@@ -1379,7 +1379,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     public void shouldTakeBlacklistFiltersIntoAccount() throws Exception {
         // YB Note: Separating the ALTER commands as they were causing transaction abortion in YB
         // if run collectively, the error being:
-        // java.lang.RuntimeException: org.postgresql.util.PSQLException: ERROR: Unknown transaction, could be recently aborted: 3273ed66-13c6-4d73-8c6e-014389e5081e
+        // java.lang.RuntimeException: com.yugabyte.util.PSQLException: ERROR: Unknown transaction, could be recently aborted: 3273ed66-13c6-4d73-8c6e-014389e5081e
         String setupStmt = SETUP_TABLES_STMT +
                 "CREATE TABLE s1.b (pk SERIAL, aa integer, bb integer, PRIMARY KEY(pk));";
 
@@ -1431,7 +1431,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
 
         // YB Note: Separating the ALTER commands as they were causing transaction abortion in YB
         // if run collectively, the error being:
-        // java.lang.RuntimeException: org.postgresql.util.PSQLException: ERROR: Unknown transaction, could be recently aborted: 3273ed66-13c6-4d73-8c6e-014389e5081e
+        // java.lang.RuntimeException: com.yugabyte.util.PSQLException: ERROR: Unknown transaction, could be recently aborted: 3273ed66-13c6-4d73-8c6e-014389e5081e
         TestHelper.execute(SETUP_TABLES_STMT);
         TestHelper.execute("ALTER TABLE s1.a ADD COLUMN bb integer;");
         TestHelper.execute("ALTER TABLE s1.a ADD COLUMN cc char(12);");
@@ -2858,6 +2858,34 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
             CloudEventsConverterTest.shouldConvertToCloudEventsInJsonWithDataAsAvro(record, true);
             CloudEventsConverterTest.shouldConvertToCloudEventsInAvro(record, "postgresql", "test_server", true);
         }
+    }
+
+    @Test
+    public void testYBCustomChangesForUpdate() throws Exception {
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.execute(CREATE_TABLES_STMT);
+        TestHelper.createDefaultReplicationSlot();
+
+        final Configuration.Builder configBuilder = TestHelper.defaultConfig()
+              .with(PostgresConnectorConfig.HOSTNAME, "127.0.0.1:5433,127.0.0.2:5433,127.0.0.3:5433")
+              .with(PostgresConnectorConfig.SLOT_NAME, ReplicationConnection.Builder.DEFAULT_SLOT_NAME)
+              .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
+              .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s2.a");
+
+        start(PostgresConnector.class, configBuilder.build());
+        assertConnectorIsRunning();
+        waitForStreamingRunning();
+        TestHelper.waitFor(Duration.ofSeconds(5));
+
+        TestHelper.execute(INSERT_STMT);
+
+        LOGGER.info("Take a node down now");
+        TestHelper.waitFor(Duration.ofMinutes(1));
+
+        LOGGER.info("Inserting and waiting for another 30s");
+        TestHelper.execute("INSERT INTO s1.a (aa) VALUES (11);");
+
+        TestHelper.waitFor(Duration.ofMinutes(2));
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -2860,7 +2860,11 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         }
     }
 
-    // YB Note: Running this test also requires a change of values in the method TestHelper#defaultJdbcConfig
+    // This test is for manual testing and if this is being run then change the method TestHelper#defaultJdbcConfig
+    // to include all three nodes "127.0.0.1:5433,127.0.0.2:5433,127.0.0.3:5433".
+    //
+    // Now while running this test, as soon as you see "Take a node down now" in the logs now,
+    // take down the node at IP 127.0.0.1 in order to simulate a node going down scenario.
     @Test
     public void testYBChangesForMultiHostConfiguration() throws Exception {
         TestHelper.dropDefaultReplicationSlot();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresErrorHandlerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresErrorHandlerTest.java
@@ -8,8 +8,8 @@ package io.debezium.connector.postgresql;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
-import org.postgresql.util.PSQLException;
-import org.postgresql.util.PSQLState;
+import com.yugabyte.util.PSQLException;
+import com.yugabyte.util.PSQLState;
 
 import io.debezium.DebeziumException;
 import io.debezium.config.CommonConnectorConfig;

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -61,7 +61,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
-import org.postgresql.util.PSQLException;
+import com.yugabyte.util.PSQLException;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.CommonConnectorConfig.BinaryHandlingMode;

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
-import org.postgresql.jdbc.PgConnection;
+import com.yugabyte.jdbc.PgConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -217,7 +217,7 @@ public final class TestHelper {
         TestHelper.execute(dropStmts);
 
         try {
-            TestHelper.executeDDL("init_database.ddl");
+//            TestHelper.executeDDL("init_database.ddl");
         }
         catch (Exception e) {
             throw new IllegalStateException("Failed to initialize database", e);
@@ -276,7 +276,7 @@ public final class TestHelper {
     }
 
     public static JdbcConfiguration defaultJdbcConfig() {
-        return defaultJdbcConfig("127.0.0.1", 5433);
+        return defaultJdbcConfig("127.0.0.1:5433,127.0.0.2:5433,127.0.0.3:5433", 5433);
     }
 
     public static Configuration.Builder defaultConfig() {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -217,7 +217,7 @@ public final class TestHelper {
         TestHelper.execute(dropStmts);
 
         try {
-//            TestHelper.executeDDL("init_database.ddl");
+            TestHelper.executeDDL("init_database.ddl");
         }
         catch (Exception e) {
             throw new IllegalStateException("Failed to initialize database", e);
@@ -276,7 +276,7 @@ public final class TestHelper {
     }
 
     public static JdbcConfiguration defaultJdbcConfig() {
-        return defaultJdbcConfig("127.0.0.1:5433,127.0.0.2:5433,127.0.0.3:5433", 5433);
+        return defaultJdbcConfig("127.0.0.1", 5433);
     }
 
     public static Configuration.Builder defaultConfig() {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Future;
 import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.postgresql.jdbc.PgConnection;
+import com.yugabyte.jdbc.PgConnection;
 
 import io.debezium.connector.postgresql.TestHelper;
 import io.debezium.doc.FixFor;

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -824,19 +824,15 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
         return problemCount;
     }
 
-    private static int validateHostname(Configuration config, Field field, ValidationOutput problems) {
-        // YB Note: Bypassing this check.
-        LOGGER.info("YB: Bypassing hostname validation");
+    protected static int validateHostname(Configuration config, Field field, ValidationOutput problems) {
+        String hostName = config.getString(field);
+        if (!Strings.isNullOrBlank(hostName)) {
+            if (!HOSTNAME_PATTERN.asPredicate().test(hostName)) {
+                problems.accept(field, hostName, hostName + " has invalid format (only the underscore, hyphen, dot and alphanumeric characters are allowed)");
+                return 1;
+            }
+        }
         return 0;
-
-        //String hostName = config.getString(field);
-        //if (!Strings.isNullOrBlank(hostName)) {
-        //    if (!HOSTNAME_PATTERN.asPredicate().test(hostName)) {
-        //        problems.accept(field, hostName, hostName + " has invalid format (only the underscore, hyphen, dot and alphanumeric characters are allowed)");
-        //        return 1;
-        //    }
-        //}
-        //return 0;
     }
 
     public FieldNamer<Column> getFieldNamer() {

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -825,14 +825,17 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
     }
 
     private static int validateHostname(Configuration config, Field field, ValidationOutput problems) {
-        String hostName = config.getString(field);
-        if (!Strings.isNullOrBlank(hostName)) {
-            if (!HOSTNAME_PATTERN.asPredicate().test(hostName)) {
-                problems.accept(field, hostName, hostName + " has invalid format (only the underscore, hyphen, dot and alphanumeric characters are allowed)");
-                return 1;
-            }
-        }
+        // YB Note: Bypassing this check.
         return 0;
+
+        //String hostName = config.getString(field);
+        //if (!Strings.isNullOrBlank(hostName)) {
+        //    if (!HOSTNAME_PATTERN.asPredicate().test(hostName)) {
+        //        problems.accept(field, hostName, hostName + " has invalid format (only the underscore, hyphen, dot and alphanumeric characters are allowed)");
+        //        return 1;
+        //    }
+        //}
+        //return 0;
     }
 
     public FieldNamer<Column> getFieldNamer() {

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -826,6 +826,7 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
 
     private static int validateHostname(Configuration config, Field field, ValidationOutput problems) {
         // YB Note: Bypassing this check.
+        LOGGER.info("YB: Bypassing hostname validation");
         return 0;
 
         //String hostName = config.getString(field);

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -825,14 +825,17 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
     }
 
     protected static int validateHostname(Configuration config, Field field, ValidationOutput problems) {
-        String hostName = config.getString(field);
-        if (!Strings.isNullOrBlank(hostName)) {
-            if (!HOSTNAME_PATTERN.asPredicate().test(hostName)) {
-                problems.accept(field, hostName, hostName + " has invalid format (only the underscore, hyphen, dot and alphanumeric characters are allowed)");
-                return 1;
-            }
-        }
+        LOGGER.info("Bypassing hostname validation for YB");
         return 0;
+
+        // String hostName = config.getString(field);
+        // if (!Strings.isNullOrBlank(hostName)) {
+        //     if (!HOSTNAME_PATTERN.asPredicate().test(hostName)) {
+        //         problems.accept(field, hostName, hostName + " has invalid format (only the underscore, hyphen, dot and alphanumeric characters are allowed)");
+        //         return 1;
+        //     }
+        // }
+        // return 0;
     }
 
     public FieldNamer<Column> getFieldNamer() {

--- a/debezium-ddl-parser/pom.xml
+++ b/debezium-ddl-parser/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-ddl-parser/pom.xml
+++ b/debezium-ddl-parser/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-ddl-parser/pom.xml
+++ b/debezium-ddl-parser/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-embedded/pom.xml
+++ b/debezium-embedded/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-embedded/pom.xml
+++ b/debezium-embedded/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-embedded/pom.xml
+++ b/debezium-embedded/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-interceptor/pom.xml
+++ b/debezium-interceptor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-interceptor/pom.xml
+++ b/debezium-interceptor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-interceptor/pom.xml
+++ b/debezium-interceptor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-microbenchmark-oracle/pom.xml
+++ b/debezium-microbenchmark-oracle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-microbenchmark-oracle/pom.xml
+++ b/debezium-microbenchmark-oracle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-microbenchmark-oracle/pom.xml
+++ b/debezium-microbenchmark-oracle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-microbenchmark/pom.xml
+++ b/debezium-microbenchmark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-microbenchmark/pom.xml
+++ b/debezium-microbenchmark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-microbenchmark/pom.xml
+++ b/debezium-microbenchmark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-parent/pom.xml
+++ b/debezium-parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-build-parent</artifactId>
-    <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+    <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/debezium-parent/pom.xml
+++ b/debezium-parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-build-parent</artifactId>
-    <version>2.5.2.Final-SNAPSHOT</version>
+    <version>2.5.2.ybpg.20241-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/debezium-parent/pom.xml
+++ b/debezium-parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-build-parent</artifactId>
-    <version>2.5.2.Final</version>
+    <version>2.5.2.Final-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/debezium-quarkus-outbox-common/deployment/pom.xml
+++ b/debezium-quarkus-outbox-common/deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-common-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-common/deployment/pom.xml
+++ b/debezium-quarkus-outbox-common/deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-common-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-common/deployment/pom.xml
+++ b/debezium-quarkus-outbox-common/deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-common-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-common/pom.xml
+++ b/debezium-quarkus-outbox-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-common/pom.xml
+++ b/debezium-quarkus-outbox-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-common/pom.xml
+++ b/debezium-quarkus-outbox-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-common/runtime/pom.xml
+++ b/debezium-quarkus-outbox-common/runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-common-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-common/runtime/pom.xml
+++ b/debezium-quarkus-outbox-common/runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-common-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-common/runtime/pom.xml
+++ b/debezium-quarkus-outbox-common/runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-common-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-reactive/deployment/pom.xml
+++ b/debezium-quarkus-outbox-reactive/deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-reactive-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-reactive/deployment/pom.xml
+++ b/debezium-quarkus-outbox-reactive/deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-reactive-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-reactive/deployment/pom.xml
+++ b/debezium-quarkus-outbox-reactive/deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-reactive-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-reactive/integration-tests/pom.xml
+++ b/debezium-quarkus-outbox-reactive/integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-reactive-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-reactive/integration-tests/pom.xml
+++ b/debezium-quarkus-outbox-reactive/integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-reactive-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-reactive/integration-tests/pom.xml
+++ b/debezium-quarkus-outbox-reactive/integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-reactive-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-reactive/pom.xml
+++ b/debezium-quarkus-outbox-reactive/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-reactive/pom.xml
+++ b/debezium-quarkus-outbox-reactive/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-reactive/pom.xml
+++ b/debezium-quarkus-outbox-reactive/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-reactive/runtime/pom.xml
+++ b/debezium-quarkus-outbox-reactive/runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-reactive-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-reactive/runtime/pom.xml
+++ b/debezium-quarkus-outbox-reactive/runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-reactive-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-reactive/runtime/pom.xml
+++ b/debezium-quarkus-outbox-reactive/runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-reactive-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/deployment/pom.xml
+++ b/debezium-quarkus-outbox/deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/deployment/pom.xml
+++ b/debezium-quarkus-outbox/deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/deployment/pom.xml
+++ b/debezium-quarkus-outbox/deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/integration-tests/pom.xml
+++ b/debezium-quarkus-outbox/integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/integration-tests/pom.xml
+++ b/debezium-quarkus-outbox/integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/integration-tests/pom.xml
+++ b/debezium-quarkus-outbox/integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/pom.xml
+++ b/debezium-quarkus-outbox/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/pom.xml
+++ b/debezium-quarkus-outbox/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/pom.xml
+++ b/debezium-quarkus-outbox/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/runtime/pom.xml
+++ b/debezium-quarkus-outbox/runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/runtime/pom.xml
+++ b/debezium-quarkus-outbox/runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/runtime/pom.xml
+++ b/debezium-quarkus-outbox/runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-schema-generator/pom.xml
+++ b/debezium-schema-generator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-parent</artifactId>
-    <version>2.5.2.Final-SNAPSHOT</version>
+    <version>2.5.2.ybpg.20241-SNAPSHOT</version>
     <relativePath>../debezium-parent/pom.xml</relativePath>
   </parent>
 

--- a/debezium-schema-generator/pom.xml
+++ b/debezium-schema-generator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-parent</artifactId>
-    <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+    <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
     <relativePath>../debezium-parent/pom.xml</relativePath>
   </parent>
 

--- a/debezium-schema-generator/pom.xml
+++ b/debezium-schema-generator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-parent</artifactId>
-    <version>2.5.2.Final</version>
+    <version>2.5.2.Final-SNAPSHOT</version>
     <relativePath>../debezium-parent/pom.xml</relativePath>
   </parent>
 

--- a/debezium-scripting/debezium-scripting-languages/pom.xml
+++ b/debezium-scripting/debezium-scripting-languages/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-scripting-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-scripting/debezium-scripting-languages/pom.xml
+++ b/debezium-scripting/debezium-scripting-languages/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-scripting-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-scripting/debezium-scripting-languages/pom.xml
+++ b/debezium-scripting/debezium-scripting-languages/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-scripting-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-scripting/debezium-scripting/pom.xml
+++ b/debezium-scripting/debezium-scripting/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-scripting-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-scripting/debezium-scripting/pom.xml
+++ b/debezium-scripting/debezium-scripting/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-scripting-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-scripting/debezium-scripting/pom.xml
+++ b/debezium-scripting/debezium-scripting/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-scripting-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-scripting/pom.xml
+++ b/debezium-scripting/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-scripting/pom.xml
+++ b/debezium-scripting/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-scripting/pom.xml
+++ b/debezium-scripting/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-azure-blob/pom.xml
+++ b/debezium-storage/debezium-storage-azure-blob/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-azure-blob/pom.xml
+++ b/debezium-storage/debezium-storage-azure-blob/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-azure-blob/pom.xml
+++ b/debezium-storage/debezium-storage-azure-blob/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-file/pom.xml
+++ b/debezium-storage/debezium-storage-file/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-file/pom.xml
+++ b/debezium-storage/debezium-storage-file/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-file/pom.xml
+++ b/debezium-storage/debezium-storage-file/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-jdbc/pom.xml
+++ b/debezium-storage/debezium-storage-jdbc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-jdbc/pom.xml
+++ b/debezium-storage/debezium-storage-jdbc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-jdbc/pom.xml
+++ b/debezium-storage/debezium-storage-jdbc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-kafka/pom.xml
+++ b/debezium-storage/debezium-storage-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-kafka/pom.xml
+++ b/debezium-storage/debezium-storage-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-kafka/pom.xml
+++ b/debezium-storage/debezium-storage-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-redis/pom.xml
+++ b/debezium-storage/debezium-storage-redis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-redis/pom.xml
+++ b/debezium-storage/debezium-storage-redis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-redis/pom.xml
+++ b/debezium-storage/debezium-storage-redis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-rocketmq/pom.xml
+++ b/debezium-storage/debezium-storage-rocketmq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-storage/debezium-storage-rocketmq/pom.xml
+++ b/debezium-storage/debezium-storage-rocketmq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-storage/debezium-storage-rocketmq/pom.xml
+++ b/debezium-storage/debezium-storage-rocketmq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-storage/debezium-storage-s3/pom.xml
+++ b/debezium-storage/debezium-storage-s3/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-s3/pom.xml
+++ b/debezium-storage/debezium-storage-s3/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-s3/pom.xml
+++ b/debezium-storage/debezium-storage-s3/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-tests/pom.xml
+++ b/debezium-storage/debezium-storage-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-tests/pom.xml
+++ b/debezium-storage/debezium-storage-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-tests/pom.xml
+++ b/debezium-storage/debezium-storage-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/pom.xml
+++ b/debezium-storage/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/pom.xml
+++ b/debezium-storage/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/pom.xml
+++ b/debezium-storage/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-testing/debezium-testing-system/pom.xml
+++ b/debezium-testing/debezium-testing-system/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-testing</artifactId>
-    <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+    <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -126,7 +126,7 @@
     <database.oracle.pdbname>ORCLPDB1</database.oracle.pdbname>
 
     <!--Debezium connector versions-->
-    <version.debezium.connector>2.5.2.ybpg.20241-SNAPSHOT</version.debezium.connector>
+    <version.debezium.connector>2.5.2.ybpg.20241-SNAPSHOT.1</version.debezium.connector>
 
     <!-- Artifact repository for KC build -->
     <as.url>http://debezium-artifact-server.${ocp.project.debezium}.svc.cluster.local:8080</as.url>

--- a/debezium-testing/debezium-testing-system/pom.xml
+++ b/debezium-testing/debezium-testing-system/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-testing</artifactId>
-    <version>2.5.2.Final-SNAPSHOT</version>
+    <version>2.5.2.ybpg.20241-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -126,7 +126,7 @@
     <database.oracle.pdbname>ORCLPDB1</database.oracle.pdbname>
 
     <!--Debezium connector versions-->
-    <version.debezium.connector>2.5.2.Final-SNAPSHOT</version.debezium.connector>
+    <version.debezium.connector>2.5.2.ybpg.20241-SNAPSHOT</version.debezium.connector>
 
     <!-- Artifact repository for KC build -->
     <as.url>http://debezium-artifact-server.${ocp.project.debezium}.svc.cluster.local:8080</as.url>

--- a/debezium-testing/debezium-testing-system/pom.xml
+++ b/debezium-testing/debezium-testing-system/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-testing</artifactId>
-    <version>2.5.2.Final</version>
+    <version>2.5.2.Final-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -126,7 +126,7 @@
     <database.oracle.pdbname>ORCLPDB1</database.oracle.pdbname>
 
     <!--Debezium connector versions-->
-    <version.debezium.connector>2.5.2.Final</version.debezium.connector>
+    <version.debezium.connector>2.5.2.Final-SNAPSHOT</version.debezium.connector>
 
     <!-- Artifact repository for KC build -->
     <as.url>http://debezium-artifact-server.${ocp.project.debezium}.svc.cluster.local:8080</as.url>

--- a/debezium-testing/debezium-testing-testcontainers/pom.xml
+++ b/debezium-testing/debezium-testing-testcontainers/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-testing</artifactId>
-    <version>2.5.2.Final-SNAPSHOT</version>
+    <version>2.5.2.ybpg.20241-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/debezium-testing/debezium-testing-testcontainers/pom.xml
+++ b/debezium-testing/debezium-testing-testcontainers/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-testing</artifactId>
-    <version>2.5.2.Final</version>
+    <version>2.5.2.Final-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/debezium-testing/debezium-testing-testcontainers/pom.xml
+++ b/debezium-testing/debezium-testing-testcontainers/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-testing</artifactId>
-    <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+    <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/debezium-testing/pom.xml
+++ b/debezium-testing/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-parent</artifactId>
-    <version>2.5.2.Final</version>
+    <version>2.5.2.Final-SNAPSHOT</version>
     <relativePath>../debezium-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/debezium-testing/pom.xml
+++ b/debezium-testing/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-parent</artifactId>
-    <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+    <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
     <relativePath>../debezium-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/debezium-testing/pom.xml
+++ b/debezium-testing/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-parent</artifactId>
-    <version>2.5.2.Final-SNAPSHOT</version>
+    <version>2.5.2.ybpg.20241-SNAPSHOT</version>
     <relativePath>../debezium-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -8,7 +8,7 @@ nav:
 
 asciidoc:
   attributes:
-    debezium-version: '2.5.2.Final'
+    debezium-version: '2.5.2.Final-SNAPSHOT'
     debezium-kafka-version: '3.6.1'
     debezium-docker-label: '2.4'
     DockerKafkaConnect: registry.redhat.io/amq7/amq-streams-kafka-28-rhel8:1.8.0

--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -8,7 +8,7 @@ nav:
 
 asciidoc:
   attributes:
-    debezium-version: '2.5.2.ybpg.20241-SNAPSHOT'
+    debezium-version: '2.5.2.ybpg.20241-SNAPSHOT.1'
     debezium-kafka-version: '3.6.1'
     debezium-docker-label: '2.4'
     DockerKafkaConnect: registry.redhat.io/amq7/amq-streams-kafka-28-rhel8:1.8.0

--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -8,7 +8,7 @@ nav:
 
 asciidoc:
   attributes:
-    debezium-version: '2.5.2.Final-SNAPSHOT'
+    debezium-version: '2.5.2.ybpg.20241-SNAPSHOT'
     debezium-kafka-version: '3.6.1'
     debezium-docker-label: '2.4'
     DockerKafkaConnect: registry.redhat.io/amq7/amq-streams-kafka-28-rhel8:1.8.0

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.debezium</groupId>
     <artifactId>debezium-build-parent</artifactId>
-    <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+    <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
     <name>Debezium Build Aggregator</name>
     <description>Debezium is an open source change data capture platform</description>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.debezium</groupId>
     <artifactId>debezium-build-parent</artifactId>
-    <version>2.5.2.Final</version>
+    <version>2.5.2.ybpg.20241-SNAPSHOT</version>
     <name>Debezium Build Aggregator</name>
     <description>Debezium is an open source change data capture platform</description>
     <packaging>pom</packaging>

--- a/support/checkstyle/pom.xml
+++ b/support/checkstyle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/support/checkstyle/pom.xml
+++ b/support/checkstyle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/support/checkstyle/pom.xml
+++ b/support/checkstyle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/support/ide-configs/pom.xml
+++ b/support/ide-configs/pom.xml
@@ -3,7 +3,7 @@
    <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/support/ide-configs/pom.xml
+++ b/support/ide-configs/pom.xml
@@ -3,7 +3,7 @@
    <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/support/ide-configs/pom.xml
+++ b/support/ide-configs/pom.xml
@@ -3,7 +3,7 @@
    <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/support/revapi/pom.xml
+++ b/support/revapi/pom.xml
@@ -3,7 +3,7 @@
    <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.5.2.Final-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/support/revapi/pom.xml
+++ b/support/revapi/pom.xml
@@ -3,7 +3,7 @@
    <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.5.2.Final</version>
+        <version>2.5.2.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/support/revapi/pom.xml
+++ b/support/revapi/pom.xml
@@ -3,7 +3,7 @@
    <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>2.5.2.ybpg.20241-SNAPSHOT</version>
+        <version>2.5.2.ybpg.20241-SNAPSHOT.1</version>
         <relativePath>../../pom.xml</relativePath>
    </parent>
 


### PR DESCRIPTION
## Problem

The Debezium connector for Postgres uses a single host model where the JDBC driver connects to a PG instance and continues execution. However, when we move to YugabyteDB where we have a multi node deployment, the current model can fail in case the node it has connected to goes down.

## Solution

To address that, we have made changes in this PR and replaced the Postgres JDBC driver with [YugabyteDB smart driver](https://github.com/yugabyte/pgjdbc) which allows us to specify multiple hosts in the JDBC url so that the connector does not fail or run into any fatal error while maintaining the High Availability aspect of YugabyteDB.

Changes in this PR include:
1. Changing of version in `pom.xml` from `2.5.2.Final` to `2.5.2.ybpg.20241-SNAPSHOT`
    a. This is done to ensure that upon image compilation, the changed code from Debezium Code is picked up.
2. Replacing of all packages from `org.postgresql.*` to `com.yugabyte.*` to comply with the new JDBC driver.
3. Masking the validator method in debezium-core which disallowed characters like `: (colon)` in the configuration property `database.hostname`