### PR TITLE
[DBZ-PGYB] Consistent snapshot on YugabyteDB by a connector user who is not a superuser

### DIFF
--- a/debezium-connector-postgres/src/test/resources/replication_role_user.ddl
+++ b/debezium-connector-postgres/src/test/resources/replication_role_user.ddl
@@ -1,0 +1,21 @@
+REVOKE CREATE ON DATABASE yugabyte FROM ybpgconn;
+DROP ROLE IF EXISTS ybpgconn;
+
+CREATE ROLE ybpgconn WITH LOGIN REPLICATION;
+CREATE SCHEMA ybpgconn AUTHORIZATION ybpgconn;
+
+GRANT CREATE ON DATABASE yugabyte TO ybpgconn;
+
+BEGIN;
+    CREATE OR REPLACE PROCEDURE ybpgconn.set_yb_read_time(value TEXT)
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      EXECUTE 'SET LOCAL yb_read_time = ' || quote_literal(value);
+    END;
+    $$
+    SECURITY DEFINER;
+
+    REVOKE EXECUTE ON PROCEDURE ybpgconn.set_yb_read_time FROM PUBLIC;
+    GRANT EXECUTE ON PROCEDURE ybpgconn.set_yb_read_time TO ybpgconn;
+COMMIT;


### PR DESCRIPTION
**Summary**
This PR adds the support for a non superuser to be configured as the connector user (database.user).

Such a user is required to have the privileges listed in https://debezium.io/documentation/reference/2.5/connectors/postgresql.html#postgresql-permissions

Specifically, the changes in this revision relate to how the consistent_point is specified to the YugabyteDB server in order
to execute a consistent snapshot.

**Test Plan**
Added new test
mvn -Dtest=PostgresConnectorIT#nonSuperUserSnapshotAndStreaming test