### PR TITLE
[DBZ-PGYB] Modified Dockerfile to package custom log4j.properties

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY debezium-connector-postgres/target/debezium-connector-postgres-*.jar $KAFKA
 ENV KAFKA_OPTS="-Djdk.tls.client.protocols=TLSv1.2"
 
 # Add the required jar files to be packaged with the base connector
-RUN cd $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres && curl -sLo kafka-connect-jdbc-10.6.5.jar https://github.com/yugabyte/kafka-connect-jdbc/releases/download/10.6.5-CUSTOM/kafka-connect-jdbc-10.6.5.jar
+RUN cd $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres && curl -sLo kafka-connect-jdbc-10.6.5.jar https://github.com/yugabyte/kafka-connect-jdbc/releases/download/10.6.5-CUSTOM.1/kafka-connect-jdbc-10.6.5-CUSTOM.1.jar
 RUN cd $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres && curl -sLo jdbc-yugabytedb-42.3.5-yb-1.jar https://repo1.maven.org/maven2/com/yugabyte/jdbc-yugabytedb/42.3.5-yb-1/jdbc-yugabytedb-42.3.5-yb-1.jar
 
 # Add Jmx agent and metrics pattern file to expose the metrics info

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,3 +24,6 @@ ADD metrics.yml /etc/jmx-exporter/
 
 ENV CLASSPATH=$KAFKA_HOME
 
+# properties file having instructions to roll over log files in case the size exceeds a given limit
+COPY log4j.properties $KAFKA_HOME/config/log4j.properties
+

--- a/log4j.properties
+++ b/log4j.properties
@@ -17,7 +17,6 @@ log4j.appender.appender.policy.size=100MB
 log4j.appender.appender.strategy.type=DefaultRolloverStrategy
 log4j.appender.appender.File=${kafka.logs.dir}/connect-service.log
 log4j.appender.appender.ImmediateFlush=true
-log4j.appender.appender.MaxFileSize=100MB
 log4j.appender.appender.MaxBackupIndex=10000
 log4j.appender.appender.layout=org.apache.log4j.PatternLayout
 log4j.appender.appender.filePattern=${kafka.logs.dir}/connect-service-%d{yyyy-MM-dd}-%i.log

--- a/log4j.properties
+++ b/log4j.properties
@@ -1,0 +1,24 @@
+kafka.logs.dir=logs
+
+log4j.rootLogger=INFO, stdout, appender
+
+# Disable excessive reflection warnings - KAFKA-5229
+log4j.logger.org.reflections=ERROR
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.threshold=INFO
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p  %X{dbz.connectorType}|%X{dbz.connectorName}|%X{dbz.connectorContext}  %m   [%c]%n
+
+
+log4j.appender.appender=org.apache.log4j.RollingFileAppender
+log4j.appender.appender.policy.type=SizeBasedTriggeringPolicy
+log4j.appender.appender.policy.size=100MB
+log4j.appender.appender.strategy.type=DefaultRolloverStrategy
+log4j.appender.appender.File=${kafka.logs.dir}/connect-service.log
+log4j.appender.appender.ImmediateFlush=true
+log4j.appender.appender.MaxFileSize=100MB
+log4j.appender.appender.MaxBackupIndex=10000
+log4j.appender.appender.layout=org.apache.log4j.PatternLayout
+log4j.appender.appender.filePattern=${kafka.logs.dir}/connect-service-%d{yyyy-MM-dd}-%i.log
+log4j.appender.appender.layout.ConversionPattern=%d{ISO8601} %-5p  %X{dbz.connectorType}|%X{dbz.connectorName}|%X{dbz.connectorContext}  %m   [%c]%n

--- a/log4j.properties
+++ b/log4j.properties
@@ -17,7 +17,9 @@ log4j.appender.appender.policy.size=100MB
 log4j.appender.appender.strategy.type=DefaultRolloverStrategy
 log4j.appender.appender.File=${kafka.logs.dir}/connect-service.log
 log4j.appender.appender.ImmediateFlush=true
+log4j.appender.appender.MaxFileSize=100KB
 log4j.appender.appender.MaxBackupIndex=10000
 log4j.appender.appender.layout=org.apache.log4j.PatternLayout
 log4j.appender.appender.filePattern=${kafka.logs.dir}/connect-service-%d{yyyy-MM-dd}-%i.log
-log4j.appender.appender.layout.ConversionPattern=%d{ISO8601} %-5p  %X{dbz.connectorType}|%X{dbz.connectorName}|%X{dbz.connectorContext}  %m   [%c]%n
+# TODO: find out how to generate files in a specific pattern
+#log4j.appender.appender.layout.ConversionPattern=%d{ISO8601} %-5p  %X{dbz.connectorType}|%X{dbz.connectorName}|%X{dbz.connectorContext}  %m   [%c]%n

--- a/log4j.properties
+++ b/log4j.properties
@@ -20,6 +20,6 @@ log4j.appender.appender.ImmediateFlush=true
 log4j.appender.appender.MaxFileSize=100KB
 log4j.appender.appender.MaxBackupIndex=10000
 log4j.appender.appender.layout=org.apache.log4j.PatternLayout
-log4j.appender.appender.filePattern=${kafka.logs.dir}/connect-service-%d{yyyy-MM-dd}-%i.log
 # TODO: find out how to generate files in a specific pattern
-#log4j.appender.appender.layout.ConversionPattern=%d{ISO8601} %-5p  %X{dbz.connectorType}|%X{dbz.connectorName}|%X{dbz.connectorContext}  %m   [%c]%n
+# log4j.appender.appender.filePattern=${kafka.logs.dir}/connect-service-%d{yyyy-MM-dd}-%i.log
+log4j.appender.appender.layout.ConversionPattern=%d{ISO8601} %-5p  %X{dbz.connectorType}|%X{dbz.connectorName}|%X{dbz.connectorContext}  %m   [%c]%n


### PR DESCRIPTION
Modified Dockerfile to package custom log4j.properties so that the log files can be rolled over when their size exceeds 100MB.

Also changed the Kafka connect JDBC jar being used - this new jar has a custom change to log every sink record going to the target database.