### PR TITLE
[DBZ-PGYB] Rename jar artefact according to new naming standards

### DIFF
--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -8,8 +8,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-connector-yugabytedb</artifactId>
-    <name>Debezium Connector for YugabyteDB</name>
-    <title>YugabyteDB Source Connector</title>
+    <name>YugabyteDB Source Connector</name>
     <packaging>jar</packaging>
     <properties>
         <!-- 

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -7,8 +7,8 @@
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>debezium-connector-postgres</artifactId>
-    <name>Debezium Connector for PostgreSQL</name>
+    <artifactId>debezium-connector-yugabytedb</artifactId>
+    <name>Debezium Connector for YugabyteDB</name>
     <packaging>jar</packaging>
     <properties>
         <!-- 

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -9,6 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-connector-yugabytedb</artifactId>
     <name>Debezium Connector for YugabyteDB</name>
+    <title>YugabyteDB Source Connector</title>
     <packaging>jar</packaging>
     <properties>
         <!-- 


### PR DESCRIPTION
This PR changes the name of the jar file which gets generated once the connector is compiled. We have changed the name from `debezium-connector-postgres` to `debezium-connector-yugabytedb`.

Additionally, this PR modifies the `name` tag in the `pom.xml` file with the name of the source connector.