### PR TITLE
[DBZ-PGYB] Do not set GUC to disable catalog version check with every connection

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -122,13 +122,6 @@ public class PostgresConnection extends JdbcConnection {
             final PostgresValueConverter valueConverter = valueConverterBuilder.build(this.typeRegistry);
             this.defaultValueConverter = new PostgresDefaultValueConverter(valueConverter, this.getTimestampUtils(), typeRegistry);
         }
-
-        try {
-            LOGGER.debug("Setting GUC to disable catalog version check");
-            execute("SET yb_disable_catalog_version_check = true;");
-        } catch (Exception e) {
-            LOGGER.error("Error while setting GUC yb_disable_catalog_version_check", e);
-        }
     }
 
     public PostgresConnection(JdbcConfiguration config, PostgresValueConverterBuilder valueConverterBuilder,

--- a/debezium-connector-postgres/src/test/resources/replication_role_user.ddl
+++ b/debezium-connector-postgres/src/test/resources/replication_role_user.ddl
@@ -18,3 +18,17 @@ BEGIN;
     REVOKE EXECUTE ON PROCEDURE ybpgconn.set_yb_read_time FROM PUBLIC;
     GRANT EXECUTE ON PROCEDURE ybpgconn.set_yb_read_time TO ybpgconn;
 COMMIT;
+
+BEGIN;
+    CREATE OR REPLACE PROCEDURE ybpgconn.disable_catalog_version_check()
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      EXECUTE 'SET yb_disable_catalog_version_check = true';
+    END;
+    $$
+    SECURITY DEFINER;
+
+    REVOKE EXECUTE ON PROCEDURE ybpgconn.disable_catalog_version_check FROM PUBLIC; 
+    GRANT EXECUTE ON PROCEDURE ybpgconn.disable_catalog_version_check TO ybpgconn;
+COMMIT;


### PR DESCRIPTION
## Problem

A block of code currently sets the GUC `yb_disable_catalog_version_check` with every connection it creates. The problem here is that if the user is a non-superuser, this block will lead to an error log which doesn't cause any failure but can lead to bad user experience.

## Solution

Removing the code block from the creation flow of a connection resolves the issue and now:
1. The GUC will not be set when consistent snapshot is disabled by the config `yb.consistent.snapshot=false` or when snapshot is skipped i.e. `snapshot.mode=never`.
2. When using consistent snapshot with a non-superuser, the GUC will only be set when a procedure `disable_catalog_version_check()` is accessible to the connector user.

### Note

The procedure can be created by the superuser and be granted to the connector user by executing the following statements:

```
CREATE OR REPLACE PROCEDURE connector_user.disable_catalog_version_check()
LANGUAGE plpgsql
AS $$
BEGIN
  EXECUTE 'SET yb_disable_catalog_version_check = true';
END;
$$
SECURITY DEFINER;


REVOKE EXECUTE ON PROCEDURE connector_user.disable_catalog_version_check FROM PUBLIC; 
GRANT EXECUTE ON PROCEDURE connector_user.disable_catalog_version_check TO connector_user;
```

### Testing

The changes were tested using the existing tests for snapshot which fail if this catalog version check is not disabled while setting `yb_read_time`.