### PR TITLE
[DBZ-PGYB] Fix vulnerability in the Postgres JDBC driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <version.apicurio>2.4.3.Final</version.apicurio>
 
         <!-- Database drivers, should align with databases -->
-        <version.postgresql.driver>42.6.0</version.postgresql.driver>
+        <version.postgresql.driver>42.6.1</version.postgresql.driver>
         <version.mysql.driver>8.0.33</version.mysql.driver>
         <version.mysql.binlog>0.29.0</version.mysql.binlog>
         <version.mongo.driver>4.11.0</version.mongo.driver>


### PR DESCRIPTION
## Problem

The Postgres JDVC driver jar being used currently has a `CRITICAL` vulnerability `CVE-2024-1597` as identified by `trivy` in the version `42.6.0`.

## Solution

For the fix, this PR upgrades the jar to a driver version `42.6.1` which does not have the vulnerability.