### PR TITLE
[DBZ-PGYB] Higher level retry for failures while starting PostgresConnectorTask

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -100,7 +100,6 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
             jdbcConnection.setAutoCommit(false);
         }
         catch (SQLException e) {
-            // todo Vaibhav: if it fails, it will fail here.
             throw new DebeziumException(e);
         }
 
@@ -131,18 +130,14 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
             // Print out the server information
             SlotState slotInfo = null;
             try {
-                // todo vaibhav: how does it fail here, what happens
-                // todo: put a debugger and whatever tserver it is connected to
                 if (LOGGER.isInfoEnabled()) {
                     LOGGER.info(jdbcConnection.serverInfo().toString());
                 }
                 slotInfo = jdbcConnection.getReplicationSlotState(connectorConfig.slotName(), connectorConfig.plugin().getPostgresPluginName());
             }
             catch (SQLException e) {
-                // todo vaibhav: what is the exception we are getting, log it
                 LOGGER.warn("unable to load info of replication slot, Debezium will try to create the slot", e);
                 throw e;
-                // todo vaibhav: what happens when a slot actually doesn't exist.
             }
 
             if (previousOffset == null) {
@@ -264,8 +259,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
             coordinator.start(taskContext, this.queue, metadataProvider);
 
             return coordinator;
-        } // todo vaibhav: wrap everything thrown in a retriable exception and then throw it out
-        catch (Exception exception) {
+        } catch (Exception exception) {
             // YB Note: Catch all the exceptions and retry.
             throw new RetriableException(exception);
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -100,6 +100,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
             jdbcConnection.setAutoCommit(false);
         }
         catch (SQLException e) {
+            // todo Vaibhav: if it fails, it will fail here.
             throw new DebeziumException(e);
         }
 
@@ -130,13 +131,18 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
             // Print out the server information
             SlotState slotInfo = null;
             try {
+                // todo vaibhav: how does it fail here, what happens
+                // todo: put a debugger and whatever tserver it is connected to
                 if (LOGGER.isInfoEnabled()) {
                     LOGGER.info(jdbcConnection.serverInfo().toString());
                 }
                 slotInfo = jdbcConnection.getReplicationSlotState(connectorConfig.slotName(), connectorConfig.plugin().getPostgresPluginName());
             }
             catch (SQLException e) {
-                LOGGER.warn("unable to load info of replication slot, Debezium will try to create the slot");
+                // todo vaibhav: what is the exception we are getting, log it
+                LOGGER.warn("unable to load info of replication slot, Debezium will try to create the slot", e);
+                throw e;
+                // todo vaibhav: what happens when a slot actually doesn't exist.
             }
 
             if (previousOffset == null) {
@@ -258,6 +264,10 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
             coordinator.start(taskContext, this.queue, metadataProvider);
 
             return coordinator;
+        } // todo vaibhav: wrap everything thrown in a retriable exception and then throw it out
+        catch (Exception exception) {
+            // YB Note: Catch all the exceptions and retry.
+            throw new RetriableException(exception);
         }
         finally {
             previousContext.restore();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresErrorHandler.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresErrorHandler.java
@@ -34,4 +34,10 @@ public class PostgresErrorHandler extends ErrorHandler {
     protected boolean isRetriable(Throwable throwable) {
         return super.isRetriable(throwable);
     }
+
+    @Override
+    protected boolean isCustomRetriable(Throwable throwable) {
+        // YB Note: Yes, all the errors are custom retriable.
+        return true;
+    }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ServerInfo.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ServerInfo.java
@@ -145,6 +145,10 @@ public class ServerInfo {
             return catalogXmin;
         }
 
+        protected boolean isInvalid() {
+            return this == INVALID;
+        }
+
         protected boolean hasValidFlushedLsn() {
             return latestFlushedLsn != null;
         }


### PR DESCRIPTION
This PR is to add a higher level retry whenever there's a where while starting a PostgresConnectorTask, the failures can include but not limited to the following:
1. Failure of creating JDBC connection
2. Failure to execute query
3. Tserver/master restart
4. Node restart
5. Connection failure