### PR TITLE
[DBZ-PGYB][yugabyte/yugabyte-db#25716] Set GUC to disable catalog version check for connections

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -284,7 +284,7 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
         return snapshotter.buildSnapshotQuery(tableId, columns);
     }
 
-    protected void disableCatalogVersionCheckStatement() throws SQLException {
+    protected void disableCatalogVersionCheck() throws SQLException {
         final String disableCatalogVersionCheckStmt =
            "DO " +
            "LANGUAGE plpgsql $$ " +
@@ -303,7 +303,7 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
         } catch (SQLException sqle) {
             if (sqle.getMessage().contains("GUC not found")) {
                 LOGGER.warn("GUC not present: yb_disable_catalog_version_check");
-                jdbcConnection.execute("COMMIT;");
+                jdbcConnection.execute("ABORT;");
             } else {
                 throw sqle;
             }
@@ -311,7 +311,7 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
     }
     protected void setSnapshotTransactionIsolationLevel(boolean isOnDemand) throws SQLException {
         if (!YugabyteDBServer.isEnabled() || connectorConfig.isYbConsistentSnapshotEnabled()) {
-            disableCatalogVersionCheckStatement();
+            disableCatalogVersionCheck();
 
             LOGGER.info("Setting isolation level");
             String transactionStatement = snapshotter.snapshotTransactionIsolationLevelStatement(slotCreatedInfo, isOnDemand);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -284,8 +284,35 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
         return snapshotter.buildSnapshotQuery(tableId, columns);
     }
 
+    protected void disableCatalogVersionCheckStatement() throws SQLException {
+        final String disableCatalogVersionCheckStmt =
+           "DO " +
+           "LANGUAGE plpgsql $$ " +
+           "BEGIN " +
+               "SET yb_disable_catalog_version_check = true; " +
+           "EXCEPTION " +
+               "WHEN sqlstate '42704' THEN "+
+                   "RAISE EXCEPTION 'GUC not found'; " +
+               "WHEN OTHERS THEN " +
+                   "CALL disable_catalog_version_check(); " +
+           "END $$;";
+
+        LOGGER.info("Disabling catalog version check with statement: {}", disableCatalogVersionCheckStmt);
+        try {
+            jdbcConnection.execute(disableCatalogVersionCheckStmt);
+        } catch (SQLException sqle) {
+            if (sqle.getMessage().contains("GUC not found")) {
+                LOGGER.warn("GUC not present: yb_disable_catalog_version_check");
+                jdbcConnection.execute("COMMIT;");
+            } else {
+                throw sqle;
+            }
+        }
+    }
     protected void setSnapshotTransactionIsolationLevel(boolean isOnDemand) throws SQLException {
         if (!YugabyteDBServer.isEnabled() || connectorConfig.isYbConsistentSnapshotEnabled()) {
+            disableCatalogVersionCheckStatement();
+
             LOGGER.info("Setting isolation level");
             String transactionStatement = snapshotter.snapshotTransactionIsolationLevelStatement(slotCreatedInfo, isOnDemand);
             LOGGER.info("Opening transaction with statement {}", transactionStatement);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -117,10 +117,10 @@ public class PostgresConnection extends JdbcConnection {
         }
 
         try {
-            LOGGER.info("Setting GUC yb_disable_catalog_version_check");
+            LOGGER.debug("Setting GUC to disable catalog version check");
             execute("SET yb_disable_catalog_version_check = true;");
         } catch (Exception e) {
-            LOGGER.info("Error while setting GUC yb_disable_catalog_version_check", e);
+            LOGGER.error("Error while setting GUC yb_disable_catalog_version_check", e);
         }
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -115,13 +115,6 @@ public class PostgresConnection extends JdbcConnection {
             final PostgresValueConverter valueConverter = valueConverterBuilder.build(this.typeRegistry);
             this.defaultValueConverter = new PostgresDefaultValueConverter(valueConverter, this.getTimestampUtils(), typeRegistry);
         }
-
-        try {
-            LOGGER.debug("Setting GUC to disable catalog version check");
-            execute("SET yb_disable_catalog_version_check = true;");
-        } catch (Exception e) {
-            LOGGER.error("Error while setting GUC yb_disable_catalog_version_check", e);
-        }
     }
 
     public PostgresConnection(JdbcConfiguration config, PostgresValueConverterBuilder valueConverterBuilder, String connectionUsage) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -115,6 +115,13 @@ public class PostgresConnection extends JdbcConnection {
             final PostgresValueConverter valueConverter = valueConverterBuilder.build(this.typeRegistry);
             this.defaultValueConverter = new PostgresDefaultValueConverter(valueConverter, this.getTimestampUtils(), typeRegistry);
         }
+
+        try {
+            LOGGER.info("Setting GUC yb_disable_catalog_version_check");
+            execute("SET yb_disable_catalog_version_check = true;");
+        } catch (Exception e) {
+            LOGGER.info("Error while setting GUC yb_disable_catalog_version_check", e);
+        }
     }
 
     public PostgresConnection(JdbcConfiguration config, PostgresValueConverterBuilder valueConverterBuilder, String connectionUsage) {


### PR DESCRIPTION
## Problem

Recent changes in YugabyteDB introduced some changes where the `relcache/catcache` is reloaded as soon as `yb_read_time` is set. Now that caused an issue with the snapshots in the connector i.e. whenever the connector sets the `yb_read_time` and goes on to take the snapshot by running a `SELECT *` query, it gets the following error:

```
Caused by: io.debezium.DebeziumException: com.yugabyte.util.PSQLException: ERROR: The catalog snapshot used for this transaction has been invalidated: expected: 1, got: 0: MISMATCHED_SCHEMA
  Where: Catalog Version Mismatch: A DDL occurred while processing this query. Try again.
```

## Solution

As a workaround, we will now bypass the catalog version check by setting a GUC `yb_disable_catalog_version_check` at the connection level so that we do not hit the error during snapshot.

Note that we do not require this during streaming phase and since streaming used a separate object of `ReplicationConnection` class, we will not be modifying it.

This closes yugabyte/yugabyte-db#25716