### PR TITLE
[DBZ-PGYB][#21425] Support for INITIAL_ONLY snapshot mode for Yugabyte

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -151,7 +151,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
             }
 
             SlotCreationResult slotCreatedInfo = null;
-            if (snapshotter.shouldStream() || YugabyteDBServer.isEnabled()) {
+            if (snapshotter.shouldStream() || (YugabyteDBServer.isEnabled() && (slotInfo == null))) {
                 replicationConnection = createReplicationConnection(this.taskContext,
                         connectorConfig.maxRetries(), connectorConfig.retryDelay());
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -151,7 +151,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
             }
 
             SlotCreationResult slotCreatedInfo = null;
-            if (snapshotter.shouldStream()) {
+            if (snapshotter.shouldStream() || YugabyteDBServer.isEnabled()) {
                 replicationConnection = createReplicationConnection(this.taskContext,
                         connectorConfig.maxRetries(), connectorConfig.retryDelay());
 


### PR DESCRIPTION
**Summary**
This PR adds support for the INITIAL_ONLY snapshot mode for Yugabyte.

In the case of Yugabyte also, the snapshot is consumed by executing a snapshot query (SELECT statement) . To ensure that the streaming phase continues exactly from where the snapshot left, this snapshot query is executed as of a specific database state. In YB, this database state is represented by a value of HybridTime. Changes due to transactions with commit_time strictly greater than this snapshot HybridTime will be consumed during the streaming phase.

This value for HybridTime is the value of the "yb_restart_commit_ht" column of the pg_replication_slots view of the associated slot. Thus, in the case of Yugabyte, even for the INITIAL_ONLY snapshot mode, a slot needs to be created if one does not exist.

With this approach, a connector can be deployed in INITIAL_ONLY mode to consume the initial snapshot. This can be followed by the deployment of another connector in NEVER mode. This connector will continue the streaming from exactly where the snapshot left.

**Test Plan**
1. Added new test -` mvn -Dtest=PostgresConnectorIT#snapshotInitialOnlyFollowedByNever test `
2. Enabled existing test - `mvn -Dtest=PostgresConnectorIT#shouldNotProduceEventsWithInitialOnlySnapshot test` 
3. Enabled existing test - `mvn -Dtest=PostgresConnectorIT#shouldPerformSnapshotOnceForInitialOnlySnapshotMode test `