### PR TITLE
[DBZ-PGYB] Set transaction isolation level before executing snapshot query

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -296,7 +296,7 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
 
         // Regardless of whether consistent snapshot is enabled or not, we need to set the
         // transaction isolation level.
-        String transactionIsolationLevelStatement = "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE, READ ONLY, DEFERRABLE;";
+        String transactionIsolationLevelStatement = "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE, READ ONLY, DEFERRABLE;";
         LOGGER.info("Setting transaction isolation levels with statement {}", transactionIsolationLevelStatement);
         jdbcConnection.executeWithoutCommitting(transactionIsolationLevelStatement);
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -293,6 +293,12 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
         } else {
             LOGGER.info("Skipping setting snapshot time, snapshot data will not be consistent");
         }
+
+        // Regardless of whether consistent snapshot is enabled or not, we need to set the
+        // transaction isolation level.
+        String transactionIsolationLevelStatement = "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE, READ ONLY, DEFERRABLE;";
+        LOGGER.info("Setting transaction isolation levels with statement {}", transactionIsolationLevelStatement);
+        jdbcConnection.executeWithoutCommitting(transactionIsolationLevelStatement);
     }
 
     /**


### PR DESCRIPTION
This PR makes the changes to set the transaction isolation level to `SERIALIZABLE, READ ONLY, DEFERRABLE` before executing the snapshot read query.