### PR TITLE
[DBZ-PGYB] Restrict retries when retry count reaches limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN rm -rf debezium-connector-vitess
 WORKDIR /
 
 # Copy the Debezium Connector for Postgres adapted for YugabyteDB
-COPY debezium-connector-postgres/target/debezium-connector-yugabytedb-*.jar $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres
+COPY debezium-connector-postgres/target/debezium-connector-yugabytedb-*.jar $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres/
 
 # Set the TLS version to be used by Kafka processes
 ENV KAFKA_OPTS="-Djdk.tls.client.protocols=TLSv1.2 -javaagent:/kafka/etc/jmx_prometheus_javaagent-0.17.2.jar=8080:/kafka/etc/jmx-exporter/metrics.yml"

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -542,8 +542,8 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     protected static final int DEFAULT_SNAPSHOT_FETCH_SIZE = 10_240;
     protected static final int DEFAULT_MAX_RETRIES = 6;
     public static final Pattern YB_HOSTNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9-_.,:]+$");
-    public static final int YB_DEFAULT_ERRORS_MAX_RETRIES = 90;
-    public static final long YB_DEFAULT_RETRIABLE_RESTART_WAIT = 20000L;
+    public static final int YB_DEFAULT_ERRORS_MAX_RETRIES = 60;
+    public static final long YB_DEFAULT_RETRIABLE_RESTART_WAIT = 30000L;
 
     public static final Field PORT = RelationalDatabaseConnectorConfig.PORT
             .withDefault(DEFAULT_PORT);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -541,8 +541,6 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     protected static final int DEFAULT_PORT = 5_433;
     protected static final int DEFAULT_SNAPSHOT_FETCH_SIZE = 10_240;
     protected static final int DEFAULT_MAX_RETRIES = 6;
-    protected static final long DEFAULT_RETRIABLE_RESTART_EXPONENTIAL_DELAY_MIN_MS = 5_000;
-    protected static final long DEFAULT_RETRIABLE_RESTART_EXPONENTIAL_DELAY_MAX_MS = 120_000;
     public static final Pattern YB_HOSTNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9-_.,:]+$");
 
     public static final Field PORT = RelationalDatabaseConnectorConfig.PORT
@@ -1012,19 +1010,6 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                 return 0;
             });
 
-    public static final Field RETRIABLE_RESTART_EXPONENTIAL_DELAY_MIN_MS = Field.create("retriable.restart.exponential.delay.min.ms")
-            .withDisplayName("Minimum delay in case of retries for exponential backoff")
-            .withType(Type.LONG)
-            .withImportance(Importance.LOW)
-            .withDescription("The minimum delay between retry when following exponential backoff")
-            .withDefault(DEFAULT_RETRIABLE_RESTART_EXPONENTIAL_DELAY_MIN_MS);
-    public static final Field RETRIABLE_RESTART_EXPONENTIAL_DELAY_MAX_MS = Field.create("retriable.restart.exponential.delay.max.ms")
-            .withDisplayName("Maximum delay in case of retries for exponential backoff")
-            .withType(Type.LONG)
-            .withImportance(Importance.LOW)
-            .withDescription("The maximum delay between retry when following exponential backoff")
-            .withDefault(DEFAULT_RETRIABLE_RESTART_EXPONENTIAL_DELAY_MAX_MS);
-
     private final LogicalDecodingMessageFilter logicalDecodingMessageFilter;
     private final HStoreHandlingMode hStoreHandlingMode;
     private final IntervalHandlingMode intervalHandlingMode;
@@ -1156,14 +1141,6 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public String primaryKeyHashColumns() {
         return getConfig().getString(PRIMARY_KEY_HASH_COLUMNS);
-    }
-
-    public long retriableRestartExponentialDelayMinMs() {
-        return getConfig().getLong(RETRIABLE_RESTART_EXPONENTIAL_DELAY_MIN_MS);
-    }
-
-    public long retriableRestartExponentialDelayMaxMs() {
-        return getConfig().getLong(RETRIABLE_RESTART_EXPONENTIAL_DELAY_MAX_MS);
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -542,6 +542,8 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     protected static final int DEFAULT_SNAPSHOT_FETCH_SIZE = 10_240;
     protected static final int DEFAULT_MAX_RETRIES = 6;
     public static final Pattern YB_HOSTNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9-_.,:]+$");
+    public static final int YB_DEFAULT_ERRORS_MAX_RETRIES = 90;
+    public static final long YB_DEFAULT_RETRIABLE_RESTART_WAIT = 20000L;
 
     public static final Field PORT = RelationalDatabaseConnectorConfig.PORT
             .withDefault(DEFAULT_PORT);
@@ -627,6 +629,28 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withImportance(Importance.LOW)
             .withDescription("Whether or not to take a consistent snapshot of the tables." +
                            "Disabling this option may result in duplication of some already snapshot data in the streaming phase.");
+
+    public static final Field MAX_RETRIES_ON_ERROR = Field.create(ERRORS_MAX_RETRIES)
+            .withDisplayName("The maximum number of retries")
+            .withType(Type.INT)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 24))
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.LOW)
+            .withDefault(YB_DEFAULT_ERRORS_MAX_RETRIES)
+            .withValidation(Field::isInteger)
+            .withDescription(
+                    "The maximum number of retries on connection errors before failing (-1 = no limit, 0 = disabled, > 0 = num of retries).");
+
+    public static final Field RETRIABLE_RESTART_WAIT = Field.create("retriable.restart.connector.wait.ms")
+            .withDisplayName("Retriable restart wait (ms)")
+            .withType(Type.LONG)
+            .withGroup(Field.createGroupEntry(Field.Group.ADVANCED, 18))
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.LOW)
+            .withDefault(YB_DEFAULT_RETRIABLE_RESTART_WAIT)
+            .withDescription(
+                    "Time to wait before restarting connector after retriable exception occurs. Defaults to " + YB_DEFAULT_RETRIABLE_RESTART_WAIT + "ms.")
+            .withValidation(Field::isPositiveLong);
 
     public enum AutoCreateMode implements EnumeratedValue {
         /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -541,6 +541,8 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     protected static final int DEFAULT_PORT = 5_433;
     protected static final int DEFAULT_SNAPSHOT_FETCH_SIZE = 10_240;
     protected static final int DEFAULT_MAX_RETRIES = 6;
+    protected static final long DEFAULT_RETRIABLE_RESTART_EXPONENTIAL_DELAY_MIN_MS = 5_000;
+    protected static final long DEFAULT_RETRIABLE_RESTART_EXPONENTIAL_DELAY_MAX_MS = 120_000;
     public static final Pattern YB_HOSTNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9-_.,:]+$");
 
     public static final Field PORT = RelationalDatabaseConnectorConfig.PORT
@@ -1010,6 +1012,19 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                 return 0;
             });
 
+    public static final Field RETRIABLE_RESTART_EXPONENTIAL_DELAY_MIN_MS = Field.create("retriable.restart.exponential.delay.min.ms")
+            .withDisplayName("Minimum delay in case of retries for exponential backoff")
+            .withType(Type.LONG)
+            .withImportance(Importance.LOW)
+            .withDescription("The minimum delay between retry when following exponential backoff")
+            .withDefault(DEFAULT_RETRIABLE_RESTART_EXPONENTIAL_DELAY_MIN_MS);
+    public static final Field RETRIABLE_RESTART_EXPONENTIAL_DELAY_MAX_MS = Field.create("retriable.restart.exponential.delay.max.ms")
+            .withDisplayName("Maximum delay in case of retries for exponential backoff")
+            .withType(Type.LONG)
+            .withImportance(Importance.LOW)
+            .withDescription("The maximum delay between retry when following exponential backoff")
+            .withDefault(DEFAULT_RETRIABLE_RESTART_EXPONENTIAL_DELAY_MAX_MS);
+
     private final LogicalDecodingMessageFilter logicalDecodingMessageFilter;
     private final HStoreHandlingMode hStoreHandlingMode;
     private final IntervalHandlingMode intervalHandlingMode;
@@ -1141,6 +1156,14 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public String primaryKeyHashColumns() {
         return getConfig().getString(PRIMARY_KEY_HASH_COLUMNS);
+    }
+
+    public long retriableRestartExponentialDelayMinMs() {
+        return getConfig().getLong(RETRIABLE_RESTART_EXPONENTIAL_DELAY_MIN_MS);
+    }
+
+    public long retriableRestartExponentialDelayMaxMs() {
+        return getConfig().getLong(RETRIABLE_RESTART_EXPONENTIAL_DELAY_MAX_MS);
     }
 
     @Override


### PR DESCRIPTION
## Problem

With the current retry model, it was being noticed that the connector ended up retrying infinitely whenever an exception was thrown. This could lead to false positives that the connector is still running while the retries will keep failing.

## Solution

This PR addresses the issue by adding a check to the task layer so now if the retry count reaches the maximum value, the connector will exit and the task will reach in a failed state - this will help the end user know the status of the task and act accordingly.

This PR also redefines the following properties and changes their default values:
1. `errors.max.retries` - new default value is 60
2. `retriable.restart.connector.wait.ms` - new default value is 30000 (30s)

With the above change, the complete retry duration with the above default configuration will now be 30 minutes. This effectively means that if the connector/s task fails after exhausting all the retries then it will go into a `FAILED` state.

For example, if the connector is needed to retry for a total of 30 minutes then we can handle it in 2 ways:
1. **By fixing the number of retries:** Let's say we want the number of retries to be fixed to 15 so we can now configure our retry delay accordingly i.e. `30 / 15 = 2 minutes = 120 s = 120000 ms`, so the configuration will now add:

```json
"retriable.restart.connector.wait.ms":"120000",
"errors.max.retries":"15"
```

4. **By fixing the retry delay:** If we want to have a retry delay of a minute then we will configure the number of retries accordingly i.e. `30 / 1 = 30 retries`, so the configuration will now be:

```json
"retriable.restart.connector.wait.ms":"60000",
"errors.max.retries":"30"
```