### PR TITLE
[DBZ-PGYB] Modify GitHub Action to publish to set proper versions

### DIFF
--- a/.github/workflows/yb-release-quay.yml
+++ b/.github/workflows/yb-release-quay.yml
@@ -23,11 +23,11 @@ jobs:
       - name: Checkout Action
         uses: actions/checkout@v4
       
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       
       - name: Set version for release
         run: ./mvnw versions:set -DnewVersion=${{ inputs.version }}

--- a/.github/workflows/yb-release-quay.yml
+++ b/.github/workflows/yb-release-quay.yml
@@ -23,11 +23,14 @@ jobs:
       - name: Checkout Action
         uses: actions/checkout@v4
       
-      - name: Set up Java 17
+      - name: Set up Java 11
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 11
+      
+      - name: Set version for release
+        run: ./mvnw versions:set -DnewVersion=${{ inputs.version }}
       
       - name: Compile jar file
         run: ./mvnw clean install -Dquick -pl debezium-connector-postgres -am
@@ -58,8 +61,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./debezium-connector-postgres/target/debezium-connector-yugabytedb-dz.2.5.2.yb.2024.1-SNAPSHOT-jar-with-dependencies.jar
-          asset_name: debezium-connector-postgres-${{ inputs.version }}-jar-with-dependencies.jar
+          asset_path: ./debezium-connector-postgres/target/debezium-connector-yugabytedb-${{ inputs.version }}-jar-with-dependencies.jar
+          asset_name: debezium-connector-yugabytedb-${{ inputs.version }}-jar-with-dependencies.jar
           asset_content_type: application/java-archive
     #   Commenting the code to upload a light jar for the time being.
     #   - name: Upload fat jar to GitHub release


### PR DESCRIPTION
This PR introduces the following change:
* Version of the pom in the jar file will now be the same as the one being specified in the input form