### PR TITLE
[DBZ-PGYB][yugabyte/yugabyte-db#23081] Renamed connector to new naming convention

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -54,7 +54,7 @@ import io.debezium.relational.Tables.TableFilter;
 import io.debezium.util.Strings;
 
 /**
- * The configuration properties for the {@link PostgresConnector}
+ * The configuration properties for the {@link YugabyteDBConnector}
  *
  * @author Horia Chiorean
  */

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -195,7 +195,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                 final PostgresEventMetadataProvider metadataProvider = new PostgresEventMetadataProvider();
 
                 SignalProcessor<PostgresPartition, PostgresOffsetContext> signalProcessor = new SignalProcessor<>(
-                        PostgresConnector.class, connectorConfig, Map.of(),
+                        YugabyteDBConnector.class, connectorConfig, Map.of(),
                         getAvailableSignalChannels(),
                         DocumentReader.defaultReader(),
                         previousOffsets);
@@ -235,7 +235,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                 ChangeEventSourceCoordinator<PostgresPartition, PostgresOffsetContext> coordinator = new PostgresChangeEventSourceCoordinator(
                         previousOffsets,
                         errorHandler,
-                        PostgresConnector.class,
+                        YugabyteDBConnector.class,
                         connectorConfig,
                         new PostgresChangeEventSourceFactory(
                                 connectorConfig,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresErrorHandler.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresErrorHandler.java
@@ -21,7 +21,7 @@ import io.debezium.util.Collect;
 public class PostgresErrorHandler extends ErrorHandler {
 
     public PostgresErrorHandler(PostgresConnectorConfig connectorConfig, ChangeEventQueue<?> queue, ErrorHandler replacedErrorHandler) {
-        super(PostgresConnector.class, connectorConfig, queue, replacedErrorHandler);
+        super(YugabyteDBConnector.class, connectorConfig, queue, replacedErrorHandler);
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
@@ -32,7 +32,7 @@ import io.debezium.relational.Tables;
 import io.debezium.spi.topic.TopicNamingStrategy;
 
 /**
- * Component that records the schema information for the {@link PostgresConnector}. The schema information contains
+ * Component that records the schema information for the {@link YugabyteDBConnector}. The schema information contains
  * the {@link Tables table definitions} and the Kafka Connect {@link #schemaFor(TableId) Schema}s for each table, where the
  * {@link Schema} excludes any columns that have been {@link PostgresConnectorConfig#COLUMN_EXCLUDE_LIST specified} in the
  * configuration.

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -11,7 +11,6 @@ import java.util.Objects;
 import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.debezium.connector.postgresql.connection.*;
 import org.apache.kafka.connect.errors.ConnectException;
 import com.yugabyte.core.BaseConnection;
 import org.slf4j.Logger;
@@ -166,7 +165,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
             // such that the connection times out. We must enable keep
             // alive to ensure that it doesn't time out
             ReplicationStream stream = this.replicationStream.get();
-            stream.startKeepAlive(Threads.newSingleThreadExecutor(PostgresConnector.class, connectorConfig.getLogicalName(), KEEP_ALIVE_THREAD_NAME));
+            stream.startKeepAlive(Threads.newSingleThreadExecutor(YugabyteDBConnector.class, connectorConfig.getLogicalName(), KEEP_ALIVE_THREAD_NAME));
 
             initSchema();
 
@@ -201,7 +200,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
 
                     replicationStream.set(replicationConnection.startStreaming(walPosition.getLastEventStoredLsn(), walPosition));
                     stream = this.replicationStream.get();
-                    stream.startKeepAlive(Threads.newSingleThreadExecutor(PostgresConnector.class, connectorConfig.getLogicalName(), KEEP_ALIVE_THREAD_NAME));
+                    stream.startKeepAlive(Threads.newSingleThreadExecutor(YugabyteDBConnector.class, connectorConfig.getLogicalName(), KEEP_ALIVE_THREAD_NAME));
                 }
             } else {
                 LOGGER.info("Connector config provide.transaction.metadata is set to true. Therefore, skip records filtering in order to ship entire transactions.");

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/ReplicaIdentityMapper.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/ReplicaIdentityMapper.java
@@ -21,7 +21,7 @@ import io.debezium.function.Predicates;
 import io.debezium.relational.TableId;
 
 /**
- * Class that records Replica Identity information for the {@link PostgresConnector}
+ * Class that records Replica Identity information for the {@link YugabyteDBConnector}
  * @author Ben White, Miguel Sotomayor
  */
 @Immutable

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
@@ -36,12 +36,12 @@ import io.debezium.relational.TableId;
  *
  * @author Horia Chiorean
  */
-public class PostgresConnector extends RelationalBaseSourceConnector {
+public class YugabyteDBConnector extends RelationalBaseSourceConnector {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresConnector.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBConnector.class);
     private Map<String, String> props;
 
-    public PostgresConnector() {
+    public YugabyteDBConnector() {
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/metadata/PostgresConnectorMetadata.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/metadata/PostgresConnectorMetadata.java
@@ -7,7 +7,7 @@ package io.debezium.connector.postgresql.metadata;
 
 import io.debezium.config.Field;
 import io.debezium.connector.postgresql.Module;
-import io.debezium.connector.postgresql.PostgresConnector;
+import io.debezium.connector.postgresql.YugabyteDBConnector;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.metadata.ConnectorDescriptor;
 import io.debezium.metadata.ConnectorMetadata;
@@ -16,7 +16,7 @@ public class PostgresConnectorMetadata implements ConnectorMetadata {
 
     @Override
     public ConnectorDescriptor getConnectorDescriptor() {
-        return new ConnectorDescriptor("postgres", "Debezium PostgreSQL Connector", PostgresConnector.class.getName(), Module.version());
+        return new ConnectorDescriptor("postgres", "Debezium PostgreSQL Connector", YugabyteDBConnector.class.getName(), Module.version());
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/rest/DebeziumPostgresConnectorResource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/rest/DebeziumPostgresConnectorResource.java
@@ -16,11 +16,11 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import io.debezium.connector.postgresql.YugabyteDBConnector;
 import org.apache.kafka.connect.health.ConnectClusterState;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.Module;
-import io.debezium.connector.postgresql.PostgresConnector;
 import io.debezium.rest.ConnectionValidationResource;
 import io.debezium.rest.FilterValidationResource;
 import io.debezium.rest.MetricsResource;
@@ -36,7 +36,7 @@ import io.debezium.rest.model.MetricsDescriptor;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class DebeziumPostgresConnectorResource
-        implements SchemaResource, ConnectionValidationResource<PostgresConnector>, FilterValidationResource<PostgresConnector>, MetricsResource {
+        implements SchemaResource, ConnectionValidationResource<YugabyteDBConnector>, FilterValidationResource<YugabyteDBConnector>, MetricsResource {
 
     public static final String BASE_PATH = "/debezium/postgres";
     public static final String VERSION_ENDPOINT = "/version";
@@ -53,8 +53,8 @@ public class DebeziumPostgresConnectorResource
     }
 
     @Override
-    public PostgresConnector getConnector() {
-        return new PostgresConnector();
+    public YugabyteDBConnector getConnector() {
+        return new YugabyteDBConnector();
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
+++ b/debezium-connector-postgres/src/main/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
@@ -1,1 +1,1 @@
-io.debezium.connector.postgresql.PostgresConnector
+io.debezium.connector.postgresql.YugabyteDBConnector

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/BlockingSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/BlockingSnapshotIT.java
@@ -78,8 +78,8 @@ public class BlockingSnapshotIT extends AbstractBlockingSnapshotTest {
     }
 
     @Override
-    protected Class<PostgresConnector> connectorClass() {
-        return PostgresConnector.class;
+    protected Class<YugabyteDBConnector> connectorClass() {
+        return YugabyteDBConnector.class;
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CloudEventsConverterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CloudEventsConverterIT.java
@@ -16,11 +16,11 @@ import io.debezium.converters.AbstractCloudEventsConverterTest;
 import io.debezium.jdbc.JdbcConnection;
 
 /**
- * Integration test for {@link io.debezium.converters.CloudEventsConverter} with {@link PostgresConnector}
+ * Integration test for {@link io.debezium.converters.CloudEventsConverter} with {@link YugabyteDBConnector}
  *
  * @author Roman Kudryashov
  */
-public class CloudEventsConverterIT extends AbstractCloudEventsConverterTest<PostgresConnector> {
+public class CloudEventsConverterIT extends AbstractCloudEventsConverterTest<YugabyteDBConnector> {
 
     private static final String SETUP_SCHEMA = "DROP SCHEMA IF EXISTS s1 CASCADE;" +
             "CREATE SCHEMA s1;";
@@ -51,8 +51,8 @@ public class CloudEventsConverterIT extends AbstractCloudEventsConverterTest<Pos
     }
 
     @Override
-    protected Class<PostgresConnector> getConnectorClass() {
-        return PostgresConnector.class;
+    protected Class<YugabyteDBConnector> getConnectorClass() {
+        return YugabyteDBConnector.class;
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DebeziumEngineIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DebeziumEngineIT.java
@@ -82,7 +82,7 @@ public class DebeziumEngineIT {
         final Properties props = new Properties();
         props.putAll(TestHelper.defaultConfig().build().asMap());
         props.setProperty("name", "debezium-engine");
-        props.setProperty("connector.class", "io.debezium.connector.postgresql.PostgresConnector");
+        props.setProperty("connector.class", "io.debezium.connector.postgresql.YugabyteDBConnector");
         props.setProperty(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG,
                 OFFSET_STORE_PATH.toAbsolutePath().toString());
         props.setProperty("offset.flush.interval.ms", "0");
@@ -129,7 +129,7 @@ public class DebeziumEngineIT {
         final Properties props = new Properties();
         props.putAll(TestHelper.defaultConfig().build().asMap());
         props.setProperty("name", "debezium-engine");
-        props.setProperty("connector.class", "io.debezium.connector.postgresql.PostgresConnector");
+        props.setProperty("connector.class", "io.debezium.connector.postgresql.YugabyteDBConnector");
         props.setProperty(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG,
                 OFFSET_STORE_PATH.toAbsolutePath().toString());
         props.setProperty("offset.flush.interval.ms", "0");
@@ -169,7 +169,7 @@ public class DebeziumEngineIT {
         final Properties props = new Properties();
         props.putAll(TestHelper.defaultConfig().build().asMap());
         props.setProperty("name", "debezium-engine");
-        props.setProperty("connector.class", "io.debezium.connector.postgresql.PostgresConnector");
+        props.setProperty("connector.class", "io.debezium.connector.postgresql.YugabyteDBConnector");
         props.setProperty(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG,
                 OFFSET_STORE_PATH.toAbsolutePath().toString());
         props.setProperty("offset.flush.interval.ms", "0");
@@ -244,7 +244,7 @@ public class DebeziumEngineIT {
         final Properties props = new Properties();
         props.putAll(TestHelper.defaultConfig().build().asMap());
         props.setProperty("name", "debezium-engine");
-        props.setProperty("connector.class", "io.debezium.connector.postgresql.PostgresConnector");
+        props.setProperty("connector.class", "io.debezium.connector.postgresql.YugabyteDBConnector");
         props.setProperty(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG,
                 OFFSET_STORE_PATH.toAbsolutePath().toString());
         props.setProperty("offset.flush.interval.ms", "3000");

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DomainTypesIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DomainTypesIT.java
@@ -43,7 +43,7 @@ public class DomainTypesIT extends AbstractRecordsProducerTest {
     @Test
     @FixFor("DBZ-3657")
     public void shouldNotChokeOnDomainTypeInArray() throws Exception {
-        start(PostgresConnector.class, TestHelper.defaultConfig()
+        start(YugabyteDBConnector.class, TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
                 .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "domaintypes")
                 .build());
@@ -63,7 +63,7 @@ public class DomainTypesIT extends AbstractRecordsProducerTest {
     @Test
     @FixFor("DBZ-3657")
     public void shouldExportDomainTypeInArrayAsUnknown() throws Exception {
-        start(PostgresConnector.class, TestHelper.defaultConfig()
+        start(YugabyteDBConnector.class, TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
                 .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "domaintypes")
                 .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true)

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
@@ -41,7 +41,7 @@ import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.util.Collect;
 import io.debezium.util.Testing;
 
-public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<PostgresConnector> {
+public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<YugabyteDBConnector> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IncrementalSnapshotIT.class);
 
@@ -134,8 +134,8 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
     }
 
     @Override
-    protected Class<PostgresConnector> connectorClass() {
-        return PostgresConnector.class;
+    protected Class<YugabyteDBConnector> connectorClass() {
+        return YugabyteDBConnector.class;
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/LogicalDecodingMessageIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/LogicalDecodingMessageIT.java
@@ -76,7 +76,7 @@ public class LogicalDecodingMessageIT extends AbstractConnectorTest {
         TestHelper.execute(SETUP_TABLES_STMT);
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.LOGICAL_DECODING_MESSAGE_PREFIX_EXCLUDE_LIST, ".*");
-        start(PostgresConnector.class, configBuilder.build());
+        start(YugabyteDBConnector.class, configBuilder.build());
         assertConnectorIsRunning();
         waitForSnapshotToBeCompleted();
 
@@ -99,7 +99,7 @@ public class LogicalDecodingMessageIT extends AbstractConnectorTest {
         TestHelper.execute(SETUP_TABLES_STMT);
         Configuration.Builder configBuilder = TestHelper.defaultConfig();
 
-        start(PostgresConnector.class, configBuilder.build());
+        start(YugabyteDBConnector.class, configBuilder.build());
         assertConnectorIsRunning();
         waitForSnapshotToBeCompleted();
 
@@ -138,7 +138,7 @@ public class LogicalDecodingMessageIT extends AbstractConnectorTest {
         TestHelper.execute(SETUP_TABLES_STMT);
         Configuration.Builder configBuilder = TestHelper.defaultConfig();
 
-        start(PostgresConnector.class, configBuilder.build());
+        start(YugabyteDBConnector.class, configBuilder.build());
         assertConnectorIsRunning();
         waitForSnapshotToBeCompleted();
 
@@ -180,7 +180,7 @@ public class LogicalDecodingMessageIT extends AbstractConnectorTest {
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.BINARY_HANDLING_MODE, "base64");
 
-        start(PostgresConnector.class, configBuilder.build());
+        start(YugabyteDBConnector.class, configBuilder.build());
         assertConnectorIsRunning();
         waitForSnapshotToBeCompleted();
 
@@ -206,7 +206,7 @@ public class LogicalDecodingMessageIT extends AbstractConnectorTest {
         TestHelper.execute(SETUP_TABLES_STMT);
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.LOGICAL_DECODING_MESSAGE_PREFIX_EXCLUDE_LIST, "excluded_prefix, prefix:excluded");
-        start(PostgresConnector.class, configBuilder.build());
+        start(YugabyteDBConnector.class, configBuilder.build());
         assertConnectorIsRunning();
         waitForSnapshotToBeCompleted();
 
@@ -232,7 +232,7 @@ public class LogicalDecodingMessageIT extends AbstractConnectorTest {
         TestHelper.execute(SETUP_TABLES_STMT);
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.LOGICAL_DECODING_MESSAGE_PREFIX_INCLUDE_LIST, "included_prefix, prefix:included, ano.*er_included");
-        start(PostgresConnector.class, configBuilder.build());
+        start(YugabyteDBConnector.class, configBuilder.build());
         assertConnectorIsRunning();
         waitForSnapshotToBeCompleted();
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/NotificationsIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/NotificationsIT.java
@@ -14,7 +14,7 @@ import org.junit.Before;
 import io.debezium.config.Configuration;
 import io.debezium.pipeline.notification.AbstractNotificationsIT;
 
-public class NotificationsIT extends AbstractNotificationsIT<PostgresConnector> {
+public class NotificationsIT extends AbstractNotificationsIT<YugabyteDBConnector> {
 
     @Before
     public void before() throws SQLException {
@@ -31,8 +31,8 @@ public class NotificationsIT extends AbstractNotificationsIT<PostgresConnector> 
     }
 
     @Override
-    protected Class<PostgresConnector> connectorClass() {
-        return PostgresConnector.class;
+    protected Class<YugabyteDBConnector> connectorClass() {
+        return YugabyteDBConnector.class;
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -19,11 +19,11 @@ import io.debezium.jdbc.JdbcConnection;
 import io.debezium.transforms.outbox.AbstractEventRouterTest;
 
 /**
- * Integration test for {@link io.debezium.transforms.outbox.EventRouter} with {@link PostgresConnector}
+ * Integration test for {@link io.debezium.transforms.outbox.EventRouter} with {@link YugabyteDBConnector}
  *
  * @author Renato Mefi (gh@mefi.in)
  */
-public class OutboxEventRouterIT extends AbstractEventRouterTest<PostgresConnector> {
+public class OutboxEventRouterIT extends AbstractEventRouterTest<YugabyteDBConnector> {
 
     private static final String SETUP_OUTBOX_SCHEMA = "DROP SCHEMA IF EXISTS outboxsmtit CASCADE;" +
             "CREATE SCHEMA outboxsmtit;";
@@ -47,8 +47,8 @@ public class OutboxEventRouterIT extends AbstractEventRouterTest<PostgresConnect
     }
 
     @Override
-    protected Class<PostgresConnector> getConnectorClass() {
-        return PostgresConnector.class;
+    protected Class<YugabyteDBConnector> getConnectorClass() {
+        return YugabyteDBConnector.class;
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorConfigDefTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorConfigDefTest.java
@@ -15,7 +15,7 @@ import io.debezium.config.Configuration;
 public class PostgresConnectorConfigDefTest extends ConfigDefinitionMetadataTest {
 
     public PostgresConnectorConfigDefTest() {
-        super(new PostgresConnector());
+        super(new YugabyteDBConnector());
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresDefaultValueConverterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresDefaultValueConverterIT.java
@@ -52,7 +52,7 @@ public class PostgresDefaultValueConverterIT extends AbstractConnectorTest {
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL.getValue())
                 .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "s1");
-        start(PostgresConnector.class, configBuilder.build());
+        start(YugabyteDBConnector.class, configBuilder.build());
         assertConnectorIsRunning();
 
         waitForSnapshotToBeCompleted("postgres", TestHelper.TEST_SERVER);
@@ -69,7 +69,7 @@ public class PostgresDefaultValueConverterIT extends AbstractConnectorTest {
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL.getValue())
                 .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "s1");
-        start(PostgresConnector.class, configBuilder.build());
+        start(YugabyteDBConnector.class, configBuilder.build());
         assertConnectorIsRunning();
 
         waitForSnapshotToBeCompleted("postgres", TestHelper.TEST_SERVER);
@@ -99,7 +99,7 @@ public class PostgresDefaultValueConverterIT extends AbstractConnectorTest {
         TestHelper.execute(ddl);
 
         Configuration config = TestHelper.defaultConfig().build();
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
 
         waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresMetricsIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresMetricsIT.java
@@ -59,7 +59,7 @@ public class PostgresMetricsIT extends AbstractRecordsProducerTest {
     @Test
     public void testLifecycle() throws Exception {
         // start connector
-        start(PostgresConnector.class,
+        start(YugabyteDBConnector.class,
                 TestHelper.defaultConfig()
                         .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.ALWAYS)
                         .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
@@ -100,7 +100,7 @@ public class PostgresMetricsIT extends AbstractRecordsProducerTest {
         TestHelper.execute(INIT_STATEMENTS, INSERT_STATEMENTS);
 
         // start connector
-        start(PostgresConnector.class,
+        start(YugabyteDBConnector.class,
                 TestHelper.defaultConfig()
                         .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_ONLY)
                         .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
@@ -115,7 +115,7 @@ public class PostgresMetricsIT extends AbstractRecordsProducerTest {
         TestHelper.execute(INIT_STATEMENTS, INSERT_STATEMENTS);
 
         // start connector
-        start(PostgresConnector.class,
+        start(YugabyteDBConnector.class,
                 TestHelper.defaultConfig()
                         .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.ALWAYS)
                         .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
@@ -138,7 +138,7 @@ public class PostgresMetricsIT extends AbstractRecordsProducerTest {
                 .with(PostgresConnectorConfig.CUSTOM_METRIC_TAGS, "env=test,bu=bigdata")
                 .build();
         Map<String, String> customMetricTags = new PostgresConnectorConfig(config).getCustomMetricTags();
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
 
         assertSnapshotWithCustomMetrics(customMetricTags);
         assertStreamingWithCustomMetrics(customMetricTags);
@@ -150,7 +150,7 @@ public class PostgresMetricsIT extends AbstractRecordsProducerTest {
         TestHelper.execute(INIT_STATEMENTS);
 
         // start connector
-        start(PostgresConnector.class,
+        start(YugabyteDBConnector.class,
                 TestHelper.defaultConfig()
                         .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
                         .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
@@ -275,7 +275,7 @@ public class PostgresMetricsIT extends AbstractRecordsProducerTest {
                 .with(PostgresConnectorConfig.MAX_BATCH_SIZE, 1)
                 .with(PostgresConnectorConfig.POLL_INTERVAL_MS, 100L)
                 .with(PostgresConnectorConfig.MAX_QUEUE_SIZE_IN_BYTES, 10000L);
-        start(PostgresConnector.class, configBuilder.build(), loggingCompletion(), null, x -> {
+        start(YugabyteDBConnector.class, configBuilder.build(), loggingCompletion(), null, x -> {
             LOGGER.info("Record '{}' arrived", x);
             step1.countDown();
             try {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresMoneyIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresMoneyIT.java
@@ -51,7 +51,7 @@ public class PostgresMoneyIT extends AbstractConnectorTest {
         Configuration config = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER)
                 .build();
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
 
         // insert 2 records for testing
@@ -77,7 +77,7 @@ public class PostgresMoneyIT extends AbstractConnectorTest {
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER)
                 .with(PostgresConnectorConfig.DECIMAL_HANDLING_MODE, "string")
                 .build();
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
 
         // insert 2 records for testing
@@ -103,7 +103,7 @@ public class PostgresMoneyIT extends AbstractConnectorTest {
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER)
                 .with(PostgresConnectorConfig.DECIMAL_HANDLING_MODE, "double")
                 .build();
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
 
         // insert 2 records for testing
@@ -128,7 +128,7 @@ public class PostgresMoneyIT extends AbstractConnectorTest {
         Configuration config = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER)
                 .build();
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
 
         // insert 2 records for testing

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresReselectColumnsProcessorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresReselectColumnsProcessorIT.java
@@ -30,7 +30,7 @@ import io.debezium.processors.reselect.ReselectColumnsPostProcessor;
  *
  * @author Chris Cranford
  */
-public class PostgresReselectColumnsProcessorIT extends AbstractReselectProcessorTest<PostgresConnector> {
+public class PostgresReselectColumnsProcessorIT extends AbstractReselectProcessorTest<YugabyteDBConnector> {
 
     public static final String CREATE_STMT = "DROP SCHEMA IF EXISTS s1 CASCADE;" +
             "CREATE SCHEMA s1; ";
@@ -53,8 +53,8 @@ public class PostgresReselectColumnsProcessorIT extends AbstractReselectProcesso
     }
 
     @Override
-    protected Class<PostgresConnector> getConnectorClass() {
-        return PostgresConnector.class;
+    protected Class<YugabyteDBConnector> getConnectorClass() {
+        return YugabyteDBConnector.class;
     }
 
     @Override
@@ -120,7 +120,7 @@ public class PostgresReselectColumnsProcessorIT extends AbstractReselectProcesso
                 .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1\\.dbz4321_toast")
                 .build();
 
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         waitForStreamingStarted();
 
         final String text = RandomStringUtils.randomAlphabetic(10000);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresShutdownIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresShutdownIT.java
@@ -34,7 +34,7 @@ import io.debezium.testing.testcontainers.util.ContainerImageVersions;
 import io.debezium.util.Testing;
 
 /**
- * Integration test for {@link PostgresConnector} using an {@link EmbeddedEngine} and Testcontainers infrastructure for when Postgres is shutdown during streaming
+ * Integration test for {@link YugabyteDBConnector} using an {@link EmbeddedEngine} and Testcontainers infrastructure for when Postgres is shutdown during streaming
  */
 public class PostgresShutdownIT extends AbstractConnectorTest {
 
@@ -114,7 +114,7 @@ public class PostgresShutdownIT extends AbstractConnectorTest {
         String initialHeartbeat = postgresConnection.queryAndMap(
                 "SELECT ts FROM s1.heartbeat;",
                 postgresConnection.singleResultMapper(rs -> rs.getString("ts"), "Could not fetch keepalive info"));
-        start(PostgresConnector.class, configBuilder.build());
+        start(YugabyteDBConnector.class, configBuilder.build());
         assertConnectorIsRunning();
 
         waitForSnapshotToBeCompleted("postgres", TestHelper.TEST_SERVER);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSkipMessagesWithoutChangeConfigIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSkipMessagesWithoutChangeConfigIT.java
@@ -58,7 +58,7 @@ public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnector
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER)
                 .build();
 
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
 
         TestHelper.execute("INSERT INTO updates_test.debezium_test (id,white,black) VALUES (1,1,1);");
@@ -98,7 +98,7 @@ public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnector
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER)
                 .build();
 
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
 
         TestHelper.execute("INSERT INTO updates_test.debezium_test (id,white,black) VALUES (1,1,1);");
@@ -136,7 +136,7 @@ public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnector
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER)
                 .build();
 
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
 
         TestHelper.execute("INSERT INTO updates_test.debezium_test (id,white,black) VALUES (1,1,1);");
@@ -177,7 +177,7 @@ public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnector
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER)
                 .build();
 
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
 
         TestHelper.execute("INSERT INTO updates_test.debezium_test (id,white,black) VALUES (1,1,1);");

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PublicGeometryIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PublicGeometryIT.java
@@ -90,7 +90,7 @@ public class PublicGeometryIT extends AbstractRecordsProducerTest {
     }
 
     private void setupRecordsProducer(Configuration.Builder config) {
-        start(PostgresConnector.class, config
+        start(YugabyteDBConnector.class, config
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
                 .build());
         assertConnectorIsRunning();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -1218,7 +1218,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_ONLY.getValue())
                 .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1.part");
-        start(PostgresConnector.class, configBuilder.build());
+        start(YugabyteDBConnector.class, configBuilder.build());
         assertConnectorIsRunning();
         waitForSnapshotToBeCompleted();
 
@@ -1256,7 +1256,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
 
     private void buildNoStreamProducer(Configuration.Builder config) {
         alterConfig(config);
-        start(PostgresConnector.class, config
+        start(YugabyteDBConnector.class, config
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_ONLY)
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE_CLASS, CustomTestSnapshot.class.getName())
                 .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
@@ -1266,7 +1266,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
 
     private void buildWithStreamProducer(Configuration.Builder config) {
         alterConfig(config);
-        start(PostgresConnector.class, config
+        start(YugabyteDBConnector.class, config
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.ALWAYS)
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE_CLASS, CustomTestSnapshot.class.getName())
                 .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -150,7 +150,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
     private void startConnector(Function<Configuration.Builder, Configuration.Builder> customConfig, boolean waitForSnapshot, Predicate<SourceRecord> isStopRecord)
             throws InterruptedException {
-        start(PostgresConnector.class, new PostgresConnectorConfig(customConfig.apply(TestHelper.defaultConfig()
+        start(YugabyteDBConnector.class, new PostgresConnectorConfig(customConfig.apply(TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, false)
                 .with(PostgresConnectorConfig.SCHEMA_EXCLUDE_LIST, "postgis")
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, waitForSnapshot ? SnapshotMode.INITIAL : SnapshotMode.NEVER))

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SignalsIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SignalsIT.java
@@ -70,7 +70,7 @@ public class SignalsIT extends AbstractConnectorTest {
                 .with(PostgresConnectorConfig.SIGNAL_DATA_COLLECTION, "s1.debezium_signal")
                 .with(CommonConnectorConfig.SIGNAL_POLL_INTERVAL_MS, "500")
                 .build();
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         assertConnectorIsRunning();
         TestHelper.waitForDefaultReplicationSlotBeActive();
 
@@ -105,7 +105,7 @@ public class SignalsIT extends AbstractConnectorTest {
                 .with(CommonConnectorConfig.SIGNAL_POLL_INTERVAL_MS, "500")
                 .with(CommonConnectorConfig.SIGNAL_ENABLED_CHANNELS, "")
                 .build();
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         assertConnectorIsRunning();
         TestHelper.waitForDefaultReplicationSlotBeActive();
 
@@ -138,7 +138,7 @@ public class SignalsIT extends AbstractConnectorTest {
                 .with(PostgresConnectorConfig.SIGNAL_DATA_COLLECTION, "s1.debezium_signal")
                 .with(CommonConnectorConfig.SIGNAL_POLL_INTERVAL_MS, "500")
                 .build();
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         assertConnectorIsRunning();
         TestHelper.waitForDefaultReplicationSlotBeActive();
 
@@ -218,7 +218,7 @@ public class SignalsIT extends AbstractConnectorTest {
                 .with(CommonConnectorConfig.SIGNAL_POLL_INTERVAL_MS, "500")
                 .with(CommonConnectorConfig.SIGNAL_ENABLED_CHANNELS, "jmx")
                 .build();
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         assertConnectorIsRunning();
         TestHelper.waitForDefaultReplicationSlotBeActive();
 
@@ -244,7 +244,7 @@ public class SignalsIT extends AbstractConnectorTest {
                 .with(CommonConnectorConfig.SIGNAL_POLL_INTERVAL_MS, "500")
                 .with(CommonConnectorConfig.SIGNAL_ENABLED_CHANNELS, "jmx")
                 .build();
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         assertConnectorIsRunning();
         TestHelper.waitForDefaultReplicationSlotBeActive();
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotWithOverridesProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotWithOverridesProducerIT.java
@@ -86,7 +86,7 @@ public class SnapshotWithOverridesProducerIT extends AbstractRecordsProducerTest
     }
 
     private void buildProducer(Configuration.Builder config) {
-        start(PostgresConnector.class, config
+        start(YugabyteDBConnector.class, config
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_ONLY)
                 .build());
         assertConnectorIsRunning();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TablesWithoutPrimaryKeyIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TablesWithoutPrimaryKeyIT.java
@@ -44,7 +44,7 @@ public class TablesWithoutPrimaryKeyIT extends AbstractRecordsProducerTest {
     public void shouldProcessFromSnapshot() throws Exception {
         TestHelper.execute(STATEMENTS);
 
-        start(PostgresConnector.class, TestHelper.defaultConfig()
+        start(YugabyteDBConnector.class, TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_ONLY)
                 .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "nopk")
                 .build());
@@ -66,7 +66,7 @@ public class TablesWithoutPrimaryKeyIT extends AbstractRecordsProducerTest {
     public void shouldProcessFromSnapshotOld() throws Exception {
         TestHelper.execute(STATEMENTS);
 
-        start(PostgresConnector.class, TestHelper.defaultConfig()
+        start(YugabyteDBConnector.class, TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_ONLY)
                 .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "nopk")
                 .build());
@@ -86,7 +86,7 @@ public class TablesWithoutPrimaryKeyIT extends AbstractRecordsProducerTest {
 
     @Test
     public void shouldProcessFromStreaming() throws Exception {
-        start(PostgresConnector.class, TestHelper.defaultConfig()
+        start(YugabyteDBConnector.class, TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
                 .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "nopk")
                 .build());
@@ -125,7 +125,7 @@ public class TablesWithoutPrimaryKeyIT extends AbstractRecordsProducerTest {
 
     @Test
     public void shouldProcessFromStreamingOld() throws Exception {
-        start(PostgresConnector.class, TestHelper.defaultConfig()
+        start(YugabyteDBConnector.class, TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
                 .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "nopk")
                 .build());

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TransactionMetadataIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TransactionMetadataIT.java
@@ -80,7 +80,7 @@ public class TransactionMetadataIT extends AbstractConnectorTest {
                 .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                 .with(PostgresConnectorConfig.PROVIDE_TRANSACTION_METADATA, true)
                 .build();
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         assertConnectorIsRunning();
         TestHelper.waitForDefaultReplicationSlotBeActive();
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteReplicaIdentityIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteReplicaIdentityIT.java
@@ -39,7 +39,7 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
   private static final String INSERT_STMT = "INSERT INTO s1.a (aa) VALUES (1);" +
      "INSERT INTO s2.a (aa) VALUES (1);";
 
-  private PostgresConnector connector;
+  private YugabyteDBConnector connector;
 
   @BeforeClass
   public static void beforeClass() throws SQLException {
@@ -68,7 +68,7 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
                              .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
                              .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                              .build();
-    start(PostgresConnector.class, config);
+    start(YugabyteDBConnector.class, config);
     assertConnectorIsRunning();
 
     // YB Note: Added a wait for replication slot to be active.
@@ -106,7 +106,7 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
                              .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
                              .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                              .build();
-    start(PostgresConnector.class, config);
+    start(YugabyteDBConnector.class, config);
     assertConnectorIsRunning();
 
     // YB Note: Added a wait for replication slot to be active.
@@ -148,7 +148,7 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
                              .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
                              .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                              .build();
-    start(PostgresConnector.class, config);
+    start(YugabyteDBConnector.class, config);
     assertConnectorIsRunning();
 
     // YB Note: Added a wait for replication slot to be active.
@@ -206,7 +206,7 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
                              .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
                              .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                              .build();
-    start(PostgresConnector.class, config);
+    start(YugabyteDBConnector.class, config);
     assertConnectorIsRunning();
 
     // YB Note: Added a wait for replication slot to be active.
@@ -241,7 +241,7 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
                              .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
                              .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                              .build();
-    start(PostgresConnector.class, config);
+    start(YugabyteDBConnector.class, config);
     assertConnectorIsRunning();
 
     // YB Note: Added a wait for replication slot to be active.
@@ -282,7 +282,7 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
                              .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
                              .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                              .build();
-    start(PostgresConnector.class, config);
+    start(YugabyteDBConnector.class, config);
     assertConnectorIsRunning();
 
     // YB Note: Added a wait for replication slot to be active.
@@ -324,7 +324,7 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
                              .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
                              .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                              .build();
-    start(PostgresConnector.class, config);
+    start(YugabyteDBConnector.class, config);
     assertConnectorIsRunning();
 
     // YB Note: Added a wait for replication slot to be active.

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/rest/DebeziumPostgresConnectorResourceIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/rest/DebeziumPostgresConnectorResourceIT.java
@@ -21,7 +21,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import io.debezium.connector.postgresql.Module;
-import io.debezium.connector.postgresql.PostgresConnector;
+import io.debezium.connector.postgresql.YugabyteDBConnector;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.testing.testcontainers.Connector;
 import io.debezium.testing.testcontainers.ConnectorConfiguration;
@@ -84,7 +84,7 @@ public class DebeziumPostgresConnectorResourceIT {
     public void testInvalidConnection() {
         given()
                 .port(RestExtensionTestInfrastructure.getDebeziumContainer().getFirstMappedPort())
-                .when().contentType(ContentType.JSON).accept(ContentType.JSON).body("{\"connector.class\": \"" + PostgresConnector.class.getName() + "\"}")
+                .when().contentType(ContentType.JSON).accept(ContentType.JSON).body("{\"connector.class\": \"" + YugabyteDBConnector.class.getName() + "\"}")
                 .put(DebeziumPostgresConnectorResource.BASE_PATH + DebeziumPostgresConnectorResource.VALIDATE_CONNECTION_ENDPOINT)
                 .then().log().all()
                 .statusCode(200)

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/rest/DebeziumPostgresConnectorResourceNoDatabaseIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/rest/DebeziumPostgresConnectorResourceNoDatabaseIT.java
@@ -17,7 +17,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import io.debezium.connector.postgresql.Module;
-import io.debezium.connector.postgresql.PostgresConnector;
+import io.debezium.connector.postgresql.YugabyteDBConnector;
 import io.debezium.testing.testcontainers.testhelper.RestExtensionTestInfrastructure;
 
 public class DebeziumPostgresConnectorResourceNoDatabaseIT {
@@ -65,7 +65,7 @@ public class DebeziumPostgresConnectorResourceNoDatabaseIT {
                 .body("properties.isEmpty()", is(false))
                 .body("x-connector-id", is("postgres"))
                 .body("x-version", is(Module.version()))
-                .body("x-className", is(PostgresConnector.class.getName()))
+                .body("x-className", is(YugabyteDBConnector.class.getName()))
                 .body("properties", hasKey("topic.prefix"))
                 .body("properties", hasKey("plugin.name"))
                 .body("properties", hasKey("slot.name"))

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDbDatabaseTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDbDatabaseTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.sql.SQLException;
 
+import io.debezium.connector.postgresql.YugabyteDBConnector;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,7 +20,6 @@ import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.lifecycle.Startables;
 
 import io.debezium.config.Configuration;
-import io.debezium.connector.postgresql.PostgresConnector;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
 import io.debezium.connector.postgresql.TestHelper;
@@ -94,7 +94,7 @@ public class TimescaleDbDatabaseTest extends AbstractConnectorTest {
     public void shouldTransformChunks() throws Exception {
         Testing.Print.enable();
 
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
 
         insertData();
@@ -112,7 +112,7 @@ public class TimescaleDbDatabaseTest extends AbstractConnectorTest {
     public void shouldTransformAggregates() throws Exception {
         Testing.Print.enable();
 
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
 
         insertData();
@@ -142,7 +142,7 @@ public class TimescaleDbDatabaseTest extends AbstractConnectorTest {
     public void shouldTransformCompressedChunks() throws Exception {
         Testing.Print.enable();
 
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
 
         insertData();


### PR DESCRIPTION
The PR renamed the main class PostgresConnector to YBPostgresConnector to avoid name clashes while loading the classes.

Additionally, this closes yugabyte/yugabyte-db#23081