### PR TITLE
[DBZ-PGYB] Add tests to enhance test suite for YugabyteDBConnector

### DIFF
--- a/debezium-connector-postgres/YB_DEV_NOTES.md
+++ b/debezium-connector-postgres/YB_DEV_NOTES.md
@@ -5,7 +5,7 @@
 Since the smart driver changes require us to build the debezium core as well, build can be completed using:
 
 ```bash
-./mvnw clean install -Dquick
+./mvnw clean install -Passembly -DskipITs -DskipTests -pl debezium-connector-postgres -am
 ```
 
 ## Running tests
@@ -13,6 +13,6 @@ Since the smart driver changes require us to build the debezium core as well, bu
 1. Compile PG connector code from the root directory with the above command.
 2. Start YugabyteDB instance using `yugabyted`:
    ```bash
-   ./bin/yugabyted start --ui=false --advertise_address=127.0.0.1 --master_flags="yb_enable_cdc_consistent_snapshot_streams=true,allowed_preview_flags_csv={yb_enable_cdc_consistent_snapshot_streams,ysql_yb_enable_replication_commands},ysql_yb_enable_replication_commands=true,ysql_TEST_enable_replication_slot_consumption=true" --tserver_flags="allowed_preview_flags_csv={yb_enable_cdc_consistent_snapshot_streams,ysql_yb_enable_replication_commands,cdcsdk_enable_dynamic_table_support},cdcsdk_enable_dynamic_table_support=true,cdcsdk_publication_list_refresh_interval_secs=3,ysql_yb_enable_replication_commands=true,yb_enable_cdc_consistent_snapshot_streams=true,ysql_TEST_enable_replication_slot_consumption=true,ysql_cdc_active_replication_slot_window_ms=0,ysql_sequence_cache_method=server"
+   ./bin/yugabyted start --ui=false --advertise_address=127.0.0.1 --master_flags="ysql_cdc_active_replication_slot_window_ms=0" --tserver_flags="allowed_preview_flags_csv={cdcsdk_enable_dynamic_table_support},cdcsdk_enable_dynamic_table_support=true,cdcsdk_publication_list_refresh_interval_secs=3,ysql_cdc_active_replication_slot_window_ms=0,ysql_sequence_cache_method=server"
    ```
 3. Run tests 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -2980,6 +2980,19 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     }
 
     @Test
+    public void shouldNotWorkWithReplicaIdentityChangeAndPgOutput() throws Exception {
+        final Configuration.Builder configBuilder = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SLOT_NAME, ReplicationConnection.Builder.DEFAULT_SLOT_NAME)
+                .with(PostgresConnectorConfig.PLUGIN_NAME, LogicalDecoder.PGOUTPUT)
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s2.a");
+
+        start(YugabyteDBConnector.class, configBuilder.build(), (success, message, error) -> {
+            assertFalse(success);
+        });
+    }
+
+    @Test
     public void shouldNotSkipMessagesWithoutChangeWithReplicaIdentityChange() throws Exception {
         testSkipMessagesWithoutChange(ReplicaIdentityInfo.ReplicaIdentity.CHANGE);
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBRecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBRecordsStreamProducerIT.java
@@ -1352,7 +1352,6 @@ public class YBRecordsStreamProducerIT extends AbstractRecordsProducerTest {
                 Envelope.FieldName.AFTER);
     }
 
-    @Ignore("hstore not supported yet")
     @Test
     @FixFor("DBZ-6379")
     public void shouldHandleToastedHstoreInHstoreMapMode() throws Exception {
@@ -1376,6 +1375,8 @@ public class YBRecordsStreamProducerIT extends AbstractRecordsProducerTest {
                 Envelope.FieldName.AFTER);
         statement = "UPDATE test_toast_table SET text = 'text';";
 
+        LOGGER.info("VKVK test verified till here");
+
         consumer.expects(1);
         executeAndWait(statement);
         consumer.process(record -> {
@@ -1384,12 +1385,10 @@ public class YBRecordsStreamProducerIT extends AbstractRecordsProducerTest {
                 assertEquals(Arrays.asList("id", "text", "col"), tbl.retrieveColumnNames());
             });
         });
-        colValue.clear();
-        colValue.put(DecoderDifferences.optionalToastedValuePlaceholder(), DecoderDifferences.optionalToastedValuePlaceholder());
+
+        // YB Note: Value for 'col' will not be present since replica identity is CHANGE.
         assertRecordSchemaAndValues(Arrays.asList(
-                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "text"),
-                new SchemaAndValueField("col", SchemaBuilder.map(SchemaBuilder.STRING_SCHEMA,
-                        SchemaBuilder.OPTIONAL_STRING_SCHEMA).optional().build(), colValue)),
+                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "text")),
                 consumer.remove(),
                 Envelope.FieldName.AFTER);
     }


### PR DESCRIPTION
This PR adds the following tests:
1. Streaming for a table with composite PK
2. Streaming with different replica identities with both plugins i.e. `yboutput` and `pgoutput`
3. Streaming changes for a table with foreign key