### PR TITLE
[yugabyte/yugabyte-db#27177] Introduce YSQL major upgrade config property

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -1182,7 +1182,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withImportance(Importance.HIGH)
             .withDefault(false)
             .withDescription("Should be used carefully only on YSQL major upgrade. This will set "
-                    + "yb_skip_read_time_in_walsender to true in the walsender session. Setting this is "
+                    + "yb_ignore_read_time_in_walsender to true in the walsender session. Setting this is "
                     + "required to get over the catalog read errors.");
 
     private final LogicalDecodingMessageFilter logicalDecodingMessageFilter;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -1176,6 +1176,15 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                 return 0;
             });
 
+    public static final Field YSQL_MAJOR_UPGRADE = Field.create("ysql.major.upgrade")
+            .withDisplayName("YSQL major upgrade")
+            .withType(Type.BOOLEAN)
+            .withImportance(Importance.HIGH)
+            .withDefault(false)
+            .withDescription("Should be used carefully only on YSQL major upgrade. This will set "
+                    + "yb_skip_read_time_in_walsender to true in the walsender session. Setting this is "
+                    + "required to get over the catalog read errors.");
+
     private final LogicalDecodingMessageFilter logicalDecodingMessageFilter;
     private final HStoreHandlingMode hStoreHandlingMode;
     private final IntervalHandlingMode intervalHandlingMode;
@@ -1334,6 +1343,10 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         return List.of(getConfig().getString(SLOT_RANGES).trim().split(";"));
     }
 
+    public boolean isYSQLMajorUpgrade() {
+        return getConfig().getBoolean(YSQL_MAJOR_UPGRADE);
+    }
+
     @Override
     public byte[] getUnavailableValuePlaceholder() {
         String placeholder = getConfig().getString(UNAVAILABLE_VALUE_PLACEHOLDER);
@@ -1422,7 +1435,8 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                     STREAMING_MODE,
                     SLOT_NAMES,
                     PUBLICATION_NAMES,
-                    SLOT_RANGES)
+                    SLOT_RANGES,
+                    YSQL_MAJOR_UPGRADE)
             .excluding(INCLUDE_SCHEMA_CHANGES)
             .create();
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -396,6 +396,14 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         initConnection();
 
         connect();
+
+        if (connectorConfig.isYSQLMajorUpgrade()) {
+            try (Statement stmt = pgConnection().createStatement()) {
+                LOGGER.info("Setting yb_skip_read_time_in_walsender for walsender session");
+                stmt.execute("SET yb_skip_read_time_in_walsender = true");
+            }
+        }
+
         if (offset == null || !offset.isValid()) {
             offset = defaultStartingPos;
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -399,8 +399,8 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
         if (connectorConfig.isYSQLMajorUpgrade()) {
             try (Statement stmt = pgConnection().createStatement()) {
-                LOGGER.info("Setting yb_skip_read_time_in_walsender for walsender session");
-                stmt.execute("SET yb_skip_read_time_in_walsender = true");
+                LOGGER.info("Setting yb_ignore_read_time_in_walsender for walsender session");
+                stmt.execute("SET yb_ignore_read_time_in_walsender = true");
             }
         }
 


### PR DESCRIPTION
### Problem

With Yugbayte-DB's ysql upgrade to PG 15, the catalog tables are deleted and recreated during the upgrade process. As a result the walsender fails when it tries to read the catalog tables by setting `yb_read_time` pointing to PG 11 era.

### Solution

With this PR we are introducing a new config property called `ysql.major.upgrade`. The default value of this property is false. Any user experiencing an error due to failure in walsender while reading catalog table can set this property to true. When set, the connector task will set the the `skip_yb_read_time_in_walsender` GUC in the walsender session, whereby the catalog reads will be performed as of the current time. Once the restart time crosses the update time, this config property should be reset to false.   

### Test Plan
Tested the changes manually by orchestrating the upgrade process manually on yugabyted cluster and using custom docker image for the connector.