### PR TITLE
[DBZ-PGYB] Fixed bug resulting a `0` value in case of `pgoutput`

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PGTableSchemaBuilder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PGTableSchemaBuilder.java
@@ -293,6 +293,7 @@ public class PGTableSchemaBuilder extends TableSchemaBuilder {
                   result.put(fields[i], null);
                 }
               } else {
+                value = converter.convert(value);
                 result.put(fields[i], value);
               }
             }


### PR DESCRIPTION
## Problem

Suppose we have a column with a non-basic value like `timestamp` - the code for converting the values here is following:

```java
if (connectorConfig.plugin().isYBOutput()) {
    if (value != null && !UnchangedToastedReplicationMessageColumn.isUnchangedToastedValue(value)) {
        value = converter.convert(((Object[]) value)[0]);
        Struct cell = new Struct(fields[i].schema());
        cell.put("value", value);
        cell.put("set", true);
        result.put(fields[i], cell);
    } else {
        result.put(fields[i], null);
    }
} else {
    result.put(fields[i], value);
}
```

The `else` block above has a missing line which should utilise a converter for the value.

## Solution

This PR fixes the `else` block with the required conversion and adds tests verifying the same for `pgoutput` by adding the following logic:

```java
...
else {
  value = converter.convert(value);
  result.put(fields[i], value);
}
...
```