### PR TITLE
Fix log statement wihile skipping empty transactions

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -299,7 +299,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
             if (lastTxnidForWhichCommitSeen.isPresent() && currentTxnid.isPresent()) {
                 long delta = currentTxnid.getAsLong() - lastTxnidForWhichCommitSeen.getAsLong() - 1;
                 if (delta > 0) {
-                    LOGGER.debug("Skipped {} transactions between {} and {}", delta, lastTxnidForWhichCommitSeen, currentTxnid);
+                    LOGGER.debug("Skipped {} empty transactions between {} and {}", delta, lastTxnidForWhichCommitSeen, currentTxnid);
                 }
             }
             lastTxnidForWhichCommitSeen = currentTxnid;


### PR DESCRIPTION
Based on our testing so far, whenever the PG connector has skipped txns, those txns have always been empty txns. 