### PR TITLE
[DBZ-PGYB][yugabyte/yugabyte-db#29660] Upgrade Java version to Java 17 in YB connector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,14 @@
 
 FROM debezium/connect:2.5.2.Final
 
+# Install Java 17 (required because connector JAR is compiled with Java 17)
+USER root
+RUN microdnf install -y java-17-openjdk-headless && microdnf clean all \
+    && ln -sfn /usr/lib/jvm/java-17-openjdk-* /usr/lib/jvm/java-17
+ENV JAVA_HOME=/usr/lib/jvm/java-17
+ENV PATH=$JAVA_HOME/bin:$PATH
+USER kafka
+
 WORKDIR $KAFKA_CONNECT_PLUGINS_DIR
 RUN rm -f debezium-connector-postgres/debezium-connector-postgres-*.jar
 RUN rm -rf debezium-connector-db2

--- a/debezium-schema-generator/pom.xml
+++ b/debezium-schema-generator/pom.xml
@@ -70,7 +70,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.9.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <maven.compiler.release>11</maven.compiler.release>
-        <maven.compiler.testRelease>11</maven.compiler.testRelease>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.testRelease>17</maven.compiler.testRelease>
 
-        <!-- Enforce JDK 11 for building (handled via JBoss parent POM)-->
-        <jdk.min.version>11</jdk.min.version>
+        <!-- Enforce JDK 17 for building (handled via JBoss parent POM)-->
+        <jdk.min.version>17</jdk.min.version>
 
         <!-- Maven Plugins -->
         <version.compiler.plugin>3.8.1</version.compiler.plugin>


### PR DESCRIPTION
## Problem 
The current YB connector is based on Java 11. This PR upgrades the Java version and necessary dependencies to Java 17-compatible versions.
The upstream Debezium project upgraded to Java 17 in version 3.0. While we are currently on version 2.5.2, upgrading to Java 17 in this version is safe and beneficial because it simplifies cherry-picking from upstream patches from upstream (which uses Java 17) will not require Java version modifications.


## Solution
To upgrade the Java version we will do the following:

- Update `pom.xml` and change the min. jdk version and maven release version
- Update `debezium-schema-generator/pom.xml` and change maven-plugin-plugin from 3.6.0 to 3.9.0. Required because 3.6.0 uses ASM 7.x which cannot read Java 17 bytecode.
- Update `Dockerfile` - Install Java 17 runtime

## Test Plan
Manual testing + Few existing  