### PR TITLE
fix: upgrade protobuf-jar version to fix reported CVE-2024-7254

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,9 +142,9 @@
         <version.cassandra4>4.0.2</version.cassandra4>
 
         <!-- Required in protoc plug-in config, too; can't be in BOM therefore -->
-        <version.com.google.protobuf>3.25.2</version.com.google.protobuf>
+        <version.com.google.protobuf>3.25.5</version.com.google.protobuf>
         <!-- The version is separate so different protoc can be used in product -->
-        <version.com.google.protobuf.protoc>3.25.2</version.com.google.protobuf.protoc>
+        <version.com.google.protobuf.protoc>3.25.5</version.com.google.protobuf.protoc>
 
         <!-- Infinispan version for Oracle and Debezium Server sink -->
         <version.infinispan>14.0.20.Final</version.infinispan>


### PR DESCRIPTION
This PR fixes a reported vulnerability CVE-2024-7254 in the repository by upgrading the dependency version to `3.25.5`.