### PR TITLE
[#26004] Make load-balance property configurable

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -96,7 +96,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
 
             final Charset databaseCharset;
             try (PostgresConnection tempConnection = new PostgresConnection(connectorConfig.getJdbcConfig(),
-                    PostgresConnection.CONNECTION_GENERAL, connectorConfig.isYbLoadBalanceConnections())) {
+                    PostgresConnection.CONNECTION_GENERAL, connectorConfig.ybShouldLoadBalanceConnections())) {
                 databaseCharset = tempConnection.getDatabaseCharset();
             }
 
@@ -107,7 +107,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
 
             MainConnectionProvidingConnectionFactory<PostgresConnection> connectionFactory = new DefaultMainConnectionProvidingConnectionFactory<>(
                     () -> new PostgresConnection(connectorConfig.getJdbcConfig(), valueConverterBuilder,
-                            PostgresConnection.CONNECTION_GENERAL, connectorConfig.isYbLoadBalanceConnections()));
+                            PostgresConnection.CONNECTION_GENERAL, connectorConfig.ybShouldLoadBalanceConnections()));
             // Global JDBC connection used both for snapshotting and streaming.
             // Must be able to resolve datatypes.
             jdbcConnection = connectionFactory.mainConnection();
@@ -218,7 +218,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                                 schemaNameAdjuster,
                                 () -> new PostgresConnection(connectorConfig.getJdbcConfig(),
                                         PostgresConnection.CONNECTION_GENERAL,
-                                        connectorConfig.isYbLoadBalanceConnections()),
+                                        connectorConfig.ybShouldLoadBalanceConnections()),
                                         exception -> {
                                     String sqlErrorId = exception.getSQLState();
                                     switch (sqlErrorId) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -95,7 +95,8 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
             }
 
             final Charset databaseCharset;
-            try (PostgresConnection tempConnection = new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_GENERAL)) {
+            try (PostgresConnection tempConnection = new PostgresConnection(connectorConfig.getJdbcConfig(),
+                    PostgresConnection.CONNECTION_GENERAL, connectorConfig.isYbLoadBalanceConnections())) {
                 databaseCharset = tempConnection.getDatabaseCharset();
             }
 
@@ -105,7 +106,8 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                     typeRegistry);
 
             MainConnectionProvidingConnectionFactory<PostgresConnection> connectionFactory = new DefaultMainConnectionProvidingConnectionFactory<>(
-                    () -> new PostgresConnection(connectorConfig.getJdbcConfig(), valueConverterBuilder, PostgresConnection.CONNECTION_GENERAL));
+                    () -> new PostgresConnection(connectorConfig.getJdbcConfig(), valueConverterBuilder,
+                            PostgresConnection.CONNECTION_GENERAL, connectorConfig.isYbLoadBalanceConnections()));
             // Global JDBC connection used both for snapshotting and streaming.
             // Must be able to resolve datatypes.
             jdbcConnection = connectionFactory.mainConnection();
@@ -214,8 +216,10 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                         connectorConfig.createHeartbeat(
                                 topicNamingStrategy,
                                 schemaNameAdjuster,
-                                () -> new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_GENERAL),
-                                exception -> {
+                                () -> new PostgresConnection(connectorConfig.getJdbcConfig(),
+                                        PostgresConnection.CONNECTION_GENERAL,
+                                        connectorConfig.isYbLoadBalanceConnections()),
+                                        exception -> {
                                     String sqlErrorId = exception.getSQLState();
                                     switch (sqlErrorId) {
                                         case "57P01":

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
@@ -161,11 +161,11 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
         final ConfigValue hostnameValue = configValues.get(RelationalDatabaseConnectorConfig.HOSTNAME.name());
         // Try to connect to the database ...
         try (PostgresConnection connection = new PostgresConnection(postgresConfig.getJdbcConfig(),
-                PostgresConnection.CONNECTION_VALIDATE_CONNECTION, postgresConfig.isYbLoadBalanceConnections())) {
+                PostgresConnection.CONNECTION_VALIDATE_CONNECTION, postgresConfig.ybShouldLoadBalanceConnections())) {
             try {
                 // Prepare connection without initial statement execution
                 connection.connection(false);
-                testConnection(connection, postgresConfig.isYbLoadBalanceConnections());
+                testConnection(connection, postgresConfig.ybShouldLoadBalanceConnections());
 
                 // YB Note: This check validates that the WAL level is "logical" - skipping this
                 //          since it is not applicable to YugabyteDB.
@@ -177,7 +177,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
             }
             catch (SQLException e) {
                 LOGGER.error("Failed testing connection for {} with user '{}'",
-                        connection.connectionString(postgresConfig.isYbLoadBalanceConnections()),
+                        connection.connectionString(postgresConfig.ybShouldLoadBalanceConnections()),
                                 connection.username(), e);
                 hostnameValue.addErrorMessage("Error while validating connector config: " + e.getMessage());
             }
@@ -238,9 +238,9 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
         }
     }
 
-    private static void testConnection(PostgresConnection connection, Boolean load_balance) throws SQLException {
+    private static void testConnection(PostgresConnection connection, Boolean loadBalance) throws SQLException {
         connection.execute("SELECT version()");
-        LOGGER.info("Successfully tested connection for {} with user '{}'", connection.connectionString(load_balance),
+        LOGGER.info("Successfully tested connection for {} with user '{}'", connection.connectionString(loadBalance),
                 connection.username());
     }
 
@@ -254,7 +254,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
     public List<TableId> getMatchingCollections(Configuration config) {
         PostgresConnectorConfig connectorConfig = new PostgresConnectorConfig(config);
         try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(),
-                PostgresConnection.CONNECTION_GENERAL, connectorConfig.isYbLoadBalanceConnections())) {
+                PostgresConnection.CONNECTION_GENERAL, connectorConfig.ybShouldLoadBalanceConnections())) {
             return connection.readTableNames(connectorConfig.databaseName(), null, null, new String[]{ "TABLE" }).stream()
                     .filter(tableId -> connectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId))
                     .collect(Collectors.toList());

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
@@ -160,11 +160,12 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
         final PostgresConnectorConfig postgresConfig = new PostgresConnectorConfig(config);
         final ConfigValue hostnameValue = configValues.get(RelationalDatabaseConnectorConfig.HOSTNAME.name());
         // Try to connect to the database ...
-        try (PostgresConnection connection = new PostgresConnection(postgresConfig.getJdbcConfig(), PostgresConnection.CONNECTION_VALIDATE_CONNECTION)) {
+        try (PostgresConnection connection = new PostgresConnection(postgresConfig.getJdbcConfig(),
+                PostgresConnection.CONNECTION_VALIDATE_CONNECTION, postgresConfig.isYbLoadBalanceConnections())) {
             try {
                 // Prepare connection without initial statement execution
                 connection.connection(false);
-                testConnection(connection);
+                testConnection(connection, postgresConfig.isYbLoadBalanceConnections());
 
                 // YB Note: This check validates that the WAL level is "logical" - skipping this
                 //          since it is not applicable to YugabyteDB.
@@ -175,8 +176,9 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
                 checkLoginReplicationRoles(connection);
             }
             catch (SQLException e) {
-                LOGGER.error("Failed testing connection for {} with user '{}'", connection.connectionString(),
-                        connection.username(), e);
+                LOGGER.error("Failed testing connection for {} with user '{}'",
+                        connection.connectionString(postgresConfig.isYbLoadBalanceConnections()),
+                                connection.username(), e);
                 hostnameValue.addErrorMessage("Error while validating connector config: " + e.getMessage());
             }
         }
@@ -236,9 +238,9 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
         }
     }
 
-    private static void testConnection(PostgresConnection connection) throws SQLException {
+    private static void testConnection(PostgresConnection connection, Boolean load_balance) throws SQLException {
         connection.execute("SELECT version()");
-        LOGGER.info("Successfully tested connection for {} with user '{}'", connection.connectionString(),
+        LOGGER.info("Successfully tested connection for {} with user '{}'", connection.connectionString(load_balance),
                 connection.username());
     }
 
@@ -251,7 +253,8 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
     @Override
     public List<TableId> getMatchingCollections(Configuration config) {
         PostgresConnectorConfig connectorConfig = new PostgresConnectorConfig(config);
-        try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_GENERAL)) {
+        try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(),
+                PostgresConnection.CONNECTION_GENERAL, connectorConfig.isYbLoadBalanceConnections())) {
             return connection.readTableNames(connectorConfig.databaseName(), null, null, new String[]{ "TABLE" }).stream()
                     .filter(tableId -> connectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId))
                     .collect(Collectors.toList());

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -132,9 +132,9 @@ public class PostgresConnection extends JdbcConnection {
     }
 
     public PostgresConnection(JdbcConfiguration config, PostgresValueConverterBuilder valueConverterBuilder,
-            String connectionUsage, Boolean load_balance) {
+            String connectionUsage, Boolean loadBalance) {
         this(config, valueConverterBuilder, connectionUsage,
-                PostgresConnectorConfig.getConnectionFactory(config.getHostname(), load_balance));
+                PostgresConnectorConfig.getConnectionFactory(config.getHostname(), loadBalance));
     }
 
     /**
@@ -160,9 +160,9 @@ public class PostgresConnection extends JdbcConnection {
     }
 
     public PostgresConnection(PostgresConnectorConfig config, TypeRegistry typeRegistry, String connectionUsage,
-            Boolean load_balance) {
+            Boolean loadBalance) {
         this(config, typeRegistry, connectionUsage,
-                PostgresConnectorConfig.getConnectionFactory(config.getJdbcConfig().getHostname(), load_balance));
+                PostgresConnectorConfig.getConnectionFactory(config.getJdbcConfig().getHostname(), loadBalance));
     }
 
     /**
@@ -172,8 +172,8 @@ public class PostgresConnection extends JdbcConnection {
      * @param config {@link Configuration} instance, may not be null.
      * @param connectionUsage a symbolic name of the connection to be tracked in monitoring tools
      */
-    public PostgresConnection(JdbcConfiguration config, String connectionUsage, Boolean load_balance) {
-        this(config, null, connectionUsage, load_balance);
+    public PostgresConnection(JdbcConfiguration config, String connectionUsage, Boolean loadBalance) {
+        this(config, null, connectionUsage, loadBalance);
     }
 
     static JdbcConfiguration addDefaultSettings(JdbcConfiguration configuration, String connectionUsage) {
@@ -189,9 +189,9 @@ public class PostgresConnection extends JdbcConnection {
      *
      * @return a {@code String} where the variables in {@code urlPattern} are replaced with values from the configuration
      */
-    public String connectionString(Boolean load_balance) {
+    public String connectionString(Boolean loadBalance) {
         Pair<String, String> urlPatterns = PostgresConnectorConfig
-                .findAndReplaceLoadBalancePropertyValues(load_balance);
+                .findAndReplaceLoadBalancePropertyValues(loadBalance);
         String hostName = jdbcConfig.getHostname();
         if (hostName.contains(":")) {
             return connectionString(urlPatterns.getFirst());

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -41,6 +41,7 @@ import io.debezium.connector.postgresql.PostgresValueConverter;
 import io.debezium.connector.postgresql.TypeRegistry;
 import io.debezium.connector.postgresql.YugabyteDBServer;
 import io.debezium.connector.postgresql.spi.SlotState;
+import io.debezium.connector.postgresql.transforms.yugabytedb.Pair;
 import io.debezium.data.SpecialValueDecimal;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
@@ -71,12 +72,18 @@ public class PostgresConnection extends JdbcConnection {
     private static final Pattern EXPRESSION_DEFAULT_PATTERN = Pattern.compile("\\(+(?:.+(?:[+ - * / < > = ~ ! @ # % ^ & | ` ?] ?.+)+)+\\)");
     private static Logger LOGGER = LoggerFactory.getLogger(PostgresConnection.class);
 
-    public static final String MULTI_HOST_URL_PATTERN = "jdbc:yugabytedb://${" + JdbcConfiguration.HOSTNAME + "}/${" + JdbcConfiguration.DATABASE + "}?load-balance=true";
+    public static final String MULTI_HOST_URL_PATTERN = "jdbc:yugabytedb://${" + JdbcConfiguration.HOSTNAME + "}/${"
+            + JdbcConfiguration.DATABASE + "}?load-balance=${" + PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS
+            + "}";
     public static final String URL_PATTERN = "jdbc:yugabytedb://${" + JdbcConfiguration.HOSTNAME + "}:${"
-            + JdbcConfiguration.PORT + "}/${" + JdbcConfiguration.DATABASE + "}";
+            + JdbcConfiguration.PORT + "}/${" + JdbcConfiguration.DATABASE + "}?load-balance=${"
+            + PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS
+            + "}";
     protected static ConnectionFactory FACTORY = JdbcConnection.patternBasedFactory(URL_PATTERN,
             com.yugabyte.Driver.class.getName(),
-            PostgresConnection.class.getClassLoader(), JdbcConfiguration.PORT.withDefault(PostgresConnectorConfig.PORT.defaultValueAsString()));
+            PostgresConnection.class.getClassLoader(),
+            JdbcConfiguration.PORT.withDefault(PostgresConnectorConfig.PORT.defaultValueAsString()),
+            PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS);
 
     /**
      * Obtaining a replication slot may fail if there's a pending transaction. We're retrying to get a slot for 30 min.
@@ -124,8 +131,10 @@ public class PostgresConnection extends JdbcConnection {
         }
     }
 
-    public PostgresConnection(JdbcConfiguration config, PostgresValueConverterBuilder valueConverterBuilder, String connectionUsage) {
-        this(config, valueConverterBuilder, connectionUsage, PostgresConnectorConfig.getConnectionFactory(config.getHostname()));
+    public PostgresConnection(JdbcConfiguration config, PostgresValueConverterBuilder valueConverterBuilder,
+            String connectionUsage, Boolean load_balance) {
+        this(config, valueConverterBuilder, connectionUsage,
+                PostgresConnectorConfig.getConnectionFactory(config.getHostname(), load_balance));
     }
 
     /**
@@ -150,8 +159,10 @@ public class PostgresConnection extends JdbcConnection {
         this.jdbcConfig = config.getJdbcConfig();
     }
 
-    public PostgresConnection(PostgresConnectorConfig config, TypeRegistry typeRegistry, String connectionUsage) {
-        this(config, typeRegistry, connectionUsage, PostgresConnectorConfig.getConnectionFactory(config.getJdbcConfig().getHostname()));
+    public PostgresConnection(PostgresConnectorConfig config, TypeRegistry typeRegistry, String connectionUsage,
+            Boolean load_balance) {
+        this(config, typeRegistry, connectionUsage,
+                PostgresConnectorConfig.getConnectionFactory(config.getJdbcConfig().getHostname(), load_balance));
     }
 
     /**
@@ -161,8 +172,8 @@ public class PostgresConnection extends JdbcConnection {
      * @param config {@link Configuration} instance, may not be null.
      * @param connectionUsage a symbolic name of the connection to be tracked in monitoring tools
      */
-    public PostgresConnection(JdbcConfiguration config, String connectionUsage) {
-        this(config, null, connectionUsage);
+    public PostgresConnection(JdbcConfiguration config, String connectionUsage, Boolean load_balance) {
+        this(config, null, connectionUsage, load_balance);
     }
 
     static JdbcConfiguration addDefaultSettings(JdbcConfiguration configuration, String connectionUsage) {
@@ -178,12 +189,14 @@ public class PostgresConnection extends JdbcConnection {
      *
      * @return a {@code String} where the variables in {@code urlPattern} are replaced with values from the configuration
      */
-    public String connectionString() {
+    public String connectionString(Boolean load_balance) {
+        Pair<String, String> urlPatterns = PostgresConnectorConfig
+                .findAndReplaceLoadBalancePropertyValues(load_balance);
         String hostName = jdbcConfig.getHostname();
         if (hostName.contains(":")) {
-            return connectionString(MULTI_HOST_URL_PATTERN);
+            return connectionString(urlPatterns.getFirst());
         } else {
-            return connectionString(URL_PATTERN);
+            return connectionString(urlPatterns.getSecond());
         }
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -142,7 +142,8 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     }
 
     private ServerInfo.ReplicationSlot getSlotInfo() throws SQLException, InterruptedException {
-        try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_SLOT_INFO)) {
+        try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(),
+                PostgresConnection.CONNECTION_SLOT_INFO, connectorConfig.isYbLoadBalanceConnections())) {
             return connection.readReplicationSlotInfo(slotName, plugin.getPostgresPluginName());
         }
     }
@@ -807,7 +808,8 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         }
         if (dropSlotOnClose && dropSlot) {
             // we're dropping the replication slot via a regular - i.e. not a replication - connection
-            try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_DROP_SLOT)) {
+            try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(),
+                    PostgresConnection.CONNECTION_DROP_SLOT, connectorConfig.isYbLoadBalanceConnections())) {
                 connection.dropReplicationSlot(slotName);
             }
             catch (Throwable e) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -143,7 +143,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
     private ServerInfo.ReplicationSlot getSlotInfo() throws SQLException, InterruptedException {
         try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(),
-                PostgresConnection.CONNECTION_SLOT_INFO, connectorConfig.isYbLoadBalanceConnections())) {
+                PostgresConnection.CONNECTION_SLOT_INFO, connectorConfig.ybShouldLoadBalanceConnections())) {
             return connection.readReplicationSlotInfo(slotName, plugin.getPostgresPluginName());
         }
     }
@@ -809,7 +809,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         if (dropSlotOnClose && dropSlot) {
             // we're dropping the replication slot via a regular - i.e. not a replication - connection
             try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(),
-                    PostgresConnection.CONNECTION_DROP_SLOT, connectorConfig.isYbLoadBalanceConnections())) {
+                    PostgresConnection.CONNECTION_DROP_SLOT, connectorConfig.ybShouldLoadBalanceConnections())) {
                 connection.dropReplicationSlot(slotName);
             }
             catch (Throwable e) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/transforms/timescaledb/QueryInformationSchemaMetadata.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/transforms/timescaledb/QueryInformationSchemaMetadata.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.DebeziumException;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.relational.TableId;
@@ -52,7 +53,7 @@ public class QueryInformationSchemaMetadata extends AbstractTimescaleDbMetadata 
         connection = new PostgresConnection(
                 JdbcConfiguration.adapt(config.subset(CommonConnectorConfig.DATABASE_CONFIG_PREFIX, true)
                         .merge(config.subset(CommonConnectorConfig.DRIVER_CONFIG_PREFIX, true))),
-                "Debezium TimescaleDB metadata");
+                "Debezium TimescaleDB metadata", config.getBoolean(PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS));
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -262,6 +262,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         validateConfigField(validatedConfig, PostgresConnectorConfig.LOGICAL_DECODING_MESSAGE_PREFIX_EXCLUDE_LIST, null);
         validateConfigField(validatedConfig, PostgresConnectorConfig.LOGICAL_DECODING_MESSAGE_PREFIX_INCLUDE_LIST, null);
         validateConfigField(validatedConfig, PostgresConnectorConfig.YB_CONSISTENT_SNAPSHOT, Boolean.TRUE);
+        validateConfigField(validatedConfig, PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS, Boolean.TRUE);
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -140,7 +140,7 @@ public final class TestHelper {
      * @return the PostgresConnection instance; never null
      */
     public static PostgresConnection create() {
-        return new PostgresConnection(defaultJdbcConfig(), CONNECTION_TEST, true /* load_balance */);
+        return new PostgresConnection(defaultJdbcConfig(), CONNECTION_TEST, true /* loadBalance */);
     }
 
     /**
@@ -155,7 +155,7 @@ public final class TestHelper {
                 config.getJdbcConfig(),
                 getPostgresValueConverterBuilder(config),
                 CONNECTION_TEST,
-                config.isYbLoadBalanceConnections());
+                config.ybShouldLoadBalanceConnections());
     }
 
     /**
@@ -168,7 +168,7 @@ public final class TestHelper {
     public static PostgresConnection create(String appName) {
         return new PostgresConnection(
                 JdbcConfiguration.adapt(defaultJdbcConfig().edit().with("ApplicationName", appName).build()),
-                CONNECTION_TEST, true /* load_balance */);
+                CONNECTION_TEST, true /* loadBalance */);
     }
 
     /**
@@ -233,7 +233,7 @@ public final class TestHelper {
         final PostgresConnectorConfig config = new PostgresConnectorConfig(defaultConfig().build());
         try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(),
                 getPostgresValueConverterBuilder(config), CONNECTION_TEST,
-                config.isYbLoadBalanceConnections())) {
+                config.ybShouldLoadBalanceConnections())) {
             return connection.getTypeRegistry();
         }
     }
@@ -241,7 +241,7 @@ public final class TestHelper {
     public static PostgresDefaultValueConverter getDefaultValueConverter() {
         final PostgresConnectorConfig config = new PostgresConnectorConfig(defaultConfig().build());
         try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(),
-                getPostgresValueConverterBuilder(config), CONNECTION_TEST, config.isYbLoadBalanceConnections())) {
+                getPostgresValueConverterBuilder(config), CONNECTION_TEST, config.ybShouldLoadBalanceConnections())) {
             return connection.getDefaultValueConverter();
         }
     }
@@ -249,7 +249,7 @@ public final class TestHelper {
     public static Charset getDatabaseCharset() {
         final PostgresConnectorConfig config = new PostgresConnectorConfig(defaultConfig().build());
         try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(),
-                getPostgresValueConverterBuilder(config), CONNECTION_TEST, config.isYbLoadBalanceConnections())) {
+                getPostgresValueConverterBuilder(config), CONNECTION_TEST, config.ybShouldLoadBalanceConnections())) {
             return connection.getDatabaseCharset();
         }
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -140,7 +140,7 @@ public final class TestHelper {
      * @return the PostgresConnection instance; never null
      */
     public static PostgresConnection create() {
-        return new PostgresConnection(defaultJdbcConfig(), CONNECTION_TEST);
+        return new PostgresConnection(defaultJdbcConfig(), CONNECTION_TEST, true /* load_balance */);
     }
 
     /**
@@ -154,7 +154,8 @@ public final class TestHelper {
         return new PostgresConnection(
                 config.getJdbcConfig(),
                 getPostgresValueConverterBuilder(config),
-                CONNECTION_TEST);
+                CONNECTION_TEST,
+                config.isYbLoadBalanceConnections());
     }
 
     /**
@@ -165,7 +166,9 @@ public final class TestHelper {
      * @return the PostgresConnection instance; never null
      */
     public static PostgresConnection create(String appName) {
-        return new PostgresConnection(JdbcConfiguration.adapt(defaultJdbcConfig().edit().with("ApplicationName", appName).build()), CONNECTION_TEST);
+        return new PostgresConnection(
+                JdbcConfiguration.adapt(defaultJdbcConfig().edit().with("ApplicationName", appName).build()),
+                CONNECTION_TEST, true /* load_balance */);
     }
 
     /**
@@ -228,21 +231,25 @@ public final class TestHelper {
 
     public static TypeRegistry getTypeRegistry() {
         final PostgresConnectorConfig config = new PostgresConnectorConfig(defaultConfig().build());
-        try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(), getPostgresValueConverterBuilder(config), CONNECTION_TEST)) {
+        try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(),
+                getPostgresValueConverterBuilder(config), CONNECTION_TEST,
+                config.isYbLoadBalanceConnections())) {
             return connection.getTypeRegistry();
         }
     }
 
     public static PostgresDefaultValueConverter getDefaultValueConverter() {
         final PostgresConnectorConfig config = new PostgresConnectorConfig(defaultConfig().build());
-        try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(), getPostgresValueConverterBuilder(config), CONNECTION_TEST)) {
+        try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(),
+                getPostgresValueConverterBuilder(config), CONNECTION_TEST, config.isYbLoadBalanceConnections())) {
             return connection.getDefaultValueConverter();
         }
     }
 
     public static Charset getDatabaseCharset() {
         final PostgresConnectorConfig config = new PostgresConnectorConfig(defaultConfig().build());
-        try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(), getPostgresValueConverterBuilder(config), CONNECTION_TEST)) {
+        try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(),
+                getPostgresValueConverterBuilder(config), CONNECTION_TEST, config.isYbLoadBalanceConnections())) {
             return connection.getDatabaseCharset();
         }
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
@@ -239,7 +239,7 @@ public class PostgresConnectionIT {
             assertTrue(replConnection.isConnected());
         }
         try (PostgresConnection withIdleTransaction = new PostgresConnection(JdbcConfiguration.adapt(TestHelper.defaultJdbcConfig()),
-                PostgresConnection.CONNECTION_GENERAL);
+                PostgresConnection.CONNECTION_GENERAL,true /* load_balance */);
                 PostgresConnection withEmptyConfirmedFlushLSN = buildConnectionWithEmptyConfirmedFlushLSN(slotName)) {
             withIdleTransaction.setAutoCommit(false);
             withIdleTransaction.query("select 1", connection -> {
@@ -253,7 +253,7 @@ public class PostgresConnectionIT {
 
     // "fake" a pg95 response by not returning confirmed_flushed_lsn
     private PostgresConnection buildPG95PGConn(String name) {
-        return new PostgresConnection(JdbcConfiguration.adapt(TestHelper.defaultJdbcConfig()), name) {
+        return new PostgresConnection(JdbcConfiguration.adapt(TestHelper.defaultJdbcConfig()), name, true /* load_balance */) {
             @Override
             protected ServerInfo.ReplicationSlot queryForSlot(String slotName, String database, String pluginName,
                                                               ResultSetMapper<ServerInfo.ReplicationSlot> map)
@@ -270,7 +270,7 @@ public class PostgresConnectionIT {
     }
 
     private PostgresConnection buildConnectionWithEmptyConfirmedFlushLSN(String name) {
-        return new PostgresConnection(JdbcConfiguration.adapt(TestHelper.defaultJdbcConfig()), name) {
+        return new PostgresConnection(JdbcConfiguration.adapt(TestHelper.defaultJdbcConfig()), name, true /* load_balance */) {
             @Override
             protected ServerInfo.ReplicationSlot queryForSlot(String slotName, String database, String pluginName,
                                                               ResultSetMapper<ServerInfo.ReplicationSlot> map)

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
@@ -239,7 +239,7 @@ public class PostgresConnectionIT {
             assertTrue(replConnection.isConnected());
         }
         try (PostgresConnection withIdleTransaction = new PostgresConnection(JdbcConfiguration.adapt(TestHelper.defaultJdbcConfig()),
-                PostgresConnection.CONNECTION_GENERAL,true /* load_balance */);
+                PostgresConnection.CONNECTION_GENERAL,true /* loadBalance */);
                 PostgresConnection withEmptyConfirmedFlushLSN = buildConnectionWithEmptyConfirmedFlushLSN(slotName)) {
             withIdleTransaction.setAutoCommit(false);
             withIdleTransaction.query("select 1", connection -> {
@@ -253,7 +253,7 @@ public class PostgresConnectionIT {
 
     // "fake" a pg95 response by not returning confirmed_flushed_lsn
     private PostgresConnection buildPG95PGConn(String name) {
-        return new PostgresConnection(JdbcConfiguration.adapt(TestHelper.defaultJdbcConfig()), name, true /* load_balance */) {
+        return new PostgresConnection(JdbcConfiguration.adapt(TestHelper.defaultJdbcConfig()), name, true /* loadBalance */) {
             @Override
             protected ServerInfo.ReplicationSlot queryForSlot(String slotName, String database, String pluginName,
                                                               ResultSetMapper<ServerInfo.ReplicationSlot> map)
@@ -270,7 +270,7 @@ public class PostgresConnectionIT {
     }
 
     private PostgresConnection buildConnectionWithEmptyConfirmedFlushLSN(String name) {
-        return new PostgresConnection(JdbcConfiguration.adapt(TestHelper.defaultJdbcConfig()), name, true /* load_balance */) {
+        return new PostgresConnection(JdbcConfiguration.adapt(TestHelper.defaultJdbcConfig()), name, true /* loadBalance */) {
             @Override
             protected ServerInfo.ReplicationSlot queryForSlot(String slotName, String database, String pluginName,
                                                               ResultSetMapper<ServerInfo.ReplicationSlot> map)

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDbDatabaseTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDbDatabaseTest.java
@@ -53,7 +53,8 @@ public class TimescaleDbDatabaseTest extends AbstractConnectorTest {
     public void prepareDatabase() throws Exception {
         Startables.deepStart(timescaleDbContainer).join();
         connection = new PostgresConnection(
-                TestHelper.defaultJdbcConfig(timescaleDbContainer.getHost(), timescaleDbContainer.getMappedPort(5432)), TestHelper.CONNECTION_TEST);
+                TestHelper.defaultJdbcConfig(timescaleDbContainer.getHost(), timescaleDbContainer.getMappedPort(5432)),
+                TestHelper.CONNECTION_TEST, true /* load_balance */);
         dropPublication(connection);
         connection.execute(
                 "DROP TABLE IF EXISTS conditions",

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDbDatabaseTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDbDatabaseTest.java
@@ -54,7 +54,7 @@ public class TimescaleDbDatabaseTest extends AbstractConnectorTest {
         Startables.deepStart(timescaleDbContainer).join();
         connection = new PostgresConnection(
                 TestHelper.defaultJdbcConfig(timescaleDbContainer.getHost(), timescaleDbContainer.getMappedPort(5432)),
-                TestHelper.CONNECTION_TEST, true /* load_balance */);
+                TestHelper.CONNECTION_TEST, true /* loadBalance */);
         dropPublication(connection);
         connection.execute(
                 "DROP TABLE IF EXISTS conditions",


### PR DESCRIPTION
### Description
Currently the `load-balance` property in connection URL is hardcoded to true for Multi host pattern. We do not mention any value to this property for single host pattern and as a result it always defaults to false.

This PR makes this property configurable via a connector config. A new connector config `yb.load.balance.connections` has been introduced which determines the value of `load-balance` property in the connection URL. When set to true, the driver fetches and maintains a list of nodes from the given endpoint (even when a single hostname is provided in the config) in the universe and distributes the connections equally across these nodes.

The default value of `yb.load.balance.connections` is true. We may want to set this to false while testing scenarios where we want to have imbalance of replication connections (walsenders) across nodes.

### Testing
Manually tested out by toggling the values of this config and providing single host name in the connector config with a 3 node universe.