### PR TITLE
FIx: Upgrade jackson version to 2.19.0 to fix CVE-2025-52999

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <version.kafka>3.6.1</version.kafka>
         <version.zookeeper>3.8.3</version.zookeeper>
         <!-- NOTE: These two versions are maintained separately due to decoupling jackson and databind for downstream -->
-        <version.jackson>2.16.0</version.jackson>
+        <version.jackson>2.19.0</version.jackson>
         <version.jackson.databind>2.13.5</version.jackson.databind>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.netty>4.1.100.Final</version.netty>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <version.kafka>3.6.1</version.kafka>
         <version.zookeeper>3.8.3</version.zookeeper>
         <!-- NOTE: These two versions are maintained separately due to decoupling jackson and databind for downstream -->
-        <version.jackson>2.13.5</version.jackson>
+        <version.jackson>2.16.0</version.jackson>
         <version.jackson.databind>2.13.5</version.jackson.databind>
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.netty>4.1.100.Final</version.netty>


### PR DESCRIPTION
Upgraded jackson version to 2.19.0 to fix CVE-2025-52999