### PR TITLE
[#28533] Make yb.load.balance.connections connector config a string instead of boolean

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,28 +25,28 @@ ENV KAFKA_OPTS="-Djdk.tls.client.protocols=TLSv1.2 -javaagent:/kafka/etc/jmx_pro
 # Package all the Avro related jar files
 RUN mkdir -p $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres/avro-supporting-jars/
 WORKDIR $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres/avro-supporting-jars
-RUN curl -sLo kafka-connect-avro-converter-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-connect-avro-converter/7.5.3/kafka-connect-avro-converter-7.5.3.jar
+RUN curl -sLo kafka-connect-avro-converter-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-connect-avro-converter/7.5.3/kafka-connect-avro-converter-7.5.3.jar 
 RUN curl -sLo kafka-connect-avro-data-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-connect-avro-data/7.5.3/kafka-connect-avro-data-7.5.3.jar
 RUN curl -sLo kafka-avro-serializer-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-avro-serializer/7.5.3/kafka-avro-serializer-7.5.3.jar
-RUN curl -sLo kafka-schema-serializer-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-schema-serializer/7.5.3/kafka-schema-serializer-7.5.3.jar
+RUN curl -sLo kafka-schema-serializer-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-schema-serializer/7.5.3/kafka-schema-serializer-7.5.3.jar 
 RUN curl -sLo kafka-schema-converter-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-schema-converter/7.5.3/kafka-schema-converter-7.5.3.jar
-RUN curl -sLo kafka-schema-registry-client-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/7.5.3/kafka-schema-registry-client-7.5.3.jar
+RUN curl -sLo kafka-schema-registry-client-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/7.5.3/kafka-schema-registry-client-7.5.3.jar 
 RUN curl -sLo common-config-7.5.3.jar https://packages.confluent.io/maven/io/confluent/common-config/7.5.3/common-config-7.5.3.jar
-RUN curl -sLo common-utils-7.5.3.jar https://packages.confluent.io/maven/io/confluent/common-utils/7.5.3/common-utils-7.5.3.jar
+RUN curl -sLo common-utils-7.5.3.jar https://packages.confluent.io/maven/io/confluent/common-utils/7.5.3/common-utils-7.5.3.jar 
 
 RUN curl -sLo avro-1.11.3.jar https://repo1.maven.org/maven2/org/apache/avro/avro/1.11.3/avro-1.11.3.jar
 RUN curl -sLo commons-compress-1.21.jar https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.21/commons-compress-1.21.jar
 RUN curl -sLo failureaccess-1.0.jar https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0/failureaccess-1.0.jar
-RUN curl -sLo guava-33.0.0-jre.jar https://repo1.maven.org/maven2/com/google/guava/guava/33.0.0-jre/guava-33.0.0-jre.jar
+RUN curl -sLo guava-33.0.0-jre.jar https://repo1.maven.org/maven2/com/google/guava/guava/33.0.0-jre/guava-33.0.0-jre.jar 
 RUN curl -sLo minimal-json-0.9.5.jar https://repo1.maven.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5.jar
-RUN curl -sLo re2j-1.6.jar https://repo1.maven.org/maven2/com/google/re2j/re2j/1.6/re2j-1.6.jar
+RUN curl -sLo re2j-1.6.jar https://repo1.maven.org/maven2/com/google/re2j/re2j/1.6/re2j-1.6.jar 
 RUN curl -sLo slf4j-api-1.7.36.jar https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar
-RUN curl -sLo snakeyaml-2.0.jar https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.0/snakeyaml-2.0.jar
-RUN curl -sLo swagger-annotations-2.1.10.jar https://repo1.maven.org/maven2/io/swagger/core/v3/swagger-annotations/2.1.10/swagger-annotations-2.1.10.jar
-RUN curl -sLo jackson-databind-2.14.2.jar https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.14.2/jackson-databind-2.14.2.jar
-RUN curl -sLo jackson-core-2.14.2.jar https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.14.2/jackson-core-2.14.2.jar
-RUN curl -sLo jackson-annotations-2.14.2.jar https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.14.2/jackson-annotations-2.14.2.jar
-RUN curl -sLo jackson-dataformat-csv-2.14.2.jar https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-csv/2.14.2/jackson-dataformat-csv-2.14.2.jar
+RUN curl -sLo snakeyaml-2.0.jar https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.0/snakeyaml-2.0.jar 
+RUN curl -sLo swagger-annotations-2.1.10.jar https://repo1.maven.org/maven2/io/swagger/core/v3/swagger-annotations/2.1.10/swagger-annotations-2.1.10.jar 
+RUN curl -sLo jackson-databind-2.14.2.jar https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.14.2/jackson-databind-2.14.2.jar 
+RUN curl -sLo jackson-core-2.14.2.jar https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.14.2/jackson-core-2.14.2.jar 
+RUN curl -sLo jackson-annotations-2.14.2.jar https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.14.2/jackson-annotations-2.14.2.jar 
+RUN curl -sLo jackson-dataformat-csv-2.14.2.jar https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-csv/2.14.2/jackson-dataformat-csv-2.14.2.jar 
 RUN curl -sLo logredactor-1.0.12.jar https://repo1.maven.org/maven2/io/confluent/logredactor/1.0.12/logredactor-1.0.12.jar
 RUN curl -sLo logredactor-metrics-1.0.12.jar https://repo1.maven.org/maven2/io/confluent/logredactor-metrics/1.0.12/logredactor-metrics-1.0.12.jar
 WORKDIR /
@@ -68,3 +68,4 @@ ENV JMXPORT=1976
 
 # properties file having instructions to roll over log files in case the size exceeds a given limit
 COPY log4j.properties $KAFKA_HOME/config/log4j.properties
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,35 +25,35 @@ ENV KAFKA_OPTS="-Djdk.tls.client.protocols=TLSv1.2 -javaagent:/kafka/etc/jmx_pro
 # Package all the Avro related jar files
 RUN mkdir -p $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres/avro-supporting-jars/
 WORKDIR $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres/avro-supporting-jars
-RUN curl -sLo kafka-connect-avro-converter-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-connect-avro-converter/7.5.3/kafka-connect-avro-converter-7.5.3.jar 
+RUN curl -sLo kafka-connect-avro-converter-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-connect-avro-converter/7.5.3/kafka-connect-avro-converter-7.5.3.jar
 RUN curl -sLo kafka-connect-avro-data-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-connect-avro-data/7.5.3/kafka-connect-avro-data-7.5.3.jar
 RUN curl -sLo kafka-avro-serializer-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-avro-serializer/7.5.3/kafka-avro-serializer-7.5.3.jar
-RUN curl -sLo kafka-schema-serializer-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-schema-serializer/7.5.3/kafka-schema-serializer-7.5.3.jar 
+RUN curl -sLo kafka-schema-serializer-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-schema-serializer/7.5.3/kafka-schema-serializer-7.5.3.jar
 RUN curl -sLo kafka-schema-converter-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-schema-converter/7.5.3/kafka-schema-converter-7.5.3.jar
-RUN curl -sLo kafka-schema-registry-client-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/7.5.3/kafka-schema-registry-client-7.5.3.jar 
+RUN curl -sLo kafka-schema-registry-client-7.5.3.jar https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/7.5.3/kafka-schema-registry-client-7.5.3.jar
 RUN curl -sLo common-config-7.5.3.jar https://packages.confluent.io/maven/io/confluent/common-config/7.5.3/common-config-7.5.3.jar
-RUN curl -sLo common-utils-7.5.3.jar https://packages.confluent.io/maven/io/confluent/common-utils/7.5.3/common-utils-7.5.3.jar 
+RUN curl -sLo common-utils-7.5.3.jar https://packages.confluent.io/maven/io/confluent/common-utils/7.5.3/common-utils-7.5.3.jar
 
 RUN curl -sLo avro-1.11.3.jar https://repo1.maven.org/maven2/org/apache/avro/avro/1.11.3/avro-1.11.3.jar
 RUN curl -sLo commons-compress-1.21.jar https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.21/commons-compress-1.21.jar
 RUN curl -sLo failureaccess-1.0.jar https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0/failureaccess-1.0.jar
-RUN curl -sLo guava-33.0.0-jre.jar https://repo1.maven.org/maven2/com/google/guava/guava/33.0.0-jre/guava-33.0.0-jre.jar 
+RUN curl -sLo guava-33.0.0-jre.jar https://repo1.maven.org/maven2/com/google/guava/guava/33.0.0-jre/guava-33.0.0-jre.jar
 RUN curl -sLo minimal-json-0.9.5.jar https://repo1.maven.org/maven2/com/eclipsesource/minimal-json/minimal-json/0.9.5/minimal-json-0.9.5.jar
-RUN curl -sLo re2j-1.6.jar https://repo1.maven.org/maven2/com/google/re2j/re2j/1.6/re2j-1.6.jar 
+RUN curl -sLo re2j-1.6.jar https://repo1.maven.org/maven2/com/google/re2j/re2j/1.6/re2j-1.6.jar
 RUN curl -sLo slf4j-api-1.7.36.jar https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar
-RUN curl -sLo snakeyaml-2.0.jar https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.0/snakeyaml-2.0.jar 
-RUN curl -sLo swagger-annotations-2.1.10.jar https://repo1.maven.org/maven2/io/swagger/core/v3/swagger-annotations/2.1.10/swagger-annotations-2.1.10.jar 
-RUN curl -sLo jackson-databind-2.14.2.jar https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.14.2/jackson-databind-2.14.2.jar 
-RUN curl -sLo jackson-core-2.14.2.jar https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.14.2/jackson-core-2.14.2.jar 
-RUN curl -sLo jackson-annotations-2.14.2.jar https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.14.2/jackson-annotations-2.14.2.jar 
-RUN curl -sLo jackson-dataformat-csv-2.14.2.jar https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-csv/2.14.2/jackson-dataformat-csv-2.14.2.jar 
+RUN curl -sLo snakeyaml-2.0.jar https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.0/snakeyaml-2.0.jar
+RUN curl -sLo swagger-annotations-2.1.10.jar https://repo1.maven.org/maven2/io/swagger/core/v3/swagger-annotations/2.1.10/swagger-annotations-2.1.10.jar
+RUN curl -sLo jackson-databind-2.14.2.jar https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.14.2/jackson-databind-2.14.2.jar
+RUN curl -sLo jackson-core-2.14.2.jar https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.14.2/jackson-core-2.14.2.jar
+RUN curl -sLo jackson-annotations-2.14.2.jar https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.14.2/jackson-annotations-2.14.2.jar
+RUN curl -sLo jackson-dataformat-csv-2.14.2.jar https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-csv/2.14.2/jackson-dataformat-csv-2.14.2.jar
 RUN curl -sLo logredactor-1.0.12.jar https://repo1.maven.org/maven2/io/confluent/logredactor/1.0.12/logredactor-1.0.12.jar
 RUN curl -sLo logredactor-metrics-1.0.12.jar https://repo1.maven.org/maven2/io/confluent/logredactor-metrics/1.0.12/logredactor-metrics-1.0.12.jar
 WORKDIR /
 
 # Add the required jar files to be packaged with the base connector
 RUN cd $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres && curl -sLo kafka-connect-jdbc-10.6.5-CUSTOM.7.jar https://github.com/yugabyte/kafka-connect-jdbc/releases/download/10.6.5-CUSTOM.7/kafka-connect-jdbc-10.6.5-CUSTOM.7.jar
-RUN cd $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres && curl -sLo jdbc-yugabytedb-42.3.5-yb-1.jar https://repo1.maven.org/maven2/com/yugabyte/jdbc-yugabytedb/42.3.5-yb-1/jdbc-yugabytedb-42.3.5-yb-1.jar
+RUN cd $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres && curl -sLo jdbc-yugabytedb-42.7.3-yb-4.jar https://repo1.maven.org/maven2/com/yugabyte/jdbc-yugabytedb/42.7.3-yb-4/jdbc-yugabytedb-42.7.3-yb-4.jar
 RUN cd $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres && curl -sLo transforms-for-apache-kafka-connect-1.5.0.zip https://github.com/Aiven-Open/transforms-for-apache-kafka-connect/releases/download/v1.5.0/transforms-for-apache-kafka-connect-1.5.0.zip
 RUN cd $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-postgres && unzip transforms-for-apache-kafka-connect-1.5.0.zip
 
@@ -68,4 +68,3 @@ ENV JMXPORT=1976
 
 # properties file having instructions to roll over log files in case the size exceeds a given limit
 COPY log4j.properties $KAFKA_HOME/config/log4j.properties
-

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -11,7 +11,7 @@
     <name>YugabyteDB Source Connector</name>
     <packaging>jar</packaging>
     <properties>
-        <!-- 
+        <!--
           Specify the properties that will be used for setting up the integration tests' Docker container.
           Note that the `dockerhost.ip` property is computed from the IP address of DOCKER_HOST, which will
           work on all platforms. We'll set some of these as system properties during integration testing.
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.yugabyte</groupId>
             <artifactId>jdbc-yugabytedb</artifactId>
-            <version>42.3.5-yb-4</version>
+            <version>42.7.3-yb-4</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
@@ -354,7 +354,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- 
+            <!--
             Unlike surefire, the failsafe plugin ensures 'post-integration-test' phase always runs, even
             when there are failed integration tests. We rely upon this to always shut down the Docker container
             after the integration tests (defined as '*IT.java') are run.

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -11,7 +11,7 @@
     <name>YugabyteDB Source Connector</name>
     <packaging>jar</packaging>
     <properties>
-        <!--
+        <!-- 
           Specify the properties that will be used for setting up the integration tests' Docker container.
           Note that the `dockerhost.ip` property is computed from the IP address of DOCKER_HOST, which will
           work on all platforms. We'll set some of these as system properties during integration testing.
@@ -354,7 +354,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--
+            <!-- 
             Unlike surefire, the failsafe plugin ensures 'post-integration-test' phase always runs, even
             when there are failed integration tests. We rely upon this to always shut down the Docker container
             after the integration tests (defined as '*IT.java') are run.

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -783,16 +783,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                     "This config determines load-balance property in the connection url. " +
                     "Supported values are 'true', 'only-primary', 'only-rr', 'prefer-primary', " +
                     "'prefer-rr' and 'false'")
-            .withValidation((config, field, output) -> {
-                final String value = config.getString(field);
-                Set<String> validValues = Set.of("true", "only-primary", "only-rr", "prefer-primary", "prefer-rr", "false");
-                if (!validValues.contains(value)) {
-                    output.accept(field, value,
-                            "The valid values of yb.load.balance.connections are " + validValues);
-                    return 1;
-                }
-                return 0;
-            });
+            .withValidation(PostgresConnectorConfig::validateYbLoadBalanceConnectionsValue);
 
     public static final Field MAX_RETRIES_ON_ERROR = Field.create(ERRORS_MAX_RETRIES)
             .withDisplayName("The maximum number of retries")
@@ -1314,7 +1305,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     }
 
     public String getYbLoadBalanceConnections() {
-      return getConfig().getString(YB_LOAD_BALANCE_CONNECTIONS);
+        return getConfig().getString(YB_LOAD_BALANCE_CONNECTIONS);
     }
 
     protected Snapshotter getSnapshotter() {
@@ -1611,6 +1602,20 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                 problems.accept(field, hostName, hostName + " has invalid format (only the underscore, hyphen, dot, comma, colon and alphanumeric characters are allowed)");
                 ++problemCount;
             }
+        }
+
+        return problemCount;
+    }
+
+    protected static int validateYbLoadBalanceConnectionsValue(Configuration config, Field field, Field.ValidationOutput problems) {
+        final String value = config.getString(field);
+        Set<String> validValues = Set.of("true", "only-primary", "only-rr", "prefer-primary", "prefer-rr", "false");
+        int problemCount = 0;
+
+        if (!validValues.contains(value)) {
+            problems.accept(field, value,
+                    "The valid values of yb.load.balance.connections are " + validValues);
+            ++problemCount;
         }
 
         return problemCount;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import io.debezium.DebeziumException;
@@ -780,13 +781,14 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withImportance(Importance.LOW)
             .withDescription(
                     "This config determines load-balance property in the connection url. " +
-                    "Supported values are 'only-primary' and 'false'")
+                    "Supported values are 'true', 'only-primary', 'only-rr', 'prefer-primary', " +
+                    "'prefer-rr' and 'false'")
             .withValidation((config, field, output) -> {
                 final String value = config.getString(field);
-                if (!value.equals("only-primary") && !value.equals("false")) {
+                Set<String> validValues = Set.of("true", "only-primary", "only-rr", "prefer-primary", "prefer-rr", "false");
+                if (!validValues.contains(value)) {
                     output.accept(field, value,
-                            "yb.load.balance.connections has only 'only-primary' and 'false' as " +
-                            "valid values");
+                            "The valid values of yb.load.balance.connections are " + validValues);
                     return 1;
                 }
                 return 0;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -634,7 +634,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     public static final Pattern YB_HOSTNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9-_.,:]+$");
     public static final int YB_DEFAULT_ERRORS_MAX_RETRIES = 60;
     public static final long YB_DEFAULT_RETRIABLE_RESTART_WAIT = 30000L;
-    public static final boolean YB_DEFAULT_LOAD_BALANCE_CONNECTIONS = true;
+    public static final String YB_DEFAULT_LOAD_BALANCE_CONNECTIONS = "only-primary";
 
     public static final Field PORT = RelationalDatabaseConnectorConfig.PORT
             .withDefault(DEFAULT_PORT);
@@ -772,12 +772,25 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                 return 0;
             });
 
-    public static final Field YB_LOAD_BALANCE_CONNECTIONS = Field.create("yb.load.balance.connections")
+    public static final Field YB_LOAD_BALANCE_CONNECTIONS =
+        Field.create("yb.load.balance.connections")
             .withDisplayName("YB load balance connections")
-            .withType(Type.BOOLEAN)
+            .withType(Type.STRING)
             .withDefault(YB_DEFAULT_LOAD_BALANCE_CONNECTIONS)
             .withImportance(Importance.LOW)
-            .withDescription("Whether or not to add load-balance property to connection url");
+            .withDescription(
+                    "This config determines load-balance property in the connection url. " +
+                    "Supported values are 'only-primary' and 'false'")
+            .withValidation((config, field, output) -> {
+                final String value = config.getString(field);
+                if (!value.equals("only-primary") && !value.equals("false")) {
+                    output.accept(field, value,
+                            "yb.load.balance.connections has only 'only-primary' and 'false' as " +
+                            "valid values");
+                    return 1;
+                }
+                return 0;
+            });
 
     public static final Field MAX_RETRIES_ON_ERROR = Field.create(ERRORS_MAX_RETRIES)
             .withDisplayName("The maximum number of retries")
@@ -1298,8 +1311,8 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         return getConfig().getBoolean(YB_CONSISTENT_SNAPSHOT);
     }
 
-    public boolean ybShouldLoadBalanceConnections() {
-        return getConfig().getBoolean(YB_LOAD_BALANCE_CONNECTIONS);
+    public String getYbLoadBalanceConnections() {
+      return getConfig().getString(YB_LOAD_BALANCE_CONNECTIONS);
     }
 
     protected Snapshotter getSnapshotter() {
@@ -1467,20 +1480,21 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         }
         return 0;
     }
-    
-    public static Pair<String, String> findAndReplaceLoadBalancePropertyValues(Boolean loadBalance) {
+
+    public static Pair<String, String> findAndReplaceLoadBalancePropertyValues(String loadBalance) {
         String multiHostUrl = PostgresConnection.MULTI_HOST_URL_PATTERN;
         String singleHostUrl = PostgresConnection.URL_PATTERN;
-        String value = loadBalance.toString();
 
         if (multiHostUrl.contains("${" + PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS + "}")) {
             multiHostUrl = multiHostUrl.replaceAll(
-                    "\\$\\{" + PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS + "\\}", value);
+                    "\\$\\{" + PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS + "\\}",
+                    loadBalance);
         }
 
         if (singleHostUrl.contains("${" + PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS + "}")) {
             singleHostUrl = singleHostUrl.replaceAll(
-                    "\\$\\{" + PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS + "\\}", value);
+                    "\\$\\{" + PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS + "\\}",
+                    loadBalance);
         }
 
         return new Pair<>(multiHostUrl, singleHostUrl);
@@ -1491,7 +1505,8 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
      * @param hostName the host(s) for the PostgreSQL/YugabyteDB instance
      * @return a {@link io.debezium.jdbc.JdbcConnection.ConnectionFactory} instance
      */
-    public static JdbcConnection.ConnectionFactory getConnectionFactory(String hostName, Boolean loadBalance) {
+    public static JdbcConnection.ConnectionFactory getConnectionFactory(
+            String hostName, String loadBalance) {
         // The first string in the pair contains multi host URL pattern while the second string contains single host URL pattern.
         Pair<String,String> urlPatterns = findAndReplaceLoadBalancePropertyValues(loadBalance);
         return hostName.contains(":")

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -97,7 +97,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
 
             final Charset databaseCharset;
             try (PostgresConnection tempConnection = new PostgresConnection(connectorConfig.getJdbcConfig(),
-                    PostgresConnection.CONNECTION_GENERAL, connectorConfig.ybShouldLoadBalanceConnections())) {
+                    PostgresConnection.CONNECTION_GENERAL, connectorConfig.getYbLoadBalanceConnections())) {
                 databaseCharset = tempConnection.getDatabaseCharset();
             }
 
@@ -108,7 +108,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
 
             MainConnectionProvidingConnectionFactory<PostgresConnection> connectionFactory = new DefaultMainConnectionProvidingConnectionFactory<>(
                     () -> new PostgresConnection(connectorConfig.getJdbcConfig(), valueConverterBuilder,
-                            PostgresConnection.CONNECTION_GENERAL, connectorConfig.ybShouldLoadBalanceConnections()));
+                            PostgresConnection.CONNECTION_GENERAL, connectorConfig.getYbLoadBalanceConnections()));
             // Global JDBC connection used both for snapshotting and streaming.
             // Must be able to resolve datatypes.
             jdbcConnection = connectionFactory.mainConnection();
@@ -243,7 +243,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                                 schemaNameAdjuster,
                                 () -> new PostgresConnection(connectorConfig.getJdbcConfig(),
                                         PostgresConnection.CONNECTION_GENERAL,
-                                        connectorConfig.ybShouldLoadBalanceConnections()),
+                                        connectorConfig.getYbLoadBalanceConnections()),
                                         exception -> {
                                     String sqlErrorId = exception.getSQLState();
                                     switch (sqlErrorId) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
@@ -230,11 +230,11 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
         final ConfigValue hostnameValue = configValues.get(RelationalDatabaseConnectorConfig.HOSTNAME.name());
         // Try to connect to the database ...
         try (PostgresConnection connection = new PostgresConnection(postgresConfig.getJdbcConfig(),
-                PostgresConnection.CONNECTION_VALIDATE_CONNECTION, postgresConfig.ybShouldLoadBalanceConnections())) {
+                PostgresConnection.CONNECTION_VALIDATE_CONNECTION, postgresConfig.getYbLoadBalanceConnections())) {
             try {
                 // Prepare connection without initial statement execution
                 connection.connection(false);
-                testConnection(connection, postgresConfig.ybShouldLoadBalanceConnections());
+                testConnection(connection, postgresConfig.getYbLoadBalanceConnections());
 
                 // YB Note: This check validates that the WAL level is "logical" - skipping this
                 //          since it is not applicable to YugabyteDB.
@@ -246,7 +246,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
             }
             catch (SQLException e) {
                 LOGGER.error("Failed testing connection for {} with user '{}'",
-                        connection.connectionString(postgresConfig.ybShouldLoadBalanceConnections()),
+                        connection.connectionString(postgresConfig.getYbLoadBalanceConnections()),
                                 connection.username(), e);
                 hostnameValue.addErrorMessage("Error while validating connector config: " + e.getMessage());
             }
@@ -307,7 +307,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
         }
     }
 
-    private static void testConnection(PostgresConnection connection, Boolean loadBalance) throws SQLException {
+    private static void testConnection(PostgresConnection connection, String loadBalance) throws SQLException {
         connection.execute("SELECT version()");
         LOGGER.info("Successfully tested connection for {} with user '{}'", connection.connectionString(loadBalance),
                 connection.username());
@@ -323,7 +323,7 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
     public List<TableId> getMatchingCollections(Configuration config) {
         PostgresConnectorConfig connectorConfig = new PostgresConnectorConfig(config);
         try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(),
-                PostgresConnection.CONNECTION_GENERAL, connectorConfig.ybShouldLoadBalanceConnections())) {
+                PostgresConnection.CONNECTION_GENERAL, connectorConfig.getYbLoadBalanceConnections())) {
             return connection.readTableNames(connectorConfig.databaseName(), null, null, new String[]{ "TABLE" }).stream()
                     .filter(tableId -> connectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId))
                     .collect(Collectors.toList());

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -124,10 +124,11 @@ public class PostgresConnection extends JdbcConnection {
         }
     }
 
-    public PostgresConnection(JdbcConfiguration config, PostgresValueConverterBuilder valueConverterBuilder,
-            String connectionUsage, Boolean loadBalance) {
+    public PostgresConnection(JdbcConfiguration config,
+            PostgresValueConverterBuilder valueConverterBuilder, String connectionUsage,
+            String loadBalance) {
         this(config, valueConverterBuilder, connectionUsage,
-                PostgresConnectorConfig.getConnectionFactory(config.getHostname(), loadBalance));
+            PostgresConnectorConfig.getConnectionFactory(config.getHostname(), loadBalance));
     }
 
     /**
@@ -152,10 +153,11 @@ public class PostgresConnection extends JdbcConnection {
         this.jdbcConfig = config.getJdbcConfig();
     }
 
-    public PostgresConnection(PostgresConnectorConfig config, TypeRegistry typeRegistry, String connectionUsage,
-            Boolean loadBalance) {
+    public PostgresConnection(PostgresConnectorConfig config, TypeRegistry typeRegistry,
+            String connectionUsage, String loadBalance) {
         this(config, typeRegistry, connectionUsage,
-                PostgresConnectorConfig.getConnectionFactory(config.getJdbcConfig().getHostname(), loadBalance));
+            PostgresConnectorConfig.getConnectionFactory(
+                config.getJdbcConfig().getHostname(), loadBalance));
     }
 
     /**
@@ -165,7 +167,8 @@ public class PostgresConnection extends JdbcConnection {
      * @param config {@link Configuration} instance, may not be null.
      * @param connectionUsage a symbolic name of the connection to be tracked in monitoring tools
      */
-    public PostgresConnection(JdbcConfiguration config, String connectionUsage, Boolean loadBalance) {
+    public PostgresConnection(JdbcConfiguration config, String connectionUsage,
+            String loadBalance) {
         this(config, null, connectionUsage, loadBalance);
     }
 
@@ -182,14 +185,15 @@ public class PostgresConnection extends JdbcConnection {
      *
      * @return a {@code String} where the variables in {@code urlPattern} are replaced with values from the configuration
      */
-    public String connectionString(Boolean loadBalance) {
-        Pair<String, String> urlPatterns = PostgresConnectorConfig
-                .findAndReplaceLoadBalancePropertyValues(loadBalance);
+    @Override
+    public String connectionString(String loadBalance) {
+        Pair<String, String> urlPatterns =
+            PostgresConnectorConfig.findAndReplaceLoadBalancePropertyValues(loadBalance);
         String hostName = jdbcConfig.getHostname();
         if (hostName.contains(":")) {
-            return connectionString(urlPatterns.getFirst());
+            return super.connectionString(urlPatterns.getFirst());
         } else {
-            return connectionString(urlPatterns.getSecond());
+            return super.connectionString(urlPatterns.getSecond());
         }
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -145,7 +145,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
     private ServerInfo.ReplicationSlot getSlotInfo() throws SQLException, InterruptedException {
         try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(),
-                PostgresConnection.CONNECTION_SLOT_INFO, connectorConfig.ybShouldLoadBalanceConnections())) {
+                PostgresConnection.CONNECTION_SLOT_INFO, connectorConfig.getYbLoadBalanceConnections())) {
             return connection.readReplicationSlotInfo(slotName, plugin.getPostgresPluginName());
         }
     }
@@ -824,7 +824,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         if (dropSlotOnClose && dropSlot) {
             // we're dropping the replication slot via a regular - i.e. not a replication - connection
             try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(),
-                    PostgresConnection.CONNECTION_DROP_SLOT, connectorConfig.ybShouldLoadBalanceConnections())) {
+                    PostgresConnection.CONNECTION_DROP_SLOT, connectorConfig.getYbLoadBalanceConnections())) {
                 connection.dropReplicationSlot(slotName);
             }
             catch (Throwable e) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/transforms/timescaledb/QueryInformationSchemaMetadata.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/transforms/timescaledb/QueryInformationSchemaMetadata.java
@@ -53,7 +53,8 @@ public class QueryInformationSchemaMetadata extends AbstractTimescaleDbMetadata 
         connection = new PostgresConnection(
                 JdbcConfiguration.adapt(config.subset(CommonConnectorConfig.DATABASE_CONFIG_PREFIX, true)
                         .merge(config.subset(CommonConnectorConfig.DRIVER_CONFIG_PREFIX, true))),
-                "Debezium TimescaleDB metadata", config.getBoolean(PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS));
+                "Debezium TimescaleDB metadata",
+                config.getString(PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS));
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorConfigDefTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorConfigDefTest.java
@@ -121,6 +121,17 @@ public class PostgresConnectorConfigDefTest extends ConfigDefinitionMetadataTest
         assertThat(valid).isTrue();
     }
 
+    @Test
+    public void shouldFailForInvalidYbLoadBalanceConnectionsValue() {
+        Configuration.Builder configBuilder = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS, "invalid");
+
+        int problemCount = PostgresConnectorConfig.validateYbLoadBalanceConnectionsValue(
+                configBuilder.build(), PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS, (field, value, problemMessage) -> System.out.println(problemMessage));
+
+        assertThat((problemCount == 1)).isTrue();
+    }
+
     public void validateCorrectHostname(boolean multiNode) {
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.HOSTNAME, multiNode ? "127.0.0.1:5433,127.0.0.2:5433,127.0.0.3:5433" : "127.0.0.1");

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -262,7 +262,8 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         validateConfigField(validatedConfig, PostgresConnectorConfig.LOGICAL_DECODING_MESSAGE_PREFIX_EXCLUDE_LIST, null);
         validateConfigField(validatedConfig, PostgresConnectorConfig.LOGICAL_DECODING_MESSAGE_PREFIX_INCLUDE_LIST, null);
         validateConfigField(validatedConfig, PostgresConnectorConfig.YB_CONSISTENT_SNAPSHOT, Boolean.TRUE);
-        validateConfigField(validatedConfig, PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS, Boolean.TRUE);
+        validateConfigField(validatedConfig, PostgresConnectorConfig.YB_LOAD_BALANCE_CONNECTIONS,
+                String.valueOf("only-primary"));
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -140,7 +140,8 @@ public final class TestHelper {
      * @return the PostgresConnection instance; never null
      */
     public static PostgresConnection create() {
-        return new PostgresConnection(defaultJdbcConfig(), CONNECTION_TEST, true /* loadBalance */);
+        return new PostgresConnection(
+                defaultJdbcConfig(), CONNECTION_TEST, "only-primary" /* loadBalance */);
     }
 
     /**
@@ -155,7 +156,7 @@ public final class TestHelper {
                 config.getJdbcConfig(),
                 getPostgresValueConverterBuilder(config),
                 CONNECTION_TEST,
-                config.ybShouldLoadBalanceConnections());
+                config.getYbLoadBalanceConnections());
     }
 
     /**
@@ -168,7 +169,7 @@ public final class TestHelper {
     public static PostgresConnection create(String appName) {
         return new PostgresConnection(
                 JdbcConfiguration.adapt(defaultJdbcConfig().edit().with("ApplicationName", appName).build()),
-                CONNECTION_TEST, true /* loadBalance */);
+                CONNECTION_TEST, "only-primary" /* loadBalance */);
     }
 
     /**
@@ -233,7 +234,7 @@ public final class TestHelper {
         final PostgresConnectorConfig config = new PostgresConnectorConfig(defaultConfig().build());
         try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(),
                 getPostgresValueConverterBuilder(config), CONNECTION_TEST,
-                config.ybShouldLoadBalanceConnections())) {
+                config.getYbLoadBalanceConnections())) {
             return connection.getTypeRegistry();
         }
     }
@@ -241,7 +242,8 @@ public final class TestHelper {
     public static PostgresDefaultValueConverter getDefaultValueConverter() {
         final PostgresConnectorConfig config = new PostgresConnectorConfig(defaultConfig().build());
         try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(),
-                getPostgresValueConverterBuilder(config), CONNECTION_TEST, config.ybShouldLoadBalanceConnections())) {
+                getPostgresValueConverterBuilder(config), CONNECTION_TEST,
+                config.getYbLoadBalanceConnections())) {
             return connection.getDefaultValueConverter();
         }
     }
@@ -249,7 +251,8 @@ public final class TestHelper {
     public static Charset getDatabaseCharset() {
         final PostgresConnectorConfig config = new PostgresConnectorConfig(defaultConfig().build());
         try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(),
-                getPostgresValueConverterBuilder(config), CONNECTION_TEST, config.ybShouldLoadBalanceConnections())) {
+                getPostgresValueConverterBuilder(config), CONNECTION_TEST,
+                config.getYbLoadBalanceConnections())) {
             return connection.getDatabaseCharset();
         }
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
@@ -239,7 +239,7 @@ public class PostgresConnectionIT {
             assertTrue(replConnection.isConnected());
         }
         try (PostgresConnection withIdleTransaction = new PostgresConnection(JdbcConfiguration.adapt(TestHelper.defaultJdbcConfig()),
-                PostgresConnection.CONNECTION_GENERAL,true /* loadBalance */);
+                PostgresConnection.CONNECTION_GENERAL, "only-primary" /* loadBalance */);
                 PostgresConnection withEmptyConfirmedFlushLSN = buildConnectionWithEmptyConfirmedFlushLSN(slotName)) {
             withIdleTransaction.setAutoCommit(false);
             withIdleTransaction.query("select 1", connection -> {
@@ -253,7 +253,8 @@ public class PostgresConnectionIT {
 
     // "fake" a pg95 response by not returning confirmed_flushed_lsn
     private PostgresConnection buildPG95PGConn(String name) {
-        return new PostgresConnection(JdbcConfiguration.adapt(TestHelper.defaultJdbcConfig()), name, true /* loadBalance */) {
+        return new PostgresConnection(JdbcConfiguration.adapt(TestHelper.defaultJdbcConfig()), name,
+                "only-primary" /* loadBalance */) {
             @Override
             protected ServerInfo.ReplicationSlot queryForSlot(String slotName, String database, String pluginName,
                                                               ResultSetMapper<ServerInfo.ReplicationSlot> map)
@@ -270,7 +271,8 @@ public class PostgresConnectionIT {
     }
 
     private PostgresConnection buildConnectionWithEmptyConfirmedFlushLSN(String name) {
-        return new PostgresConnection(JdbcConfiguration.adapt(TestHelper.defaultJdbcConfig()), name, true /* loadBalance */) {
+        return new PostgresConnection(JdbcConfiguration.adapt(TestHelper.defaultJdbcConfig()), name,
+                "only-primary" /* loadBalance */) {
             @Override
             protected ServerInfo.ReplicationSlot queryForSlot(String slotName, String database, String pluginName,
                                                               ResultSetMapper<ServerInfo.ReplicationSlot> map)

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDbDatabaseTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDbDatabaseTest.java
@@ -54,7 +54,7 @@ public class TimescaleDbDatabaseTest extends AbstractConnectorTest {
         Startables.deepStart(timescaleDbContainer).join();
         connection = new PostgresConnection(
                 TestHelper.defaultJdbcConfig(timescaleDbContainer.getHost(), timescaleDbContainer.getMappedPort(5432)),
-                TestHelper.CONNECTION_TEST, true /* loadBalance */);
+                TestHelper.CONNECTION_TEST, "only-primary" /* loadBalance */);
         dropPublication(connection);
         connection.execute(
                 "DROP TABLE IF EXISTS conditions",


### PR DESCRIPTION
### Problem

Currently, the yb.load.balance.connections config is a boolean and so only accepts either true or false. However, load balancing property of smart drivers accepts additional values such as `any`, `only-primary`, `only-rr`, `prefer-primary` and `prefer-rr`. Currently, the value `any` is alias to yb.load.balance.connections' value `true`.

### Solution

To support these additional values of load balancing property, this PR converts yb.load.balance.connections to string with default value being **`only-primary`**. PR also changes the JDBC smart driver version to `42.7.3-yb-4` since load-balance property (including advanced options like `any`, `only-primary`, `only-rr`, etc.) is supported in version `42.7.3-yb-1` and later.

### Test Plan

To validate the change, a YugabyteDB cluster was deployed and connected to a custom docker image of the connector. The connection was established to the correct node as per the value of the yb.load.balance.connections property provided in connector creation request (or defaulted to `only-primary` when no value of it was provided).