### PR TITLE
[DBZ-PGYB] Specify only HYBRID_TIME when creating slot, skip otherwise

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -531,7 +531,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                     slotName,
                     tempPart,
                     plugin.getPostgresPluginName(),
-                    lsnType.getLsnTypeName(),
+                    lsnType.getLsnTypeName().equalsIgnoreCase("SEQUENCE") ? "" : "HYBRID_TIME",
                     streamingMode.isParallel() ? "USE_SNAPSHOT" : "");
 
             // Begin a read-only transaction when it is the parallel streaming mode because

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -525,6 +525,10 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         // For pgoutput specifically, the publication must be created prior to the slot.
         initPublication();
 
+        // YB Note: We will only be specifying the LSN type when it is HYBRID_TIME, for other case(s)
+        // i.e. SEQUENCE, we will let the service handle it with the default value. This is to ensure
+        // that we stay backward compatible as the syntax is not recognizable by initial versions
+        // of logical replication in YugabyteDB.
         try (Statement stmt = pgConnection().createStatement()) {
             String createCommand = String.format(
                     "CREATE_REPLICATION_SLOT \"%s\" %s LOGICAL %s %s %s",


### PR DESCRIPTION
## Problem

With the introduction of `slot.lsn.type`, the default value we use for creating the replication slot is `SEQUENCE` when the user does not provide any value to the configuration property. However, while creating the replication slot, if the user doesn't provide this config, the `CREATE_REPLICATION_SLOT` statement looks like:

```
CREATE_REPLICATION_SLOT slot_name LOGICAL plugin_name SEQUENCE;
```

The above breaks the backward compatibility and causes the creation of replication slot to fail on older versions where the newly added syntax is not supported.

## Solution

As a fix, we will now only specify a LSN type while creating the replication slot if it is `HYBRID_TIME`. For the case with `SEQUENCE`, we will now rely on the default values as specified on the service to create a replication slot of LSN type `SEQUENCE`.