### PR TITLE
[DBZ-PGYB] Bug fix to use correct getter for maximum retries

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -1111,6 +1111,11 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         return getConfig().getInteger(MAX_RETRIES);
     }
 
+    @Override
+    public int getMaxRetriesOnError() {
+        return getConfig().getInteger(MAX_RETRIES_ON_ERROR);
+    }
+
     public Duration retryDelay() {
         return Duration.ofMillis(getConfig().getInteger(RETRY_DELAY_MS));
     }


### PR DESCRIPTION
This PR fixes a method by overriding it in `PostgresConnectorConfig` class to use the value we have defined as our maximum retry count. Currently, the code uses the value defined in the base class which defaults to the the connector going for unlimited retries.