### PR TITLE
Disable records filtering when 'provide.transaction.metadata' config is set

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -177,7 +177,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
 
             this.lastCompletelyProcessedLsn = replicationStream.get().startLsn();
 
-            // Against YB, filtering of records based on Wal position is only enabled when PG connector is not configured to send transactional metadata in a separate topic.
+            // Against YB, filtering of records based on Wal position is only enabled when connector config provide.transaction.metadata is set to false.
             if(!YugabyteDBServer.isEnabled() || (YugabyteDBServer.isEnabled() && !connectorConfig.shouldProvideTransactionMetadata())) {
                 if (walPosition.searchingEnabled()) {
                     searchWalPosition(context, partition, this.effectiveOffset, stream, walPosition);
@@ -203,7 +203,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                     stream.startKeepAlive(Threads.newSingleThreadExecutor(PostgresConnector.class, connectorConfig.getLogicalName(), KEEP_ALIVE_THREAD_NAME));
                 }
             } else {
-                LOGGER.info("Skip records filtering since PG connector is configured to send transactional metadata in a separate topic.");
+                LOGGER.info("Connector config provide.transaction.metadata is set to true. Therefore, skip records filtering so as to ship entire transactions.");
             }
 
             processMessages(context, partition, this.effectiveOffset, stream);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -177,29 +177,33 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
 
             this.lastCompletelyProcessedLsn = replicationStream.get().startLsn();
 
-            if (walPosition.searchingEnabled()) {
-                searchWalPosition(context, partition, this.effectiveOffset, stream, walPosition);
-                try {
-                    if (!isInPreSnapshotCatchUpStreaming(this.effectiveOffset)) {
-                        connection.commit();
+            // Against YB, filtering of records based on Wal position is only enabled when PG connector is not configured to send transactional metadata in a separate topic.
+            if(!YugabyteDBServer.isEnabled() || (YugabyteDBServer.isEnabled() && !connectorConfig.shouldProvideTransactionMetadata())) {
+                if (walPosition.searchingEnabled()) {
+                    searchWalPosition(context, partition, this.effectiveOffset, stream, walPosition);
+                    try {
+                        if (!isInPreSnapshotCatchUpStreaming(this.effectiveOffset)) {
+                            connection.commit();
+                        }
+                    } catch (Exception e) {
+                        LOGGER.info("Commit failed while preparing for reconnect", e);
                     }
-                }
-                catch (Exception e) {
-                    LOGGER.info("Commit failed while preparing for reconnect", e);
-                }
-                walPosition.enableFiltering();
-                stream.stopKeepAlive();
-                replicationConnection.reconnect();
+                    walPosition.enableFiltering();
+                    stream.stopKeepAlive();
+                    replicationConnection.reconnect();
 
-                if (YugabyteDBServer.isEnabled()) {
-                    LOGGER.info("PID for replication connection: {} on node {}",
+                    if (YugabyteDBServer.isEnabled()) {
+                        LOGGER.info("PID for replication connection: {} on node {}",
                                 replicationConnection.getBackendPid(),
                                 replicationConnection.getConnectedNodeIp());
-                }
+                    }
 
-                replicationStream.set(replicationConnection.startStreaming(walPosition.getLastEventStoredLsn(), walPosition));
-                stream = this.replicationStream.get();
-                stream.startKeepAlive(Threads.newSingleThreadExecutor(PostgresConnector.class, connectorConfig.getLogicalName(), KEEP_ALIVE_THREAD_NAME));
+                    replicationStream.set(replicationConnection.startStreaming(walPosition.getLastEventStoredLsn(), walPosition));
+                    stream = this.replicationStream.get();
+                    stream.startKeepAlive(Threads.newSingleThreadExecutor(PostgresConnector.class, connectorConfig.getLogicalName(), KEEP_ALIVE_THREAD_NAME));
+                }
+            } else {
+                LOGGER.info("Skip records filtering since PG connector is configured to send transactional metadata in a separate topic.");
             }
 
             processMessages(context, partition, this.effectiveOffset, stream);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -203,7 +203,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                     stream.startKeepAlive(Threads.newSingleThreadExecutor(PostgresConnector.class, connectorConfig.getLogicalName(), KEEP_ALIVE_THREAD_NAME));
                 }
             } else {
-                LOGGER.info("Connector config provide.transaction.metadata is set to true. Therefore, skip records filtering so as to ship entire transactions.");
+                LOGGER.info("Connector config provide.transaction.metadata is set to true. Therefore, skip records filtering in order to ship entire transactions.");
             }
 
             processMessages(context, partition, this.effectiveOffset, stream);


### PR DESCRIPTION
## Problem
PG connector filters out record based on its starting point (WAL position), which in turn depends on the offset received from Kafka. So, in case, the starting point corresponds to a record in the middle of a transaction, PG connector will filter out the records of that transaction with LSN < starting point. 

This creates a problem in the downstream pipeline expects consistency of data. Filtering of records leads to PG connector shipping transaction with missing records. When such a transaction is applied on the sink, consistency breaks.

## Solution
When 'provide.transaction.metadata' connector configuration is set, PG connector ships transaction boundary records BEGIN/COMMIT. Based on these boundary records, sink connector writes data maintaining consistency. Therefore, when this connector config is set, we will disable filtering records based on WAL Resume position.

## Testing
Manually testing - Ran the connector with this fix in our QA runs where the issue was first discovered. All 10 runs triggered passed.
Unit testing - Cannot reproduce the above mentioned scenario in a unit test. 