### PR TITLE
[yugabyte/yugabyte-db#26107] Parellel streaming changes

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -745,7 +745,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withImportance(Importance.LOW)
             .withDescription("Comma separated values for multiple publication names");
 
-    public static final Field RANGES = Field.create("ranges")
+    public static final Field SLOT_RANGES = Field.create("slot.ranges")
             .withDisplayName("Ranges on which a slot is supposed to operate")
             .withImportance(Importance.LOW)
             .withDescription("Semi-colon separated values for hash ranges to be polled by tasks.");
@@ -1320,7 +1320,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     }
 
     public List<String> getSlotRanges() {
-        return List.of(getConfig().getString(RANGES).trim().split(";"));
+        return List.of(getConfig().getString(SLOT_RANGES).trim().split(";"));
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -1585,11 +1585,9 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         String mode = config.getString(STREAMING_MODE);
         int problemCount = 0;
 
-        if (!Strings.isNullOrBlank(mode)) {
-            if (!StreamingMode.parse(mode).isParallel()) {
-                problems.accept(field, config.getString(field), "Configuration is only valid with parallel streaming mode");
-                ++problemCount;
-            }
+        if (!StreamingMode.parse(mode).isParallel()) {
+            problems.accept(field, config.getString(field), "Configuration is only valid with parallel streaming mode");
+            ++problemCount;
         }
 
         return problemCount;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -165,6 +165,16 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                     snapshotter.init(connectorConfig, previousOffset.asOffsetState(), slotInfo);
                 }
 
+                // TODO Vaibhav: Read more in https://issues.redhat.com/browse/DBZ-2118
+                if (connectorConfig.streamingMode().isParallel()) {
+                    try {
+                        jdbcConnection.commit();
+                    }
+                    catch (SQLException e) {
+                        throw new DebeziumException(e);
+                    }
+                }
+
                 SlotCreationResult slotCreatedInfo = null;
                 if (snapshotter.shouldStream() || (YugabyteDBServer.isEnabled() && (slotInfo == null))) {
                     replicationConnection = createReplicationConnection(this.taskContext,
@@ -189,7 +199,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                     }
                 }
 
-                // TODO Vaibhav: Connector works without committing here as well, read more in https://issues.redhat.com/browse/DBZ-2118
+                // TODO Vaibhav: Read more in https://issues.redhat.com/browse/DBZ-2118
                 if (!connectorConfig.streamingMode().isParallel()) {
                     try {
                         jdbcConnection.commit();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -189,11 +189,14 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                     }
                 }
 
-                try {
-                    jdbcConnection.commit();
-                }
-                catch (SQLException e) {
-                    throw new DebeziumException(e);
+                // TODO Vaibhav: Connector works without committing here as well, read more in https://issues.redhat.com/browse/DBZ-2118
+                if (!connectorConfig.streamingMode().isParallel()) {
+                    try {
+                        jdbcConnection.commit();
+                    }
+                    catch (SQLException e) {
+                        throw new DebeziumException(e);
+                    }
                 }
 
                 final PostgresEventMetadataProvider metadataProvider = new PostgresEventMetadataProvider();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPartition.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPartition.java
@@ -23,7 +23,6 @@ public class PostgresPartition extends AbstractPartition implements Partition {
     private final String serverName;
     private final String taskId;
     private final String slotName;
-    private final String taskId;
 
     public PostgresPartition(String serverName, String databaseName, String taskId, String slotName) {
         super(databaseName);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPartition.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPartition.java
@@ -22,11 +22,13 @@ public class PostgresPartition extends AbstractPartition implements Partition {
 
     private final String serverName;
     private final int taskId;
+    private final String slotName;
 
-    public PostgresPartition(String serverName, String databaseName, int taskId) {
+    public PostgresPartition(String serverName, String databaseName, int taskId, String slotName) {
         super(databaseName);
         this.serverName = serverName;
         this.taskId = taskId;
+        this.slotName = slotName;
     }
 
     @Override
@@ -57,7 +59,7 @@ public class PostgresPartition extends AbstractPartition implements Partition {
     }
 
     public String getPartitionIdentificationKey() {
-        return String.format("%s_%d", serverName, taskId);
+        return String.format("%s_%d_%s", serverName, taskId, slotName);
     }
 
     static class Provider implements Partition.Provider<PostgresPartition> {
@@ -73,7 +75,7 @@ public class PostgresPartition extends AbstractPartition implements Partition {
         public Set<PostgresPartition> getPartitions() {
             return Collections.singleton(new PostgresPartition(
                     connectorConfig.getLogicalName(), taskConfig.getString(DATABASE_NAME.name()),
-                    connectorConfig.taskId()));
+                    connectorConfig.taskId(), connectorConfig.slotName()));
         }
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YBValidate.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YBValidate.java
@@ -1,0 +1,61 @@
+package io.debezium.connector.postgresql;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.postgresql.transforms.yugabytedb.Pair;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Class to store all the validation methods.
+ *
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ */
+public class YBValidate {
+    private static final String RANGE_BEGIN = "0";
+    private static final String RANGE_END = "65536";
+
+    public static void completeRangesProvided(List<String> slotRanges) {
+        List<Pair<String, String>> pairList = slotRanges.stream()
+                .map(entry -> {
+                    String[] parts = entry.split(",");
+                    return new Pair<>(parts[0], parts[1]);
+                })
+                .sorted(Comparator.comparing(Pair::getFirst))
+                .collect(Collectors.toList());
+
+        String rangeBegin = RANGE_BEGIN;
+
+        for (Pair<String, String> pair : pairList) {
+            if (!rangeBegin.equals(pair.getFirst())) {
+                throw new DebeziumException(
+                    String.format("Tablet range starting from hash_code %s is missing", rangeBegin));
+            }
+
+            rangeBegin = pair.getSecond();
+        }
+
+        // At this point, if the range is complete, rangeBegin will be pointing to the RANGE_END value.
+        if (!rangeBegin.equals(RANGE_END)) {
+            throw new DebeziumException(
+                String.format("Incomplete ranges provided. Range starting from hash_code %s is missing", rangeBegin));
+        }
+    }
+
+    public static void slotAndPublicationsAreEqual(List<String> slotNames, List<String> publicationNames) {
+        if (slotNames.size() != publicationNames.size()) {
+            throw new DebeziumException(
+                String.format("Number of provided slots does not match the number of provided " +
+                                "publications. Slots: %s, Publications: %s", slotNames, publicationNames));
+        }
+    }
+
+    public static void slotRangesMatchSlotNames(List<String> slotNames, List<String> slotRanges) {
+        if (slotNames.size() != slotRanges.size()) {
+            throw new DebeziumException(
+                    String.format("Number of provided slots does not match the number of provided " +
+                            "slot ranges. Slots: %s, Slot ranges: %s", slotNames, slotRanges));
+        }
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
@@ -64,7 +64,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
 
     protected List<Map<String, String>> getTaskConfigsForParallelStreaming(List<String> slotNames,
                                                                            List<String> publicationNames,
-                                                                           List<String> ranges) {
+                                                                           List<String> slotRanges) {
         List<Map<String, String>> taskConfigs = new ArrayList<>();
 
         if (connectorConfig.getSnapshotter().shouldSnapshot()) {
@@ -77,10 +77,10 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
             taskProps.put(PostgresConnectorConfig.TASK_ID.name(), String.valueOf(i));
             taskProps.put(PostgresConnectorConfig.SLOT_NAME.name(), slotNames.get(i));
             taskProps.put(PostgresConnectorConfig.PUBLICATION_NAME.name(), publicationNames.get(i));
-            taskProps.put(PostgresConnectorConfig.STREAM_PARAMS.name(), "hash_range=" + ranges.get(i));
+            taskProps.put(PostgresConnectorConfig.STREAM_PARAMS.name(), "hash_range=" + slotRanges.get(i));
 
             if (connectorConfig.getSnapshotter().shouldSnapshot()) {
-                String[] splitRange = ranges.get(i).split(",");
+                String[] splitRange = slotRanges.get(i).split(",");
                 String query = getParallelSnapshotQuery(splitRange[0], splitRange[1]);
                 taskProps.put(
                     PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE.name() + "." + taskProps.get(PostgresConnectorConfig.TABLE_INCLUDE_LIST.name()),
@@ -110,13 +110,13 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
 
             List<String> slotNames = connectorConfig.getSlotNames();
             List<String> publicationNames = connectorConfig.getPublicationNames();
-            List<String> ranges = connectorConfig.getSlotRanges();
+            List<String> slotRanges = connectorConfig.getSlotRanges();
 
             YBValidate.slotAndPublicationsAreEqual(slotNames, publicationNames);
-            YBValidate.slotRangesMatchSlotNames(slotNames, ranges);
-            YBValidate.completeRangesProvided(ranges);
+            YBValidate.slotRangesMatchSlotNames(slotNames, slotRanges);
+            YBValidate.completeRangesProvided(slotRanges);
 
-            return getTaskConfigsForParallelStreaming(slotNames, publicationNames, ranges);
+            return getTaskConfigsForParallelStreaming(slotNames, publicationNames, slotRanges);
         }
 
         // TODO Vaibhav (#26106): The following code block is not needed now, remove in a separate PR.

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
@@ -74,7 +74,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
         for (int i = 0; i < slotNames.size(); ++i) {
             Map<String, String> taskProps = new HashMap<>(this.props);
 
-            taskProps.put(PostgresConnectorConfig.TASK_ID.name(), String.valueOf(i));
+            taskProps.put(PostgresConnectorConfig.TASK_ID, String.valueOf(i));
             taskProps.put(PostgresConnectorConfig.SLOT_NAME.name(), slotNames.get(i));
             taskProps.put(PostgresConnectorConfig.PUBLICATION_NAME.name(), publicationNames.get(i));
             taskProps.put(PostgresConnectorConfig.STREAM_PARAMS.name(), "hash_range=" + slotRanges.get(i));

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
@@ -89,9 +89,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
 
         final String tableIncludeList = props.get(PostgresConnectorConfig.TABLE_INCLUDE_LIST.name());
 
-        if (props.containsKey(PostgresConnectorConfig.STREAMING_MODE.name())
-                && props.get(PostgresConnectorConfig.STREAMING_MODE.name())
-                    .equalsIgnoreCase(PostgresConnectorConfig.StreamingMode.PARALLEL.getValue())) {
+        if (connectorConfig.streamingMode().isParallel()) {
             LOGGER.info("Initialising parallel streaming mode");
 
             // Validate for a single table.
@@ -101,15 +99,9 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
             List<String> publicationNames = connectorConfig.getPublicationNames();
             List<String> slotRanges = connectorConfig.getSlotRanges();
 
-            if (slotNames.size() != publicationNames.size()) {
-                throw new IllegalArgumentException("Number of slots do not match with number of publications provided");
-            }
-
-            if (slotNames.size() != slotRanges.size()) {
-                throw new IllegalArgumentException("Number of slot ranges should be equal to the number of slots provided");
-            }
-
-            // TODO: Add validation that the slots are already created.
+            YBValidate.slotAndPublicationsAreEqual(slotNames, publicationNames);
+            YBValidate.slotRangesMatchSlotNames(slotNames, slotRanges);
+            YBValidate.completeRangesProvided(slotRanges);
 
             return getTaskConfigsForParallelStreaming(slotNames, publicationNames, slotRanges);
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -533,6 +533,8 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                     plugin.getPostgresPluginName(),
                     lsnType.getLsnTypeName(),
                     streamingMode.isParallel() ? "USE_SNAPSHOT" : "");
+            LOGGER.info("executing: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY");
+            stmt.execute("BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY");
             LOGGER.info("Creating replication slot with command {}", createCommand);
             stmt.execute(createCommand);
             // when we are in Postgres 9.4+, we can parse the slot creation info,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -65,6 +65,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
     private final String slotName;
     private final PostgresConnectorConfig.LsnType lsnType;
+    private final PostgresConnectorConfig.StreamingMode streamingMode;
     private final String publicationName;
     private final RelationalTableFilters tableFilter;
     private final PostgresConnectorConfig.AutoCreateMode publicationAutocreateMode;
@@ -116,6 +117,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         this.connectorConfig = config;
         this.slotName = slotName;
         this.lsnType = config.slotLsnType();
+        this.streamingMode = config.streamingMode();
         this.publicationName = publicationName;
         this.tableFilter = tableFilter;
         this.publicationAutocreateMode = publicationAutocreateMode;
@@ -525,11 +527,12 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
         try (Statement stmt = pgConnection().createStatement()) {
             String createCommand = String.format(
-                    "CREATE_REPLICATION_SLOT \"%s\" %s LOGICAL %s %s",
+                    "CREATE_REPLICATION_SLOT \"%s\" %s LOGICAL %s %s %s",
                     slotName,
                     tempPart,
                     plugin.getPostgresPluginName(),
-                    lsnType.getLsnTypeName());
+                    lsnType.getLsnTypeName(),
+                    streamingMode.isParallel() ? "USE_SNAPSHOT" : "");
             LOGGER.info("Creating replication slot with command {}", createCommand);
             stmt.execute(createCommand);
             // when we are in Postgres 9.4+, we can parse the slot creation info,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/transforms/yugabytedb/Pair.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/transforms/yugabytedb/Pair.java
@@ -48,6 +48,11 @@ public class Pair<A, B> {
     }
   }
 
+  @Override
+  public String toString() {
+    return String.format("%s,%s", first.toString(), second.toString());
+  }
+
   public int hashCode() {
     return Objects.hashCode(new Object[]{this.first, this.second});
   }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorConfigDefTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorConfigDefTest.java
@@ -97,6 +97,18 @@ public class PostgresConnectorConfigDefTest extends ConfigDefinitionMetadataTest
         assertThat((problemCount == 2)).isTrue();
     }
 
+    @Test
+    public void shouldFailIfSlotRangesSpecifiedWithoutParallelStreamingMode() {
+        Configuration.Builder configBuilder = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.STREAMING_MODE, PostgresConnectorConfig.StreamingMode.DEFAULT)
+                .with(PostgresConnectorConfig.SLOT_RANGES, "0,10;10,65536");
+
+        int problemCount = PostgresConnectorConfig.validateUsageWithParallelStreamingMode(
+          configBuilder.build(), PostgresConnectorConfig.SLOT_RANGES, (field, value, problemMessage) -> System.out.println(problemMessage));
+
+        assertThat(problemCount == 1).isTrue();
+    }
+
     public void validateCorrectHostname(boolean multiNode) {
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.HOSTNAME, multiNode ? "127.0.0.1:5433,127.0.0.2:5433,127.0.0.3:5433" : "127.0.0.1");

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresPartitionTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresPartitionTest.java
@@ -11,11 +11,11 @@ public class PostgresPartitionTest extends AbstractPartitionTest<PostgresPartiti
 
     @Override
     protected PostgresPartition createPartition1() {
-        return new PostgresPartition("server1", "database1", 0);
+        return new PostgresPartition("server1", "database1", 0, "slot_name");
     }
 
     @Override
     protected PostgresPartition createPartition2() {
-        return new PostgresPartition("server2", "database1", 0);
+        return new PostgresPartition("server2", "database1", 0, "slot_name");
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBValidateTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBValidateTest.java
@@ -27,10 +27,10 @@ public class YBValidateTest {
     @Test
     public void shouldThrowExceptionWhenSlotsAndSlotRangesDoNotMatch() {
         List<String> slots = List.of("a", "b", "c");
-        List<String> ranges = List.of("0,10", "10,1000");
+        List<String> slotRanges = List.of("0,10", "10,1000");
 
         try {
-            YBValidate.slotRangesMatchSlotNames(slots, ranges);
+            YBValidate.slotRangesMatchSlotNames(slots, slotRanges);
         } catch (DebeziumException ex) {
             assertTrue(ex.getMessage().contains("Number of provided slots does not match the number of provided slot ranges"));
         }
@@ -38,10 +38,10 @@ public class YBValidateTest {
 
     @Test
     public void shouldThrowExceptionWhenEndBoundaryIsMissing() {
-        List<String> ranges = List.of("0,10", "10,1000");
+        List<String> slotRanges = List.of("0,10", "10,1000");
 
         try {
-            YBValidate.completeRangesProvided(ranges);
+            YBValidate.completeRangesProvided(slotRanges);
         } catch (DebeziumException ex) {
             assertTrue(ex.getMessage().contains("Incomplete ranges provided"));
         }
@@ -49,10 +49,10 @@ public class YBValidateTest {
 
     @Test
     public void shouldThrowExceptionWhenMidRangeIsMissing() {
-        List<String> ranges = List.of("0,10", "10,1000", "32768,65536");
+        List<String> slotRanges = List.of("0,10", "10,1000", "32768,65536");
 
         try {
-            YBValidate.completeRangesProvided(ranges);
+            YBValidate.completeRangesProvided(slotRanges);
         } catch (DebeziumException ex) {
             assertTrue(ex.getMessage().contains("Tablet range starting from hash_code"));
         }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBValidateTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBValidateTest.java
@@ -1,0 +1,60 @@
+package io.debezium.connector.postgresql;
+
+import io.debezium.DebeziumException;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+/**
+ * Tests to verify that our validation methods are working fine.
+ *
+ * @author Vaibhav Kushwaha (vkushwaha@yugabyte.com)
+ */
+public class YBValidateTest {
+    @Test
+    public void shouldThrowExceptionWhenSlotsAndPublicationsDoNotMatch() {
+        List<String> slots = List.of("a", "b");
+        List<String> publications = List.of("pub");
+
+        try {
+            YBValidate.slotAndPublicationsAreEqual(slots, publications);
+        } catch (DebeziumException ex) {
+            assertTrue(ex.getMessage().contains("Number of provided slots does not match the number of provided publications"));
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenSlotsAndSlotRangesDoNotMatch() {
+        List<String> slots = List.of("a", "b", "c");
+        List<String> slotRanges = List.of("0,10", "10,1000");
+
+        try {
+            YBValidate.slotRangesMatchSlotNames(slots, slotRanges);
+        } catch (DebeziumException ex) {
+            assertTrue(ex.getMessage().contains("Number of provided slots does not match the number of provided slot ranges"));
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenEndBoundaryIsMissing() {
+        List<String> slotRanges = List.of("0,10", "10,1000");
+
+        try {
+            YBValidate.completeRangesProvided(slotRanges);
+        } catch (DebeziumException ex) {
+            assertTrue(ex.getMessage().contains("Incomplete ranges provided"));
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenMidRangeIsMissing() {
+        List<String> slotRanges = List.of("0,10", "10,1000", "32768,65536");
+
+        try {
+            YBValidate.completeRangesProvided(slotRanges);
+        } catch (DebeziumException ex) {
+            assertTrue(ex.getMessage().contains("Tablet range starting from hash_code"));
+        }
+    }
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBValidateTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBValidateTest.java
@@ -49,7 +49,7 @@ public class YBValidateTest {
 
     @Test
     public void shouldThrowExceptionWhenMidRangeIsMissing() {
-        List<String> slotRanges = List.of("0,10", "10,1000", "32768,65536");
+        List<String> slotRanges = List.of("0,6553", "13107,19660", "19660,26214", "26214,32768", "32768,39321", "39321,45875", "45875,52428", "52428,58982", "58982,65536");
 
         try {
             YBValidate.completeRangesProvided(slotRanges);


### PR DESCRIPTION
This PR introduces the changes to stream changes in parallel using multiple tasks for a table given the user provides the hash_code ranges for it to stream. The following changes have been introduced in this PR:
1. New configurations:
    a. `streaming.mode`: This values takes the input as `default` or `parallel` which is then used to decide whether or not parallel streaming mode is supposed to be used.
    b. `slot.names`: A list of comma separated values for all the slot names which should be used by each task.
    c. `publication.names`: A list of comma separated values for all the publication names which should be used by each task.
    d. `slot.ranges`: A list of **semi-colon** separated values for slot ranges in the format `a,b;b,c;c,d`.
2. Validations in the class `YBValidate` have been introduced:
    a. To validate that the complete hash range is provided by the user and nothing is missing.
    b. To validate that the number of slot names is equal to the publication names as well as the number of slot ranges.
    c. To ensure that there's only one table provided in the `table.include.list` as parallel streaming will not work with multiple tables.
3. Support for snapshot with `streaming.mode` parallel.
    a. This will require providing the hash part of the primary key columns to the configuration parameter `primary.key.hash.columns`.
4. The `PostgresPartition` object will now also use the slot name to uniquely identify the source partition.

### Usage example

If the connector configuration contains the following properties:

```
{
  ...
  "streaming.mode":"parallel",
  "slot.names":"rs1,rs1",
  "publication.names":"pb1,pb2",
  "slot.ranges":"0,32768;32768,65536"
  ...
}
```

then we will have 2 tasks created:
1. `task 0`: `slot=rs1 publication=pb1 hash_range=0,32768`
2. `task 1`: `slot=rs2 publication=pb2 hash_range=32768,65536`

### Note:
It is currently the user's responsibility to provide full hash ranges and maintain the order given in the configs for `slot.names`, `publication.names` and `slot.ranges` as the values will be picked sequentially and divided into tasks. Thus, in order to ensure that the task with a slot gets the same hash_range every time, the user needs to be careful with the order provided.

This closes yugabyte/yugabyte-db#26107.