### PR TITLE
[DBZ-PGYB][yugabyte/yuyabyte-db#24204] Changes to support LSN types with replication slot

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -375,7 +375,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     }
 
     public enum LsnType implements EnumeratedValue {
-        SEQUENCE("sequence") {
+        SEQUENCE("SEQUENCE") {
             @Override
             public String getLsnTypeName() {
                 return getValue();
@@ -391,7 +391,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                 return false;
             }
         },
-        HYBRID_TIME("hybrid_time") {
+        HYBRID_TIME("HYBRID_TIME") {
             @Override
             public String getLsnTypeName() {
                 return getValue();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -374,6 +374,62 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         }
     }
 
+    public enum LsnType implements EnumeratedValue {
+        SEQUENCE("sequence") {
+            @Override
+            public String getLsnTypeName() {
+                return getValue();
+            }
+
+            @Override
+            public boolean isSequence() {
+                return true;
+            }
+
+            @Override
+            public boolean isHybridTime() {
+                return false;
+            }
+        },
+        HYBRID_TIME("hybrid_time") {
+            @Override
+            public String getLsnTypeName() {
+                return getValue();
+            }
+
+            @Override
+            public boolean isSequence() {
+                return false;
+            }
+
+            @Override
+            public boolean isHybridTime() {
+                return true;
+            }
+        };
+
+        private final String lsnTypeName;
+
+        LsnType(String lsnTypeName) {
+            this.lsnTypeName = lsnTypeName;
+        }
+
+        public static LsnType parse(String s) {
+            return valueOf(s.trim().toUpperCase());
+        }
+
+        @Override
+        public String getValue() {
+            return lsnTypeName;
+        }
+
+        public abstract boolean isSequence();
+
+        public abstract boolean isHybridTime();
+
+        public abstract String getLsnTypeName();
+    }
+
     public enum LogicalDecoder implements EnumeratedValue {
         PGOUTPUT("pgoutput") {
             @Override
@@ -571,6 +627,14 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                     + "' and '" + LogicalDecoder.YBOUTPUT.getValue()
                     + "'. " +
                     "Defaults to '" + LogicalDecoder.YBOUTPUT.getValue() + "'.");
+
+    public static final Field SLOT_LSN_TYPE = Field.create("slot.lsn.type")
+            .withDisplayName("Slot LSN type")
+            .withType(Type.STRING)
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.MEDIUM)
+            .withEnum(LsnType.class, LsnType.SEQUENCE)
+            .withDescription("LSN type being used with the replication slot");
 
     public static final Field SLOT_NAME = Field.create("slot.name")
             .withDisplayName("Slot")
@@ -1032,6 +1096,10 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         return getConfig().getString(SLOT_NAME);
     }
 
+    public LsnType slotLsnType() {
+        return LsnType.parse(getConfig().getString(SLOT_LSN_TYPE));
+    }
+
     protected boolean dropSlotOnStop() {
         if (getConfig().hasKey(DROP_SLOT_ON_STOP.name())) {
             return getConfig().getBoolean(DROP_SLOT_ON_STOP);
@@ -1154,6 +1222,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                     DATABASE_NAME,
                     PLUGIN_NAME,
                     SLOT_NAME,
+                    SLOT_LSN_TYPE,
                     PUBLICATION_NAME,
                     PUBLICATION_AUTOCREATE_MODE,
                     REPLICA_IDENTITY_AUTOSET_VALUES,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -230,6 +230,8 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                                 replicationConnection.getConnectedNodeIp());
                     }
 
+                    // For the HybridTime mode, we always want to resume from the position of last commit so that we
+                    // send complete transactions and do not resume from the last event stored LSN.
                     Lsn lastStoredLsn = connectorConfig.slotLsnType().isHybridTime() ? walPosition.getLastCommitStoredLsn() : walPosition.getLastEventStoredLsn();
                     replicationStream.set(replicationConnection.startStreaming(lastStoredLsn, walPosition));
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -214,7 +214,8 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                     } catch (Exception e) {
                         LOGGER.info("Commit failed while preparing for reconnect", e);
                     }
-                    walPosition.enableFiltering();
+                    // Do not filter anything.
+                    // walPosition.enableFiltering();
                     stream.stopKeepAlive();
                     replicationConnection.reconnect();
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -214,8 +214,13 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                     } catch (Exception e) {
                         LOGGER.info("Commit failed while preparing for reconnect", e);
                     }
-                    // Do not filter anything.
-                    // walPosition.enableFiltering();
+                    
+                    // Do not filter anything when lsn type is hybrid time. This is to avoid the WalPositionLocator complaining
+                    // about the LSN not being present in the lsnSeen set.
+                    if (connectorConfig.slotLsnType().isSequence()) {
+                        walPosition.enableFiltering();
+                    }
+
                     stream.stopKeepAlive();
                     replicationConnection.reconnect();
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/Lsn.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/Lsn.java
@@ -144,7 +144,7 @@ public class Lsn implements Comparable<Lsn> {
 
     @Override
     public String toString() {
-        return "LSN{" + asString() + '}';
+        return "LSN{" + asLong() + '}';
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -115,6 +115,13 @@ public class PostgresConnection extends JdbcConnection {
             final PostgresValueConverter valueConverter = valueConverterBuilder.build(this.typeRegistry);
             this.defaultValueConverter = new PostgresDefaultValueConverter(valueConverter, this.getTimestampUtils(), typeRegistry);
         }
+
+        try {
+            LOGGER.debug("Setting GUC to disable catalog version check");
+            execute("SET yb_disable_catalog_version_check = true;");
+        } catch (Exception e) {
+            LOGGER.error("Error while setting GUC yb_disable_catalog_version_check", e);
+        }
     }
 
     public PostgresConnection(JdbcConfiguration config, PostgresValueConverterBuilder valueConverterBuilder, String connectionUsage) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -397,8 +397,8 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             offset = defaultStartingPos;
         }
         Lsn lsn = offset;
-        if (LOGGER.isInfoEnabled()) {
-            LOGGER.info("starting streaming from LSN '{}'", lsn);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("starting streaming from LSN '{}'", lsn);
         }
 
         final int maxRetries = connectorConfig.maxRetries();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -64,6 +64,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     private static Logger LOGGER = LoggerFactory.getLogger(PostgresReplicationConnection.class);
 
     private final String slotName;
+    private final PostgresConnectorConfig.LsnType lsnType;
     private final String publicationName;
     private final RelationalTableFilters tableFilter;
     private final PostgresConnectorConfig.AutoCreateMode publicationAutocreateMode;
@@ -114,6 +115,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
         this.connectorConfig = config;
         this.slotName = slotName;
+        this.lsnType = config.slotLsnType();
         this.publicationName = publicationName;
         this.tableFilter = tableFilter;
         this.publicationAutocreateMode = publicationAutocreateMode;
@@ -395,8 +397,8 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             offset = defaultStartingPos;
         }
         Lsn lsn = offset;
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("starting streaming from LSN '{}'", lsn);
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("starting streaming from LSN '{}'", lsn);
         }
 
         final int maxRetries = connectorConfig.maxRetries();
@@ -522,10 +524,11 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
         try (Statement stmt = pgConnection().createStatement()) {
             String createCommand = String.format(
-                    "CREATE_REPLICATION_SLOT \"%s\" %s LOGICAL %s",
+                    "CREATE_REPLICATION_SLOT \"%s\" %s LOGICAL %s %s",
                     slotName,
                     tempPart,
-                    plugin.getPostgresPluginName());
+                    plugin.getPostgresPluginName(),
+                    lsnType.getLsnTypeName());
             LOGGER.info("Creating replication slot with command {}", createCommand);
             stmt.execute(createCommand);
             // when we are in Postgres 9.4+, we can parse the slot creation info,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
@@ -91,7 +91,6 @@ public class WalPositionLocator {
                     startStreamingLsn = txStartLsn;
                     return Optional.of(startStreamingLsn);
                 }
-                LOGGER.info("Returning optional empty as resume LSN");
                 return Optional.empty();
             }
             lsnAfterLastEventStoredLsn = currentLsn;
@@ -101,18 +100,17 @@ public class WalPositionLocator {
             return Optional.of(startStreamingLsn);
         }
         if (currentLsn.equals(lastEventStoredLsn)) {
-            LOGGER.info("Current LSN is equal to the last event stored LSN {}", lastEventStoredLsn);
             storeLsnAfterLastEventStoredLsn = true;
         }
 
         if (lastCommitStoredLsn == null) {
             startStreamingLsn = firstLsnReceived;
-            LOGGER.info("Last commit stored LSN is null, returning firstLsnReceived {}", startStreamingLsn);
+            LOGGER.debug("Last commit stored LSN is null, returning firstLsnReceived {}", startStreamingLsn);
             return Optional.of(startStreamingLsn);
         }
 
         if (currentLsn.equals(lastCommitStoredLsn) && isLsnTypeHybridTime) {
-            LOGGER.info("Returning lastCommitStoredLsn {} for resuming", lastCommitStoredLsn);
+            LOGGER.debug("Returning lastCommitStoredLsn {} for resuming", lastCommitStoredLsn);
             return Optional.of(lastCommitStoredLsn);
         }
 
@@ -177,7 +175,7 @@ public class WalPositionLocator {
                     lsn,
                     lsnSeen));
         }
-        LOGGER.info("Message with LSN '{}' filtered", lsn);
+        LOGGER.debug("Message with LSN '{}' filtered", lsn);
         return true;
     }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -1010,6 +1010,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         Configuration config = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.getValue())
                 .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+                .with(PostgresConnectorConfig.SLOT_LSN_TYPE, "HYBRID_TIME")
                 .build();
         start(YugabyteDBConnector.class, config);
         assertConnectorIsRunning();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -1011,7 +1011,6 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         Configuration config = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.getValue())
                 .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
-                .with(PostgresConnectorConfig.SLOT_LSN_TYPE, "HYBRID_TIME")
                 .build();
         start(YugabyteDBConnector.class, config);
         assertConnectorIsRunning();


### PR DESCRIPTION
YugabyteDB logical replication now supports creating replication slots with two types of LSN:
1. `SEQUENCE` - This is a monotonic increasing number that will determine the record in global order within the context of a slot. However, this LSN can’t be compared across two LSN’s of different slots.
2. `HYBRID_TIME` - This will mean that the LSN will be denoted by the `HybridTime` of the transaction commit record. All the records of the transaction that is streamed will have the same LSN as that of the commit record. The user has to ensure that the changes of a transaction are applied in totality and the acknowledgement is sent only if the commit record of a transaction is processed. With this mode, the LSN value can be compared across the different slots.

To ensure that the connector also supports streaming for both LSN types, this PR introduces the following changes:
1. Adds a configuration property `slot.lsn.type` which accepts two parameters i.e. `SEQUENCE` or `HYBRID_TIME` with the default being `SEQUENCE`
    a. **Note that this property only accepts parameters in uppercase.**
2. Depending on the LSN type provided, the connector processes events accordingly.

This closes yugabyte/yuyabyte-db#24204