### PR TITLE
[DBZ-PGYB][yugabyte/yugabyte-db#29640] Add support for ORIGIN Message in Yugabyte Connector

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
@@ -138,6 +138,20 @@ public class PostgresOffsetContext extends CommonOffsetContext<SourceInfo> {
         sourceInfo.updateLastCommit(lsn);
     }
 
+    /**
+     * Updates the origin information in the source info.
+     *
+     * @param originName the name of the origin server
+     * @param originLsn the LSN on the origin server
+     */
+    public void updateOrigin(String originName, Lsn originLsn) {
+        sourceInfo.updateOrigin(originName, originLsn);
+    }
+
+    public void clearOrigin() {
+        sourceInfo.clearOrigin();
+    }
+
     boolean hasLastKnownPosition() {
         return sourceInfo.lsn() != null;
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSourceInfoStructMaker.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSourceInfoStructMaker.java
@@ -26,6 +26,8 @@ public class PostgresSourceInfoStructMaker extends AbstractSourceInfoStructMaker
                 .field(SourceInfo.TXID_KEY, Schema.OPTIONAL_INT64_SCHEMA)
                 .field(SourceInfo.LSN_KEY, Schema.OPTIONAL_INT64_SCHEMA)
                 .field(SourceInfo.XMIN_KEY, Schema.OPTIONAL_INT64_SCHEMA)
+                .field(SourceInfo.ORIGIN_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                .field(SourceInfo.ORIGIN_LSN_KEY, Schema.OPTIONAL_INT64_SCHEMA)
                 .build();
     }
 
@@ -53,6 +55,13 @@ public class PostgresSourceInfoStructMaker extends AbstractSourceInfoStructMaker
             if (sourceInfo.xmin() != null) {
                 result.put(SourceInfo.XMIN_KEY, sourceInfo.xmin());
             }
+        }
+
+        if (sourceInfo.originName() != null) {
+            result.put(SourceInfo.ORIGIN_KEY, sourceInfo.originName());
+        }
+        if (sourceInfo.originLsn() != null) {
+            result.put(SourceInfo.ORIGIN_LSN_KEY, sourceInfo.originLsn().asLong());
         }
         return result;
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -325,9 +325,11 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
 
         // Tx BEGIN/END event
         if (message.isTransactionalMessage()) {
-            if(message.getOperation() == Operation.BEGIN) {
+            if (message.getOperation() == Operation.BEGIN) {
                 LOGGER.debug("Processing BEGIN with end LSN {} and txnid {}", lsn, message.getTransactionId());
-            } else {
+                offsetContext.clearOrigin();
+            }
+            else {
                 LOGGER.debug("Processing COMMIT with end LSN {} and txnid {}", lsn, message.getTransactionId());
                 LOGGER.debug("Record count in the txn {} is {} with commit time {}", message.getTransactionId(), recordCount, lsn.asLong() - 1);
                 recordCount = 0;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.DebeziumException;
 import io.debezium.connector.postgresql.connection.LogicalDecodingMessage;
 import io.debezium.connector.postgresql.connection.Lsn;
+import io.debezium.connector.postgresql.connection.OriginMessage;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.PostgresReplicationConnection;
 import io.debezium.connector.postgresql.connection.ReplicationConnection;
@@ -381,6 +382,12 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                     (LogicalDecodingMessage) message);
 
             maybeWarnAboutGrowingWalBacklog(true);
+        }
+        // ORIGIN message - update origin state in offset context
+        else if (message.getOperation() == Operation.ORIGIN) {
+            OriginMessage originMessage = (OriginMessage) message;
+            offsetContext.updateOrigin(originMessage.getOriginName(), originMessage.getOriginLsn());
+            LOGGER.trace("Updated origin information: name={}, lsn={}", originMessage.getOriginName(), originMessage.getOriginLsn());
         }
         // DML event
         else {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/SourceInfo.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/SourceInfo.java
@@ -82,6 +82,8 @@ public final class SourceInfo extends BaseSourceInfo {
     public static final String LSN_KEY = "lsn";
     public static final String MSG_TYPE_KEY = "messageType";
     public static final String LAST_SNAPSHOT_RECORD_KEY = "last_snapshot_record";
+    public static final String ORIGIN_KEY = "origin";
+    public static final String ORIGIN_LSN_KEY = "origin_lsn";
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -95,6 +97,8 @@ public final class SourceInfo extends BaseSourceInfo {
     private Instant timestamp;
     private String schemaName;
     private String tableName;
+    private String originName;
+    private Lsn originLsn;
 
     protected SourceInfo(PostgresConnectorConfig connectorConfig) {
         super(connectorConfig);
@@ -214,6 +218,39 @@ public final class SourceInfo extends BaseSourceInfo {
         return txId;
     }
 
+    /**
+     * @return the name of the origin server from which the transaction originated.
+     */
+    public String originName() {
+        return originName;
+    }
+
+    /**
+     * @return the LSN on the origin server.
+     */
+    public Lsn originLsn() {
+        return originLsn;
+    }
+
+    /**
+     * Updates the origin information for the current transaction.
+     *
+     * @param originName the name of the origin server
+     * @param originLsn the LSN on the origin server
+     */
+    protected void updateOrigin(String originName, Lsn originLsn) {
+        this.originName = originName;
+        this.originLsn = originLsn;
+    }
+
+    /**
+     * Clears the origin information. Called when a new transaction begins.
+     */
+    protected void clearOrigin() {
+        this.originName = null;
+        this.originLsn = null;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("source_info[");
@@ -243,6 +280,12 @@ public final class SourceInfo extends BaseSourceInfo {
         }
         if (tableName != null) {
             sb.append(", table=").append(tableName);
+        }
+        if (originName != null) {
+            sb.append(", origin=").append(originName);
+        }
+        if (originLsn != null) {
+            sb.append(", originLsn=").append(originLsn.asLong());
         }
         sb.append(']');
         return sb.toString();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/OriginMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/OriginMessage.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.postgresql.connection;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.OptionalLong;
+
+/**
+ * Replication message instance representing an ORIGIN message from PostgreSQL.
+ * The ORIGIN message indicates that the transaction originated from another server
+ * in a logical replication setup.
+ *
+ * @author Shishir Sharma
+ */
+public class OriginMessage implements ReplicationMessage {
+
+    private final String originName;
+    private final Lsn originLsn;
+    private final Long transactionId;
+    private final Instant commitTime;
+
+    public OriginMessage(String originName, Lsn originLsn, Long transactionId, Instant commitTime) {
+        this.originName = originName;
+        this.originLsn = originLsn;
+        this.transactionId = transactionId;
+        this.commitTime = commitTime;
+    }
+
+    @Override
+    public Operation getOperation() {
+        return Operation.ORIGIN;
+    }
+
+    @Override
+    public boolean isLastEventForLsn() {
+        return false;
+    }
+
+    @Override
+    public OptionalLong getTransactionId() {
+        return transactionId == null ? OptionalLong.empty() : OptionalLong.of(transactionId);
+    }
+
+    @Override
+    public String getTable() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Column> getOldTupleList() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Column> getNewTupleList() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Instant getCommitTime() {
+        return commitTime;
+    }
+
+    /**
+     * @return the name of the origin server from which the transaction originated
+     */
+    public String getOriginName() {
+        return originName;
+    }
+
+    /**
+     * @return the LSN on the origin server
+     */
+    public Lsn getOriginLsn() {
+        return originLsn;
+    }
+
+    @Override
+    public String toString() {
+        return "OriginMessage [originName=" + originName + ", originLsn=" + (originLsn != null ? originLsn.asString() : null) +
+                ", transactionId=" + transactionId + ", commitTime=" + commitTime + "]";
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
@@ -47,7 +47,8 @@ public interface ReplicationMessage {
         MESSAGE,
         BEGIN,
         COMMIT,
-        NOOP
+        NOOP,
+        ORIGIN
     }
 
     /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -41,6 +41,7 @@ import io.debezium.connector.postgresql.connection.AbstractReplicationMessageCol
 import io.debezium.connector.postgresql.connection.LogicalDecodingMessage;
 import io.debezium.connector.postgresql.connection.Lsn;
 import io.debezium.connector.postgresql.connection.MessageDecoderContext;
+import io.debezium.connector.postgresql.connection.OriginMessage;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.ReplicationMessage.Column;
 import io.debezium.connector.postgresql.connection.ReplicationMessage.NoopMessage;
@@ -134,9 +135,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
             LOGGER.trace("Message Type: {}", type);
             switch (type) {
                 case TYPE:
-                case ORIGIN:
-                    // TYPE/ORIGIN
-                    // These should be skipped without calling shouldMessageBeSkipped. DBZ-5792
+                    // TYPE messages should be skipped without calling shouldMessageBeSkipped. DBZ-5792
                     LOGGER.trace("{} messages are always skipped without calling shouldMessageBeSkipped", type);
                     return true;
                 case TRUNCATE:
@@ -154,6 +153,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
                 case COMMIT:
                 case BEGIN:
                 case RELATION:
+                case ORIGIN:
                     // BEGIN
                     // These types should always be processed due to the nature that they provide
                     // the stream with pertinent per-transaction boundary state we will need to
@@ -163,6 +163,12 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
                     // RELATION
                     // These messages are always sent with a lastReceivedLSN=0; and we need to
                     // always accept these to keep per-stream table state cached properly.
+                    //
+                    // ORIGIN
+                    // These messages contain origin information that needs to be cached for
+                    // subsequent events. Even during restart recovery, we need to process
+                    // ORIGIN messages to have the correct origin info once we reach the
+                    // point where we start emitting events.
                     LOGGER.trace("{} messages are always reprocessed", type);
                     return false;
                 default:
@@ -202,6 +208,9 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
                 break;
             case RELATION:
                 handleRelationMessage(buffer, typeRegistry);
+                break;
+            case ORIGIN:
+                handleOriginMessage(buffer, processor);
                 break;
             case LOGICAL_DECODING_MESSAGE:
                 handleLogicalDecodingMessage(buffer, processor);
@@ -256,6 +265,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         final Lsn lsn = Lsn.valueOf(buffer.getLong()); // LSN
         this.commitTimestamp = PG_EPOCH.plus(buffer.getLong(), ChronoUnit.MICROS);
         this.transactionId = Integer.toUnsignedLong(buffer.getInt());
+
         LOGGER.trace("Event: {}", MessageType.BEGIN);
         LOGGER.trace("Final LSN of transaction: {}", lsn);
         LOGGER.trace("Commit timestamp of transaction: {}", commitTimestamp);
@@ -274,12 +284,36 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         final Lsn lsn = Lsn.valueOf(buffer.getLong()); // LSN of the commit
         final Lsn endLsn = Lsn.valueOf(buffer.getLong()); // End LSN of the transaction
         Instant commitTimestamp = PG_EPOCH.plus(buffer.getLong(), ChronoUnit.MICROS);
+
         LOGGER.trace("Event: {}", MessageType.COMMIT);
         LOGGER.trace("Flags: {} (currently unused and most likely 0)", flags);
         LOGGER.trace("Commit LSN: {}", lsn);
         LOGGER.trace("End LSN of transaction: {}", endLsn);
         LOGGER.trace("Commit timestamp of transaction: {}", commitTimestamp);
         processor.process(new TransactionMessage(Operation.COMMIT, transactionId, commitTimestamp));
+    }
+
+    /**
+     * Callback handler for the 'O' origin replication message.
+     * The origin message indicates that the transaction originated from another server
+     * (e.g., in a logical replication setup).
+     *
+     * Message format according to PostgreSQL protocol:
+     * - Int64: The LSN of the commit on the origin server
+     * - String: Name of the origin
+     *
+     * @param buffer The replication stream buffer
+     * @param processor The replication message processor
+     */
+    private void handleOriginMessage(ByteBuffer buffer, ReplicationMessageProcessor processor) throws SQLException, InterruptedException {
+        Lsn originLsn = Lsn.valueOf(buffer.getLong());
+        String originName = readString(buffer);
+
+        LOGGER.trace("Event: {}", MessageType.ORIGIN);
+        LOGGER.trace("Origin LSN: {}", originLsn);
+        LOGGER.trace("Origin name: {}", originName);
+
+        processor.process(new OriginMessage(originName, originLsn, transactionId, commitTimestamp));
     }
 
     /**

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -3842,6 +3842,138 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         throw new UnsupportedOperationException("Test must be updated for new logical decoder type.");
     }
 
+    @Test
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "ORIGIN messages are only supported by pgoutput decoder")
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 11, reason = "Replication origins require PostgreSQL 11+")
+    public void shouldIncludeOriginInfoInSourceMetadataWhenOriginIsSet() throws Exception {
+        // This test verifies that when a transaction has an associated replication origin,
+        // the origin name and LSN are included in the source metadata of change events.
+        // It tests both pg_replication_origin_session_setup (default LSN 0) and
+        // pg_replication_origin_xact_setup (explicit LSN).
+
+        TestHelper.execute(
+                "DROP TABLE IF EXISTS test_origin;",
+                "CREATE TABLE test_origin (pk SERIAL PRIMARY KEY, data TEXT);");
+
+        String originName = "test_origin_dc1";
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_create('" + originName + "');");
+        }
+        catch (Exception e) {
+            if (!e.getMessage().contains("already exists")) {
+                throw e;
+            }
+        }
+
+        startConnector(config -> config
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_origin")
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA),
+                false);
+
+        consumer = testConsumer(2);
+
+        // Transaction 1: Using pg_replication_origin_session_setup only (LSN defaults to 0)
+        TestHelper.execute(
+                "SELECT pg_replication_origin_session_setup('" + originName + "');" +
+                        "INSERT INTO test_origin (data) VALUES ('test with session setup only');");
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_session_reset();");
+        }
+        catch (Exception e) {
+            // Ignore
+        }
+
+        // Transaction 2: Using pg_replication_origin_xact_setup with explicit LSN (0/12345 = 74565)
+        TestHelper.execute(
+                "SELECT pg_replication_origin_session_setup('" + originName + "');" +
+                        "SELECT pg_replication_origin_xact_setup('0/12345', now());" +
+                        "INSERT INTO test_origin (data) VALUES ('test with explicit LSN');");
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_session_reset();");
+        }
+        catch (Exception e) {
+            // Ignore
+        }
+
+        consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
+
+        // Verify first record (session_setup only, LSN defaults to 0)
+        assertFalse(consumer.isEmpty(), "Expected at least one record");
+        SourceRecord record1 = consumer.remove();
+        Struct source1 = ((Struct) record1.value()).getStruct("source");
+        assertNotNull(source1, "Source struct should not be null");
+
+        String origin1 = source1.getString(SourceInfo.ORIGIN_KEY);
+        Long originLsn1 = source1.getInt64(SourceInfo.ORIGIN_LSN_KEY);
+        logger.info("Record 1 (session_setup): origin={}, origin_lsn={}", origin1, originLsn1);
+
+        assertNotNull(origin1, "Origin should not be null when replication origin is set");
+        assertThat(origin1).isEqualTo(originName);
+        assertNotNull(originLsn1, "Origin LSN should not be null");
+        assertThat(originLsn1).isEqualTo(0L); // Default LSN when using session_setup only
+
+        // Verify second record (xact_setup with explicit LSN)
+        assertFalse(consumer.isEmpty(), "Expected second record");
+        SourceRecord record2 = consumer.remove();
+        Struct source2 = ((Struct) record2.value()).getStruct("source");
+        assertNotNull(source2, "Source struct should not be null");
+
+        String origin2 = source2.getString(SourceInfo.ORIGIN_KEY);
+        Long originLsn2 = source2.getInt64(SourceInfo.ORIGIN_LSN_KEY);
+        logger.info("Record 2 (xact_setup): origin={}, origin_lsn={}", origin2, originLsn2);
+
+        assertNotNull(origin2, "Origin should not be null when replication origin is set");
+        assertThat(origin2).isEqualTo(originName);
+        assertNotNull(originLsn2, "Origin LSN should not be null");
+        assertThat(originLsn2).isEqualTo(74565L); // 0x12345 in decimal
+
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_drop('" + originName + "');");
+        }
+        catch (Exception e) {
+            // Ignore cleanup errors
+        }
+    }
+
+    @Test
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "ORIGIN messages are only supported by pgoutput decoder")
+    public void shouldHaveNullOriginInfoWhenNoOriginIsSet() throws Exception {
+        // This test verifies that when no replication origin is set,
+        // the origin fields in source metadata are null.
+
+        TestHelper.execute(
+                "DROP TABLE IF EXISTS test_no_origin;",
+                "CREATE TABLE test_no_origin (pk SERIAL PRIMARY KEY, data TEXT);");
+
+        // Use waitForSnapshot=false since we're using NO_DATA snapshot mode
+        startConnector(config -> config
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_no_origin")
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA),
+                false);
+
+        consumer = testConsumer(1);
+
+        // Insert without any origin set - this is the normal case
+        TestHelper.execute("INSERT INTO test_no_origin (data) VALUES ('test without origin');");
+
+        consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
+
+        assertFalse(consumer.isEmpty(), "Expected at least one record");
+        SourceRecord record = consumer.remove();
+
+        // Verify the source metadata exists but origin fields are null
+        Struct source = ((Struct) record.value()).getStruct("source");
+        assertNotNull(source, "Source struct should not be null");
+
+        // Origin fields should be null when no origin is set
+        assertThat(source.getString(SourceInfo.ORIGIN_KEY)).isNull();
+        assertThat(source.getInt64(SourceInfo.ORIGIN_LSN_KEY)).isNull();
+
+        // But the schema should still have the fields defined (as optional)
+        assertThat(source.schema().field(SourceInfo.ORIGIN_KEY)).isNotNull();
+        assertThat(source.schema().field(SourceInfo.ORIGIN_LSN_KEY)).isNotNull();
+    }
+
     private void assertInsert(String statement, List<SchemaAndValueField> expectedSchemaAndValuesByColumn) {
         assertInsert(statement, null, expectedSchemaAndValuesByColumn);
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -3974,6 +3974,447 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         assertThat(source.schema().field(SourceInfo.ORIGIN_LSN_KEY)).isNotNull();
     }
 
+    @Test
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "ORIGIN messages are only supported by pgoutput decoder")
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 11, reason = "Replication origins require PostgreSQL 11+")
+    public void shouldNotLeakOriginInfoBetweenTransactions() throws Exception {
+        // This test verifies that origin information does not leak from one transaction to another.
+        // Transaction 1 has an origin set, Transaction 2 does not have an origin.
+        // The DML events from Transaction 2 should NOT show the origin from Transaction 1.
+
+        TestHelper.execute(
+                "DROP TABLE IF EXISTS test_origin_leak;",
+                "CREATE TABLE test_origin_leak (pk SERIAL PRIMARY KEY, data TEXT);");
+
+        String originName = "test_origin_leak_dc1";
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_create('" + originName + "');");
+        }
+        catch (Exception e) {
+            if (!e.getMessage().contains("already exists")) {
+                throw e;
+            }
+        }
+
+        startConnector(config -> config
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_origin_leak")
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA),
+                false);
+
+        consumer = testConsumer(2);
+
+        // Transaction 1: WITH origin set
+        TestHelper.execute(
+                "SELECT pg_replication_origin_session_setup('" + originName + "');" +
+                        "INSERT INTO test_origin_leak (data) VALUES ('transaction with origin');");
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_session_reset();");
+        }
+        catch (Exception e) {
+        }
+
+        // Transaction 2: WITHOUT origin set - this should NOT inherit origin from Transaction 1
+        TestHelper.execute("INSERT INTO test_origin_leak (data) VALUES ('transaction without origin');");
+
+        consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
+
+        // Verify first record (Transaction 1 - has origin)
+        assertFalse(consumer.isEmpty(), "Expected at least one record");
+        SourceRecord record1 = consumer.remove();
+        Struct source1 = ((Struct) record1.value()).getStruct("source");
+        assertNotNull(source1, "Source struct should not be null");
+
+        String origin1 = source1.getString(SourceInfo.ORIGIN_KEY);
+        Long originLsn1 = source1.getInt64(SourceInfo.ORIGIN_LSN_KEY);
+        logger.info("Record 1 (with origin): origin={}, origin_lsn={}", origin1, originLsn1);
+
+        assertNotNull(origin1, "Origin should not be null for transaction with origin set");
+        assertThat(origin1).isEqualTo(originName);
+        assertNotNull(originLsn1, "Origin LSN should not be null");
+
+        // Verify second record (Transaction 2 - NO origin, should be null)
+        assertFalse(consumer.isEmpty(), "Expected second record");
+        SourceRecord record2 = consumer.remove();
+        Struct source2 = ((Struct) record2.value()).getStruct("source");
+        assertNotNull(source2, "Source struct should not be null");
+
+        String origin2 = source2.getString(SourceInfo.ORIGIN_KEY);
+        Long originLsn2 = source2.getInt64(SourceInfo.ORIGIN_LSN_KEY);
+        logger.info("Record 2 (without origin): origin={}, origin_lsn={}", origin2, originLsn2);
+
+        assertThat(origin2)
+                .describedAs("Origin should be null for transaction without origin set - must not leak from previous transaction")
+                .isNull();
+        assertThat(originLsn2)
+                .describedAs("Origin LSN should be null for transaction without origin set")
+                .isNull();
+
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_drop('" + originName + "');");
+        }
+        catch (Exception e) {
+        }
+    }
+
+    @Test
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "ORIGIN messages are only supported by pgoutput decoder")
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 11, reason = "Replication origins require PostgreSQL 11+")
+    public void shouldCorrectlyTrackDifferentOriginsAcrossTransactions() throws Exception {
+        // This test verifies that when two consecutive transactions have different origins,
+        // each transaction's DML events correctly show their respective origin.
+
+        TestHelper.execute(
+                "DROP TABLE IF EXISTS test_multi_origin;",
+                "CREATE TABLE test_multi_origin (pk SERIAL PRIMARY KEY, data TEXT);");
+
+        String originName1 = "test_origin_dc1";
+        String originName2 = "test_origin_dc2";
+
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_create('" + originName1 + "');");
+        }
+        catch (Exception e) {
+            if (!e.getMessage().contains("already exists")) {
+                throw e;
+            }
+        }
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_create('" + originName2 + "');");
+        }
+        catch (Exception e) {
+            if (!e.getMessage().contains("already exists")) {
+                throw e;
+            }
+        }
+
+        startConnector(config -> config
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_multi_origin")
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA),
+                false);
+
+        consumer = testConsumer(2);
+
+        // Transaction 1: With origin "dc1" and LSN 0x11111 (69905)
+        TestHelper.execute(
+                "SELECT pg_replication_origin_session_setup('" + originName1 + "');" +
+                        "SELECT pg_replication_origin_xact_setup('0/11111', now());" +
+                        "INSERT INTO test_multi_origin (data) VALUES ('from dc1');");
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_session_reset();");
+        }
+        catch (Exception e) {
+        }
+
+        // Transaction 2: With DIFFERENT origin "dc2" and LSN 0x22222 (139810)
+        TestHelper.execute(
+                "SELECT pg_replication_origin_session_setup('" + originName2 + "');" +
+                "SELECT pg_replication_origin_xact_setup('0/22222', now());" +
+                "INSERT INTO test_multi_origin (data) VALUES ('from dc2');");
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_session_reset();");
+        }
+        catch (Exception e) {
+        }
+
+        consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
+
+        // Verify first record (Transaction 1 - origin dc1)
+        assertFalse(consumer.isEmpty(), "Expected at least one record");
+        SourceRecord record1 = consumer.remove();
+        Struct source1 = ((Struct) record1.value()).getStruct("source");
+        assertNotNull(source1, "Source struct should not be null");
+
+        String origin1 = source1.getString(SourceInfo.ORIGIN_KEY);
+        Long originLsn1 = source1.getInt64(SourceInfo.ORIGIN_LSN_KEY);
+        logger.info("Record 1 (dc1): origin={}, origin_lsn={}", origin1, originLsn1);
+
+        assertThat(origin1)
+                .describedAs("First transaction should have origin dc1")
+                .isEqualTo(originName1);
+        assertThat(originLsn1)
+                .describedAs("First transaction should have LSN 0x11111")
+                .isEqualTo(69905L); // 0x11111 in decimal
+
+        // Verify second record (Transaction 2 - origin dc2, NOT dc1)
+        assertFalse(consumer.isEmpty(), "Expected second record");
+        SourceRecord record2 = consumer.remove();
+        Struct source2 = ((Struct) record2.value()).getStruct("source");
+        assertNotNull(source2, "Source struct should not be null");
+
+        String origin2 = source2.getString(SourceInfo.ORIGIN_KEY);
+        Long originLsn2 = source2.getInt64(SourceInfo.ORIGIN_LSN_KEY);
+        logger.info("Record 2 (dc2): origin={}, origin_lsn={}", origin2, originLsn2);
+
+        // Second transaction should have its own origin (dc2), NOT the previous one (dc1)
+        assertThat(origin2)
+                .describedAs("Second transaction should have origin dc2, not dc1 from previous transaction")
+                .isEqualTo(originName2);
+        assertThat(originLsn2)
+                .describedAs("Second transaction should have LSN 0x22222")
+                .isEqualTo(139810L); // 0x22222 in decimal
+
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_drop('" + originName1 + "');");
+        }
+        catch (Exception e) {
+        }
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_drop('" + originName2 + "');");
+        }
+        catch (Exception e) {
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-1528")
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "ORIGIN messages are only supported by pgoutput decoder")
+    @SkipWhenDatabaseVersion(check = LESS_THAN, major = 11, reason = "Replication origins require PostgreSQL 11+")
+    @Timeout(value = 10, unit = TimeUnit.MINUTES)
+    public void shouldPreserveOriginInfoAfterConnectorRestartMidTransaction() throws Exception {
+        /*
+         * This test verifies that ORIGIN messages are correctly processed even when
+         * the connector restarts mid-transaction and WalPositionLocator triggers a replay
+         * from the transaction BEGIN.
+         *
+         * Key behavior being tested:
+         * - When the connector stops mid-transaction (lastEventStoredLsn > lastCommitLsn),
+         *   WalPositionLocator ensures streaming resumes from the BEGIN of that transaction.
+         * - During this replay, ORIGIN messages must be processed (shouldMessageBeSkipped returns false)
+         *   to ensure subsequent records have the correct origin info.
+         *
+         * Test approach:
+         * - Insert a large transaction (2M rows) with ORIGIN set - large enough that the connector
+         *   can't process all records before we stop it
+         * - Start connector and consume some records
+         * - Stop connector mid-transaction (before COMMIT is processed)
+         * - Restart connector - WalPositionLocator detects lastEventStoredLsn > lastCommitLsn
+         *   and replays from transaction BEGIN
+         * - Verify records after restart have origin info (proves ORIGIN was re-processed)
+         */
+
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.dropPublication();
+
+        // Create a table with multiple columns to increase message size per row
+        TestHelper.execute(
+                "DROP TABLE IF EXISTS test_origin_restart;",
+                "CREATE TABLE test_origin_restart (pk SERIAL PRIMARY KEY, " +
+                        "col1 TEXT DEFAULT 'data1', col2 TEXT DEFAULT 'data2', col3 TEXT DEFAULT 'data3', " +
+                        "col4 TEXT DEFAULT 'data4', col5 TEXT DEFAULT 'data5', col6 TEXT DEFAULT 'data6', " +
+                        "col7 TEXT DEFAULT 'data7', col8 TEXT DEFAULT 'data8', col9 TEXT DEFAULT 'data9', " +
+                        "col10 TEXT DEFAULT 'data10');");
+
+        String originName = "test_restart_origin";
+        final String originLsnPgFormat = "0/75BCD15"; // 123456789 in decimal
+        final long originLsnValue = 123456789L;
+
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_create('" + originName + "');");
+        }
+        catch (Exception e) {
+            if (!e.getMessage().contains("already exists")) {
+                throw e;
+            }
+        }
+
+        // Start connector first to create replication slot
+        // Using default FileOffsetBackingStore (persistent offsets)
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_origin_restart")
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
+                .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, false)
+                .with(PostgresConnectorConfig.SCHEMA_EXCLUDE_LIST, "postgis")
+                .build();
+
+        start(PostgresConnector.class, config);
+        assertConnectorIsRunning();
+        waitForStreamingToStart();
+
+        // Insert a small initial transaction (WITHOUT origin) to establish lastCommitLsn
+        // This ensures that when we stop mid-transaction later, lastCommitLsn will be
+        // from this transaction, not from the fallback logic
+        logger.info("Inserting initial transaction to establish lastCommitLsn...");
+        TestHelper.execute("INSERT INTO test_origin_restart (col1) VALUES ('initial_row_1'), ('initial_row_2'), ('initial_row_3');");
+
+        // Consume the initial transaction records
+        consumer = testConsumer(3);
+        consumer.await(30, TimeUnit.SECONDS);
+        logger.info("Consumed {} initial records", 3);
+        while (!consumer.isEmpty()) {
+            consumer.remove();
+        }
+
+        // Stop connector before inserting the large transaction
+        // This ensures the 2M row transaction is queued in the replication slot
+        // and the connector will process it when we restart
+        stopConnector();
+        Thread.sleep(1000);
+
+        // Insert 2M rows in a single transaction with ORIGIN set
+        // Since connector is stopped, this transaction will be queued in the replication slot
+        final int totalRows = 2_000_000;
+        final int batchSize = 50_000;
+
+        logger.info("Starting large transaction insert of {} rows with origin '{}'", totalRows, originName);
+
+        try (PostgresConnection conn = TestHelper.create()) {
+            conn.setAutoCommit(false);
+
+            // Set up the replication origin for this session
+            conn.execute("SELECT pg_replication_origin_session_setup('" + originName + "')");
+            conn.execute("SELECT pg_replication_origin_xact_setup('" + originLsnPgFormat + "', now())");
+
+            // Insert rows in batches
+            for (int batch = 0; batch < totalRows / batchSize; batch++) {
+                StringBuilder insertSql = new StringBuilder();
+                insertSql.append("INSERT INTO test_origin_restart (col1, col2, col3, col4, col5, col6, col7, col8, col9, col10) VALUES ");
+                for (int i = 0; i < batchSize; i++) {
+                    if (i > 0) {
+                        insertSql.append(",");
+                    }
+                    int rowNum = batch * batchSize + i;
+                    insertSql.append("('row_").append(rowNum).append("'");
+                    for (int col = 2; col <= 10; col++) {
+                        insertSql.append(", 'col").append(col).append("_row_").append(rowNum).append("'");
+                    }
+                    insertSql.append(")");
+                }
+                conn.executeWithoutCommitting(insertSql.toString());
+                logger.info("Inserted batch {}/{}", batch + 1, totalRows / batchSize);
+            }
+
+            logger.info("Committing large transaction...");
+            conn.commit();
+            logger.info("Large transaction committed");
+
+            try {
+                conn.execute("SELECT pg_replication_origin_session_reset()");
+            }
+            catch (Exception e) {
+            }
+        }
+
+        // Start connector to process the large transaction
+        logger.info("Starting connector to process the large transaction");
+        start(PostgresConnector.class, config);
+        assertConnectorIsRunning();
+        waitForStreamingToStart();
+
+        // Consume some records - just enough to verify origin info works
+        // but not too many so we can stop mid-transaction
+        final int recordsToConsumeFirstRun = 1000;
+        consumer = testConsumer(recordsToConsumeFirstRun);
+        consumer.await(2, TimeUnit.MINUTES);
+
+        // Verify first record has origin info
+        SourceRecord firstRecord = consumer.remove();
+        Struct firstSource = ((Struct) firstRecord.value()).getStruct("source");
+        String firstOrigin = firstSource.getString(SourceInfo.ORIGIN_KEY);
+        Long firstOriginLsn = firstSource.getInt64(SourceInfo.ORIGIN_LSN_KEY);
+        logger.info("First record (first run): origin={}, origin_lsn={}", firstOrigin, firstOriginLsn);
+
+        assertNotNull(firstOrigin, "Origin should not be null in first run");
+        assertThat(firstOrigin).isEqualTo(originName);
+        assertNotNull(firstOriginLsn, "Origin LSN should not be null in first run");
+        assertThat(firstOriginLsn).isEqualTo(originLsnValue);
+
+        // Drain remaining records from the consumer
+        while (!consumer.isEmpty()) {
+            consumer.remove();
+        }
+
+        // Stop connector mid-transaction
+        // With 100k rows, the connector should still be processing when we stop it
+        logger.info("Stopping connector mid-transaction...");
+        stopConnector();
+
+        // Small delay to ensure clean shutdown
+        Thread.sleep(2000);
+
+        // Restart connector - WalPositionLocator should detect lastEventStoredLsn > lastCommitLsn
+        // and replay from the transaction BEGIN, re-processing the ORIGIN message
+        logger.info("Restarting connector (WalPositionLocator should replay from BEGIN)...");
+        start(PostgresConnector.class, config);
+        assertConnectorIsRunning();
+        waitForStreamingToStart();
+
+        // Consume ALL remaining records after restart and verify they all have origin info
+        // This proves that ORIGIN was re-processed during replay
+        logger.info("Consuming all remaining records after restart...");
+
+        int totalRecordsConsumed = 0;
+        int recordsWithOrigin = 0;
+        int recordsWithoutOrigin = 0;
+        int lastPkSeen = 0;
+
+        // Keep consuming until no more records available
+        final long consumeStartTime = System.currentTimeMillis();
+        final long maxConsumeTimeMs = 5 * 60 * 1000; // 5 minutes max
+        boolean hasMoreRecords = true;
+
+        while (hasMoreRecords && System.currentTimeMillis() - consumeStartTime < maxConsumeTimeMs) {
+            // Poll for records with a timeout
+            SourceRecords records = consumeRecordsByTopic(10_000, false);
+            if (records == null || records.allRecordsInOrder().isEmpty()) {
+                logger.info("No more records available after consuming {} total records", totalRecordsConsumed);
+                hasMoreRecords = false;
+                break;
+            }
+
+            for (SourceRecord record : records.allRecordsInOrder()) {
+                totalRecordsConsumed++;
+
+                Struct key = (Struct) record.key();
+                Integer pk = (Integer) key.get(PK_FIELD);
+                if (pk != null) {
+                    lastPkSeen = pk;
+                }
+
+                Struct source = ((Struct) record.value()).getStruct("source");
+                String origin = source.getString(SourceInfo.ORIGIN_KEY);
+                Long originLsn = source.getInt64(SourceInfo.ORIGIN_LSN_KEY);
+
+                if (origin != null && originLsn != null) {
+                    recordsWithOrigin++;
+                    // Verify the values are correct
+                    assertThat(origin).isEqualTo(originName);
+                    assertThat(originLsn).isEqualTo(originLsnValue);
+                }
+                else {
+                    recordsWithoutOrigin++;
+                }
+            }
+
+            // Log progress every 100k records
+            if (totalRecordsConsumed % 100_000 < 10_000) {
+                logger.info("Consumed {} records so far, last pk={}, with origin={}, without origin={}",
+                        totalRecordsConsumed, lastPkSeen, recordsWithOrigin, recordsWithoutOrigin);
+            }
+        }
+
+        logger.info("After restart: consumed {} total records, last pk={}, {} with origin, {} without origin",
+                totalRecordsConsumed, lastPkSeen, recordsWithOrigin, recordsWithoutOrigin);
+
+        // All records should have origin info
+        // This proves that ORIGIN messages are correctly processed during replay
+        assertThat(totalRecordsConsumed)
+                .describedAs("Should have consumed records after restart")
+                .isGreaterThan(0);
+        assertThat(recordsWithOrigin)
+                .describedAs("All records after restart should have origin info (proves ORIGIN was re-processed during replay)")
+                .isEqualTo(totalRecordsConsumed);
+        assertThat(recordsWithoutOrigin)
+                .describedAs("No records should be missing origin info")
+                .isEqualTo(0);
+
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_drop('" + originName + "');");
+        }
+        catch (Exception e) {
+        }
+    }
+
     private void assertInsert(String statement, List<SchemaAndValueField> expectedSchemaAndValuesByColumn) {
         assertInsert(statement, null, expectedSchemaAndValuesByColumn);
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -3867,7 +3867,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
         startConnector(config -> config
                 .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_origin")
-                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA),
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER),
                 false);
 
         consumer = testConsumer(2);
@@ -3898,33 +3898,33 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
 
         // Verify first record (session_setup only, LSN defaults to 0)
-        assertFalse(consumer.isEmpty(), "Expected at least one record");
+        assertFalse("Expected at least one record", consumer.isEmpty());
         SourceRecord record1 = consumer.remove();
         Struct source1 = ((Struct) record1.value()).getStruct("source");
-        assertNotNull(source1, "Source struct should not be null");
+        assertNotNull("Source struct should not be null", source1);
 
         String origin1 = source1.getString(SourceInfo.ORIGIN_KEY);
         Long originLsn1 = source1.getInt64(SourceInfo.ORIGIN_LSN_KEY);
         logger.info("Record 1 (session_setup): origin={}, origin_lsn={}", origin1, originLsn1);
 
-        assertNotNull(origin1, "Origin should not be null when replication origin is set");
+        assertNotNull("Origin should not be null when replication origin is set", origin1);
         assertThat(origin1).isEqualTo(originName);
-        assertNotNull(originLsn1, "Origin LSN should not be null");
+        assertNotNull("Origin LSN should not be null", originLsn1);
         assertThat(originLsn1).isEqualTo(0L); // Default LSN when using session_setup only
 
         // Verify second record (xact_setup with explicit LSN)
-        assertFalse(consumer.isEmpty(), "Expected second record");
+        assertFalse("Expected second record", consumer.isEmpty());
         SourceRecord record2 = consumer.remove();
         Struct source2 = ((Struct) record2.value()).getStruct("source");
-        assertNotNull(source2, "Source struct should not be null");
+        assertNotNull("Source struct should not be null", source2);
 
         String origin2 = source2.getString(SourceInfo.ORIGIN_KEY);
         Long originLsn2 = source2.getInt64(SourceInfo.ORIGIN_LSN_KEY);
         logger.info("Record 2 (xact_setup): origin={}, origin_lsn={}", origin2, originLsn2);
 
-        assertNotNull(origin2, "Origin should not be null when replication origin is set");
+        assertNotNull("Origin should not be null when replication origin is set", origin2);
         assertThat(origin2).isEqualTo(originName);
-        assertNotNull(originLsn2, "Origin LSN should not be null");
+        assertNotNull("Origin LSN should not be null", originLsn2);
         assertThat(originLsn2).isEqualTo(74565L); // 0x12345 in decimal
 
         try {
@@ -3945,10 +3945,10 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
                 "DROP TABLE IF EXISTS test_no_origin;",
                 "CREATE TABLE test_no_origin (pk SERIAL PRIMARY KEY, data TEXT);");
 
-        // Use waitForSnapshot=false since we're using NO_DATA snapshot mode
+        // Use waitForSnapshot=false since we're using NEVER snapshot mode
         startConnector(config -> config
                 .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_no_origin")
-                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA),
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER),
                 false);
 
         consumer = testConsumer(1);
@@ -3958,12 +3958,12 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
 
-        assertFalse(consumer.isEmpty(), "Expected at least one record");
+        assertFalse("Expected at least one record", consumer.isEmpty());
         SourceRecord record = consumer.remove();
 
         // Verify the source metadata exists but origin fields are null
         Struct source = ((Struct) record.value()).getStruct("source");
-        assertNotNull(source, "Source struct should not be null");
+        assertNotNull("Source struct should not be null", source);
 
         // Origin fields should be null when no origin is set
         assertThat(source.getString(SourceInfo.ORIGIN_KEY)).isNull();
@@ -3998,7 +3998,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
         startConnector(config -> config
                 .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_origin_leak")
-                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA),
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER),
                 false);
 
         consumer = testConsumer(2);
@@ -4019,24 +4019,24 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
 
         // Verify first record (Transaction 1 - has origin)
-        assertFalse(consumer.isEmpty(), "Expected at least one record");
+        assertFalse("Expected at least one record", consumer.isEmpty());
         SourceRecord record1 = consumer.remove();
         Struct source1 = ((Struct) record1.value()).getStruct("source");
-        assertNotNull(source1, "Source struct should not be null");
+        assertNotNull("Source struct should not be null", source1);
 
         String origin1 = source1.getString(SourceInfo.ORIGIN_KEY);
         Long originLsn1 = source1.getInt64(SourceInfo.ORIGIN_LSN_KEY);
         logger.info("Record 1 (with origin): origin={}, origin_lsn={}", origin1, originLsn1);
 
-        assertNotNull(origin1, "Origin should not be null for transaction with origin set");
+        assertNotNull("Origin should not be null for transaction with origin set", origin1);
         assertThat(origin1).isEqualTo(originName);
-        assertNotNull(originLsn1, "Origin LSN should not be null");
+        assertNotNull("Origin LSN should not be null", originLsn1);
 
         // Verify second record (Transaction 2 - NO origin, should be null)
-        assertFalse(consumer.isEmpty(), "Expected second record");
+        assertFalse("Expected second record", consumer.isEmpty());
         SourceRecord record2 = consumer.remove();
         Struct source2 = ((Struct) record2.value()).getStruct("source");
-        assertNotNull(source2, "Source struct should not be null");
+        assertNotNull("Source struct should not be null", source2);
 
         String origin2 = source2.getString(SourceInfo.ORIGIN_KEY);
         Long originLsn2 = source2.getInt64(SourceInfo.ORIGIN_LSN_KEY);
@@ -4089,7 +4089,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
         startConnector(config -> config
                 .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_multi_origin")
-                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA),
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER),
                 false);
 
         consumer = testConsumer(2);
@@ -4119,10 +4119,10 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
 
         // Verify first record (Transaction 1 - origin dc1)
-        assertFalse(consumer.isEmpty(), "Expected at least one record");
+        assertFalse("Expected at least one record", consumer.isEmpty());
         SourceRecord record1 = consumer.remove();
         Struct source1 = ((Struct) record1.value()).getStruct("source");
-        assertNotNull(source1, "Source struct should not be null");
+        assertNotNull("Source struct should not be null", source1);
 
         String origin1 = source1.getString(SourceInfo.ORIGIN_KEY);
         Long originLsn1 = source1.getInt64(SourceInfo.ORIGIN_LSN_KEY);
@@ -4136,10 +4136,10 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
                 .isEqualTo(69905L); // 0x11111 in decimal
 
         // Verify second record (Transaction 2 - origin dc2, NOT dc1)
-        assertFalse(consumer.isEmpty(), "Expected second record");
+        assertFalse("Expected second record", consumer.isEmpty());
         SourceRecord record2 = consumer.remove();
         Struct source2 = ((Struct) record2.value()).getStruct("source");
-        assertNotNull(source2, "Source struct should not be null");
+        assertNotNull("Source struct should not be null", source2);
 
         String origin2 = source2.getString(SourceInfo.ORIGIN_KEY);
         Long originLsn2 = source2.getInt64(SourceInfo.ORIGIN_LSN_KEY);
@@ -4165,11 +4165,10 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         }
     }
 
-    @Test
+    @Test(timeout = 600000)
     @FixFor("DBZ-1528")
     @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "ORIGIN messages are only supported by pgoutput decoder")
     @SkipWhenDatabaseVersion(check = LESS_THAN, major = 11, reason = "Replication origins require PostgreSQL 11+")
-    @Timeout(value = 10, unit = TimeUnit.MINUTES)
     public void shouldPreserveOriginInfoAfterConnectorRestartMidTransaction() throws Exception {
         /*
          * This test verifies that ORIGIN messages are correctly processed even when
@@ -4221,13 +4220,13 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         // Using default FileOffsetBackingStore (persistent offsets)
         Configuration config = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_origin_restart")
-                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NO_DATA)
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
                 .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
                 .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, false)
                 .with(PostgresConnectorConfig.SCHEMA_EXCLUDE_LIST, "postgis")
                 .build();
 
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         assertConnectorIsRunning();
         waitForStreamingToStart();
 
@@ -4297,7 +4296,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
         // Start connector to process the large transaction
         logger.info("Starting connector to process the large transaction");
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         assertConnectorIsRunning();
         waitForStreamingToStart();
 
@@ -4314,9 +4313,9 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         Long firstOriginLsn = firstSource.getInt64(SourceInfo.ORIGIN_LSN_KEY);
         logger.info("First record (first run): origin={}, origin_lsn={}", firstOrigin, firstOriginLsn);
 
-        assertNotNull(firstOrigin, "Origin should not be null in first run");
+        assertNotNull("Origin should not be null in first run", firstOrigin);
         assertThat(firstOrigin).isEqualTo(originName);
-        assertNotNull(firstOriginLsn, "Origin LSN should not be null in first run");
+        assertNotNull("Origin LSN should not be null in first run", firstOriginLsn);
         assertThat(firstOriginLsn).isEqualTo(originLsnValue);
 
         // Drain remaining records from the consumer
@@ -4335,7 +4334,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         // Restart connector - WalPositionLocator should detect lastEventStoredLsn > lastCommitLsn
         // and replay from the transaction BEGIN, re-processing the ORIGIN message
         logger.info("Restarting connector (WalPositionLocator should replay from BEGIN)...");
-        start(PostgresConnector.class, config);
+        start(YugabyteDBConnector.class, config);
         assertConnectorIsRunning();
         waitForStreamingToStart();
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -4108,8 +4108,8 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         // Transaction 2: With DIFFERENT origin "dc2" and LSN 0x22222 (139810)
         TestHelper.execute(
                 "SELECT pg_replication_origin_session_setup('" + originName2 + "');" +
-                "SELECT pg_replication_origin_xact_setup('0/22222', now());" +
-                "INSERT INTO test_multi_origin (data) VALUES ('from dc2');");
+                        "SELECT pg_replication_origin_xact_setup('0/22222', now());" +
+                        "INSERT INTO test_multi_origin (data) VALUES ('from dc2');");
         try {
             TestHelper.execute("SELECT pg_replication_origin_session_reset();");
         }
@@ -4178,17 +4178,17 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
          *
          * Key behavior being tested:
          * - When the connector stops mid-transaction (lastEventStoredLsn > lastCommitLsn),
-         *   WalPositionLocator ensures streaming resumes from the BEGIN of that transaction.
+         * WalPositionLocator ensures streaming resumes from the BEGIN of that transaction.
          * - During this replay, ORIGIN messages must be processed (shouldMessageBeSkipped returns false)
-         *   to ensure subsequent records have the correct origin info.
+         * to ensure subsequent records have the correct origin info.
          *
          * Test approach:
          * - Insert a large transaction (2M rows) with ORIGIN set - large enough that the connector
-         *   can't process all records before we stop it
+         * can't process all records before we stop it
          * - Start connector and consume some records
          * - Stop connector mid-transaction (before COMMIT is processed)
          * - Restart connector - WalPositionLocator detects lastEventStoredLsn > lastCommitLsn
-         *   and replays from transaction BEGIN
+         * and replays from transaction BEGIN
          * - Verify records after restart have origin info (proves ORIGIN was re-processed)
          */
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -4325,7 +4325,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         }
 
         // Stop connector mid-transaction
-        // With 100k rows, the connector should still be processing when we stop it
+        // With 2M rows, the connector should still be processing when we stop it
         logger.info("Stopping connector mid-transaction...");
         stopConnector();
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SourceInfoTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SourceInfoTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.AbstractSourceInfoStructMaker;
+import io.debezium.connector.postgresql.connection.Lsn;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
 import io.debezium.relational.TableId;
@@ -75,8 +76,44 @@ public class SourceInfoTest {
                 .field("txId", Schema.OPTIONAL_INT64_SCHEMA)
                 .field("lsn", Schema.OPTIONAL_INT64_SCHEMA)
                 .field("xmin", Schema.OPTIONAL_INT64_SCHEMA)
+                .field("origin", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("origin_lsn", Schema.OPTIONAL_INT64_SCHEMA)
                 .build();
 
         VerifyRecord.assertConnectSchemasAreEqual(null, source.struct().schema(), schema);
+    }
+
+    @Test
+    void originInfoIsNullByDefault() {
+        assertThat(source.originName()).isNull();
+        assertThat(source.originLsn()).isNull();
+        // Verify struct doesn't contain origin fields when not set
+        assertThat(source.struct().schema().field(SourceInfo.ORIGIN_KEY)).isNotNull();
+        assertThat(source.struct().schema().field(SourceInfo.ORIGIN_LSN_KEY)).isNotNull();
+    }
+
+    @Test
+    void originInfoCanBeSetAndCleared() {
+        // Set origin info
+        source.updateOrigin("dc1_postgres", Lsn.valueOf(26523000L));
+
+        assertThat(source.originName()).isEqualTo("dc1_postgres");
+        assertThat(source.originLsn()).isEqualTo(Lsn.valueOf(26523000L));
+        assertThat(source.struct().getString(SourceInfo.ORIGIN_KEY)).isEqualTo("dc1_postgres");
+        assertThat(source.struct().getInt64(SourceInfo.ORIGIN_LSN_KEY)).isEqualTo(26523000L);
+
+        // Clear origin info (simulating new transaction)
+        source.clearOrigin();
+
+        assertThat(source.originName()).isNull();
+        assertThat(source.originLsn()).isNull();
+    }
+
+    @Test
+    void originInfoIncludedInToString() {
+        source.updateOrigin("replica_server", Lsn.valueOf(12345L));
+        String str = source.toString();
+        assertThat(str).contains("origin=replica_server");
+        assertThat(str).contains("originLsn=12345");
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBRecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBRecordsStreamProducerIT.java
@@ -3555,8 +3555,6 @@ public class YBRecordsStreamProducerIT extends AbstractRecordsProducerTest {
     }
 
     @Test
-    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "ORIGIN messages are only supported by pgoutput/yboutput decoder")
-    @SkipWhenDatabaseVersion(check = EqualityCheck.LESS_THAN, major = 11, reason = "Replication origins require PostgreSQL 11+")
     public void shouldIncludeOriginInfoInSourceMetadataWhenOriginIsSet() throws Exception {
         // This test verifies that when a transaction has an associated replication origin,
         // the origin name and LSN are included in the source metadata of change events.
@@ -3621,7 +3619,6 @@ public class YBRecordsStreamProducerIT extends AbstractRecordsProducerTest {
     }
 
     @Test
-    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "ORIGIN messages are only supported by pgoutput/yboutput decoder")
     public void shouldHaveNullOriginInfoWhenNoOriginIsSet() throws Exception {
         // This test verifies that when no replication origin is set,
         // the origin fields in source metadata are null.
@@ -3660,8 +3657,6 @@ public class YBRecordsStreamProducerIT extends AbstractRecordsProducerTest {
     }
 
     @Test
-    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "ORIGIN messages are only supported by pgoutput/yboutput decoder")
-    @SkipWhenDatabaseVersion(check = EqualityCheck.LESS_THAN, major = 11, reason = "Replication origins require PostgreSQL 11+")
     public void shouldNotLeakOriginInfoBetweenTransactions() throws Exception {
         // This test verifies that origin information does not leak from one transaction to another.
         // Transaction 1 has an origin set, Transaction 2 does not have an origin.
@@ -3743,8 +3738,6 @@ public class YBRecordsStreamProducerIT extends AbstractRecordsProducerTest {
     }
 
     @Test
-    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "ORIGIN messages are only supported by pgoutput/yboutput decoder")
-    @SkipWhenDatabaseVersion(check = EqualityCheck.LESS_THAN, major = 11, reason = "Replication origins require PostgreSQL 11+")
     public void shouldCorrectlyTrackDifferentOriginsAcrossTransactions() throws Exception {
         // This test verifies that different origins are correctly tracked across transactions.
         // Transaction 1 uses origin "dc1", Transaction 2 uses origin "dc2".
@@ -3844,8 +3837,6 @@ public class YBRecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
     @Test
     @FixFor("DBZ-1528")
-    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "ORIGIN messages are only supported by pgoutput/yboutput decoder")
-    @SkipWhenDatabaseVersion(check = EqualityCheck.LESS_THAN, major = 11, reason = "Replication origins require PostgreSQL 11+")
     public void shouldPreserveOriginInfoAfterConnectorRestartMidTransaction() throws Exception {
         /*
          * This test verifies that ORIGIN messages are correctly processed even when

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBRecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBRecordsStreamProducerIT.java
@@ -3554,6 +3554,528 @@ public class YBRecordsStreamProducerIT extends AbstractRecordsProducerTest {
         consumer.await(5, TimeUnit.SECONDS);
     }
 
+    @Test
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "ORIGIN messages are only supported by pgoutput/yboutput decoder")
+    @SkipWhenDatabaseVersion(check = EqualityCheck.LESS_THAN, major = 11, reason = "Replication origins require PostgreSQL 11+")
+    public void shouldIncludeOriginInfoInSourceMetadataWhenOriginIsSet() throws Exception {
+        // This test verifies that when a transaction has an associated replication origin,
+        // the origin name and LSN are included in the source metadata of change events.
+        // YB Note: In YugabyteDB, the LSN behavior differs from PostgreSQL - LSN won't default to 0,
+        // so we just verify that LSN is present and non-zero.
+
+        TestHelper.execute(
+                "DROP TABLE IF EXISTS test_origin;",
+                "CREATE TABLE test_origin (pk SERIAL PRIMARY KEY, data TEXT);");
+
+        String originName = "test_origin_dc1";
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_create('" + originName + "');");
+        }
+        catch (Exception e) {
+            if (!e.getMessage().contains("already exists")) {
+                throw e;
+            }
+        }
+
+        startConnector(config -> config
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_origin")
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER),
+                false);
+
+        consumer = testConsumer(1);
+
+        // Insert with origin set
+        TestHelper.execute(
+                "SELECT pg_replication_origin_session_setup('" + originName + "');" +
+                        "INSERT INTO test_origin (data) VALUES ('test with origin');");
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_session_reset();");
+        }
+        catch (Exception e) {
+        }
+
+        consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
+
+        // Verify record has origin info
+        Assertions.assertThat(consumer.isEmpty()).as("Expected at least one record").isFalse();
+        SourceRecord record = consumer.remove();
+        Struct source = ((Struct) record.value()).getStruct("source");
+        Assertions.assertThat(source).as("Source struct should not be null").isNotNull();
+
+        String origin = source.getString(SourceInfo.ORIGIN_KEY);
+        Long originLsn = source.getInt64(SourceInfo.ORIGIN_LSN_KEY);
+        LOGGER.info("Record with origin: origin={}, origin_lsn={}", origin, originLsn);
+
+        Assertions.assertThat(origin).as("Origin should not be null when replication origin is set").isNotNull();
+        Assertions.assertThat(origin).isEqualTo(originName);
+        Assertions.assertThat(originLsn).as("Origin LSN should not be null").isNotNull();
+        // YB Note: In YugabyteDB, LSN won't default to 0, so just verify it's present and non-zero
+        Assertions.assertThat(originLsn).isNotEqualTo(0L);
+
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_drop('" + originName + "');");
+        }
+        catch (Exception e) {
+            // Ignore cleanup errors
+        }
+    }
+
+    @Test
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "ORIGIN messages are only supported by pgoutput/yboutput decoder")
+    public void shouldHaveNullOriginInfoWhenNoOriginIsSet() throws Exception {
+        // This test verifies that when no replication origin is set,
+        // the origin fields in source metadata are null.
+
+        TestHelper.execute(
+                "DROP TABLE IF EXISTS test_no_origin;",
+                "CREATE TABLE test_no_origin (pk SERIAL PRIMARY KEY, data TEXT);");
+
+        // Use waitForSnapshot=false since we're using NEVER snapshot mode
+        startConnector(config -> config
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_no_origin")
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER),
+                false);
+
+        consumer = testConsumer(1);
+
+        // Insert without any origin set
+        TestHelper.execute("INSERT INTO test_no_origin (data) VALUES ('test without origin');");
+
+        consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
+
+        Assertions.assertThat(consumer.isEmpty()).as("Expected at least one record").isFalse();
+        SourceRecord record = consumer.remove();
+
+        // Verify the source metadata exists but origin fields are null
+        Struct source = ((Struct) record.value()).getStruct("source");
+        Assertions.assertThat(source).as("Source struct should not be null").isNotNull();
+
+        // Origin fields should be null when no origin is set
+        Assertions.assertThat(source.getString(SourceInfo.ORIGIN_KEY)).isNull();
+        Assertions.assertThat(source.getInt64(SourceInfo.ORIGIN_LSN_KEY)).isNull();
+
+        // But the schema should still have the fields defined
+        Assertions.assertThat(source.schema().field(SourceInfo.ORIGIN_KEY)).isNotNull();
+        Assertions.assertThat(source.schema().field(SourceInfo.ORIGIN_LSN_KEY)).isNotNull();
+    }
+
+    @Test
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "ORIGIN messages are only supported by pgoutput/yboutput decoder")
+    @SkipWhenDatabaseVersion(check = EqualityCheck.LESS_THAN, major = 11, reason = "Replication origins require PostgreSQL 11+")
+    public void shouldNotLeakOriginInfoBetweenTransactions() throws Exception {
+        // This test verifies that origin information does not leak from one transaction to another.
+        // Transaction 1 has an origin set, Transaction 2 does not have an origin.
+        // The DML events from Transaction 2 should NOT show the origin from Transaction 1.
+        // YB Note: In YugabyteDB, LSN won't default to 0, so we verify LSN is non-zero.
+
+        TestHelper.execute(
+                "DROP TABLE IF EXISTS test_origin_leak;",
+                "CREATE TABLE test_origin_leak (pk SERIAL PRIMARY KEY, data TEXT);");
+
+        String originName = "test_origin_leak_dc1";
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_create('" + originName + "');");
+        }
+        catch (Exception e) {
+            if (!e.getMessage().contains("already exists")) {
+                throw e;
+            }
+        }
+
+        startConnector(config -> config
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_origin_leak")
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER),
+                false);
+
+        consumer = testConsumer(2);
+
+        // Transaction 1: WITH origin set
+        TestHelper.execute(
+                "SELECT pg_replication_origin_session_setup('" + originName + "');" +
+                        "INSERT INTO test_origin_leak (data) VALUES ('transaction with origin');");
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_session_reset();");
+        }
+        catch (Exception e) {
+        }
+
+        // Transaction 2: WITHOUT origin set - this should NOT inherit origin from Transaction 1
+        TestHelper.execute("INSERT INTO test_origin_leak (data) VALUES ('transaction without origin');");
+
+        consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
+
+        Assertions.assertThat(consumer.isEmpty()).as("Expected at least one record").isFalse();
+        SourceRecord record1 = consumer.remove();
+        Struct source1 = ((Struct) record1.value()).getStruct("source");
+        Assertions.assertThat(source1).as("Source struct should not be null").isNotNull();
+
+        String origin1 = source1.getString(SourceInfo.ORIGIN_KEY);
+        Long originLsn1 = source1.getInt64(SourceInfo.ORIGIN_LSN_KEY);
+        LOGGER.info("Record 1 (with origin): origin={}, origin_lsn={}", origin1, originLsn1);
+
+        Assertions.assertThat(origin1).as("Origin should not be null for transaction with origin set").isNotNull();
+        Assertions.assertThat(origin1).isEqualTo(originName);
+        Assertions.assertThat(originLsn1).as("Origin LSN should not be null").isNotNull();
+        // YB Note: In YugabyteDB, LSN won't be 0, so just verify it's non-zero
+        Assertions.assertThat(originLsn1).isNotEqualTo(0L);
+
+        Assertions.assertThat(consumer.isEmpty()).as("Expected second record").isFalse();
+        SourceRecord record2 = consumer.remove();
+        Struct source2 = ((Struct) record2.value()).getStruct("source");
+        Assertions.assertThat(source2).as("Source struct should not be null").isNotNull();
+
+        String origin2 = source2.getString(SourceInfo.ORIGIN_KEY);
+        Long originLsn2 = source2.getInt64(SourceInfo.ORIGIN_LSN_KEY);
+        LOGGER.info("Record 2 (without origin): origin={}, origin_lsn={}", origin2, originLsn2);
+
+        Assertions.assertThat(origin2)
+                .describedAs("Origin should be null for transaction without origin set - must not leak from previous transaction")
+                .isNull();
+        Assertions.assertThat(originLsn2)
+                .describedAs("Origin LSN should be null for transaction without origin set")
+                .isNull();
+
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_drop('" + originName + "');");
+        }
+        catch (Exception e) {
+        }
+    }
+
+    @Test
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "ORIGIN messages are only supported by pgoutput/yboutput decoder")
+    @SkipWhenDatabaseVersion(check = EqualityCheck.LESS_THAN, major = 11, reason = "Replication origins require PostgreSQL 11+")
+    public void shouldCorrectlyTrackDifferentOriginsAcrossTransactions() throws Exception {
+        // This test verifies that different origins are correctly tracked across transactions.
+        // Transaction 1 uses origin "dc1", Transaction 2 uses origin "dc2".
+        // Each transaction's events should show its respective origin.
+        // YB Note: In YugabyteDB, LSN won't default to 0, so we verify LSN is non-zero.
+
+        TestHelper.execute(
+                "DROP TABLE IF EXISTS test_multi_origin;",
+                "CREATE TABLE test_multi_origin (pk SERIAL PRIMARY KEY, data TEXT);");
+
+        String originName1 = "test_multi_origin_dc1";
+        String originName2 = "test_multi_origin_dc2";
+
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_create('" + originName1 + "');");
+        }
+        catch (Exception e) {
+            if (!e.getMessage().contains("already exists")) {
+                throw e;
+            }
+        }
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_create('" + originName2 + "');");
+        }
+        catch (Exception e) {
+            if (!e.getMessage().contains("already exists")) {
+                throw e;
+            }
+        }
+
+        startConnector(config -> config
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_multi_origin")
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER),
+                false);
+
+        consumer = testConsumer(2);
+
+        // Transaction 1: origin "dc1"
+        TestHelper.execute(
+                "SELECT pg_replication_origin_session_setup('" + originName1 + "');" +
+                        "INSERT INTO test_multi_origin (data) VALUES ('from dc1');");
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_session_reset();");
+        }
+        catch (Exception e) {
+        }
+
+        // Transaction 2: origin "dc2"
+        TestHelper.execute(
+                "SELECT pg_replication_origin_session_setup('" + originName2 + "');" +
+                        "INSERT INTO test_multi_origin (data) VALUES ('from dc2');");
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_session_reset();");
+        }
+        catch (Exception e) {
+        }
+
+        consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
+
+        // Verify first record has dc1 origin
+        Assertions.assertThat(consumer.isEmpty()).as("Expected at least one record").isFalse();
+        SourceRecord record1 = consumer.remove();
+        Struct source1 = ((Struct) record1.value()).getStruct("source");
+        String origin1 = source1.getString(SourceInfo.ORIGIN_KEY);
+        Long originLsn1 = source1.getInt64(SourceInfo.ORIGIN_LSN_KEY);
+        LOGGER.info("Record 1: origin={}, origin_lsn={}", origin1, originLsn1);
+
+        Assertions.assertThat(origin1).isEqualTo(originName1);
+        Assertions.assertThat(originLsn1).isNotNull();
+        // YB Note: In YugabyteDB, LSN won't be 0
+        Assertions.assertThat(originLsn1).isNotEqualTo(0L);
+
+        // Verify second record has dc2 origin
+        Assertions.assertThat(consumer.isEmpty()).as("Expected second record").isFalse();
+        SourceRecord record2 = consumer.remove();
+        Struct source2 = ((Struct) record2.value()).getStruct("source");
+        String origin2 = source2.getString(SourceInfo.ORIGIN_KEY);
+        Long originLsn2 = source2.getInt64(SourceInfo.ORIGIN_LSN_KEY);
+        LOGGER.info("Record 2: origin={}, origin_lsn={}", origin2, originLsn2);
+
+        Assertions.assertThat(origin2).isEqualTo(originName2);
+        Assertions.assertThat(originLsn2).isNotNull();
+        // YB Note: In YugabyteDB, LSN won't be 0
+        Assertions.assertThat(originLsn2).isNotEqualTo(0L);
+
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_drop('" + originName1 + "');");
+        }
+        catch (Exception e) {
+        }
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_drop('" + originName2 + "');");
+        }
+        catch (Exception e) {
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-1528")
+    @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "ORIGIN messages are only supported by pgoutput/yboutput decoder")
+    @SkipWhenDatabaseVersion(check = EqualityCheck.LESS_THAN, major = 11, reason = "Replication origins require PostgreSQL 11+")
+    public void shouldPreserveOriginInfoAfterConnectorRestartMidTransaction() throws Exception {
+        /*
+         * This test verifies that ORIGIN messages are correctly processed even when
+         * the connector restarts mid-transaction and WalPositionLocator triggers a replay
+         * from the transaction BEGIN.
+         *
+         * Key behavior being tested:
+         * - When the connector stops mid-transaction (lastEventStoredLsn > lastCommitLsn),
+         * WalPositionLocator ensures streaming resumes from the BEGIN of that transaction.
+         * - During this replay, ORIGIN messages must be processed (shouldMessageBeSkipped returns false)
+         * to ensure subsequent records have the correct origin info.
+         *
+         * Test approach:
+         * - Insert a large transaction (2M rows) with ORIGIN set - large enough that the connector
+         * can't process all records before we stop it
+         * - Start connector and consume some records
+         * - Stop connector mid-transaction (before COMMIT is processed)
+         * - Restart connector - WalPositionLocator detects lastEventStoredLsn > lastCommitLsn
+         * and replays from transaction BEGIN
+         * - Verify records after restart have origin info (proves ORIGIN was re-processed)
+         *
+         * YB Note: In YugabyteDB, LSN values differ from PostgreSQL, so we verify LSN is non-zero
+         * instead of checking for specific values.
+         */
+
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.dropPublication();
+
+        TestHelper.execute(
+                "DROP TABLE IF EXISTS test_origin_restart;",
+                "CREATE TABLE test_origin_restart (pk SERIAL PRIMARY KEY, " +
+                        "col1 TEXT DEFAULT 'data1', col2 TEXT DEFAULT 'data2', col3 TEXT DEFAULT 'data3', " +
+                        "col4 TEXT DEFAULT 'data4', col5 TEXT DEFAULT 'data5', col6 TEXT DEFAULT 'data6', " +
+                        "col7 TEXT DEFAULT 'data7', col8 TEXT DEFAULT 'data8', col9 TEXT DEFAULT 'data9', " +
+                        "col10 TEXT DEFAULT 'data10');");
+
+        String originName = "test_restart_origin";
+
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_create('" + originName + "');");
+        }
+        catch (Exception e) {
+            if (!e.getMessage().contains("already exists")) {
+                throw e;
+            }
+        }
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.test_origin_restart")
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
+                .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, false)
+                .with(PostgresConnectorConfig.SCHEMA_EXCLUDE_LIST, "postgis")
+                .build();
+
+        start(YugabyteDBConnector.class, config);
+        assertConnectorIsRunning();
+        waitForStreamingToStart();
+
+        // Insert a small initial transaction (WITHOUT origin) to establish lastCommitLsn
+        // This ensures that when we stop mid-transaction later, lastCommitLsn will be
+        // from this transaction, not from the fallback logic
+        LOGGER.info("Inserting initial transaction to establish lastCommitLsn...");
+        TestHelper.execute("INSERT INTO test_origin_restart (col1) VALUES ('initial_row_1'), ('initial_row_2'), ('initial_row_3');");
+
+        consumer = testConsumer(3);
+        consumer.await(30, TimeUnit.SECONDS);
+        LOGGER.info("Consumed {} initial records", 3);
+        while (!consumer.isEmpty()) {
+            consumer.remove();
+        }
+
+        stopConnector();
+        Thread.sleep(1000);
+
+        // Insert 2M rows in a single transaction with ORIGIN set
+        final int totalRows = 2_000_000;
+        final int batchSize = 50_000;
+
+        LOGGER.info("Starting large transaction insert of {} rows with origin '{}'", totalRows, originName);
+
+        try (PostgresConnection conn = TestHelper.create()) {
+            conn.setAutoCommit(false);
+
+            conn.execute("SELECT pg_replication_origin_session_setup('" + originName + "')");
+
+            for (int batch = 0; batch < totalRows / batchSize; batch++) {
+                StringBuilder insertSql = new StringBuilder();
+                insertSql.append("INSERT INTO test_origin_restart (col1, col2, col3, col4, col5, col6, col7, col8, col9, col10) VALUES ");
+                for (int i = 0; i < batchSize; i++) {
+                    if (i > 0) {
+                        insertSql.append(",");
+                    }
+                    int rowNum = batch * batchSize + i;
+                    insertSql.append("('row_").append(rowNum).append("'");
+                    for (int col = 2; col <= 10; col++) {
+                        insertSql.append(", 'col").append(col).append("_row_").append(rowNum).append("'");
+                    }
+                    insertSql.append(")");
+                }
+                conn.executeWithoutCommitting(insertSql.toString());
+                LOGGER.info("Inserted batch {}/{}", batch + 1, totalRows / batchSize);
+            }
+
+            LOGGER.info("Committing large transaction...");
+            conn.commit();
+            LOGGER.info("Large transaction committed");
+
+            try {
+                conn.execute("SELECT pg_replication_origin_session_reset()");
+            }
+            catch (Exception e) {
+            }
+        }
+
+        LOGGER.info("Starting connector to process the large transaction");
+        start(YugabyteDBConnector.class, config);
+        assertConnectorIsRunning();
+        waitForStreamingToStart();
+
+        // Consume some records - just enough to verify origin info works
+        // but not too many so we can stop mid-transaction
+        final int recordsToConsumeFirstRun = 1000;
+        consumer = testConsumer(recordsToConsumeFirstRun);
+        consumer.await(2, TimeUnit.MINUTES);
+
+        // Verify first record has origin info
+        SourceRecord firstRecord = consumer.remove();
+        Struct firstSource = ((Struct) firstRecord.value()).getStruct("source");
+        String firstOrigin = firstSource.getString(SourceInfo.ORIGIN_KEY);
+        Long firstOriginLsn = firstSource.getInt64(SourceInfo.ORIGIN_LSN_KEY);
+        LOGGER.info("First record (first run): origin={}, origin_lsn={}", firstOrigin, firstOriginLsn);
+
+        Assertions.assertThat(firstOrigin).as("Origin should not be null in first run").isNotNull();
+        Assertions.assertThat(firstOrigin).isEqualTo(originName);
+        Assertions.assertThat(firstOriginLsn).as("Origin LSN should not be null in first run").isNotNull();
+        // YB Note: In YugabyteDB, LSN won't be 0, so just verify it's non-zero
+        Assertions.assertThat(firstOriginLsn).isNotEqualTo(0L);
+
+        // Drain remaining records from the consumer
+        while (!consumer.isEmpty()) {
+            consumer.remove();
+        }
+
+        // Stop connector mid-transaction
+        LOGGER.info("Stopping connector mid-transaction...");
+        stopConnector();
+
+        Thread.sleep(2000);
+
+        // Restart connector - WalPositionLocator should detect lastEventStoredLsn > lastCommitLsn
+        // and replay from the transaction BEGIN, re-processing the ORIGIN message
+        LOGGER.info("Restarting connector (WalPositionLocator should replay from BEGIN)...");
+        start(YugabyteDBConnector.class, config);
+        assertConnectorIsRunning();
+        waitForStreamingToStart();
+
+        // Consume ALL remaining records after restart and verify they all have origin info
+        // This proves that ORIGIN was re-processed during replay
+        LOGGER.info("Consuming all remaining records after restart...");
+
+        int totalRecordsConsumed = 0;
+        int recordsWithOrigin = 0;
+        int recordsWithoutOrigin = 0;
+        int lastPkSeen = 0;
+
+        // Keep consuming until no more records available
+        final long consumeStartTime = System.currentTimeMillis();
+        final long maxConsumeTimeMs = 5 * 60 * 1000; // 5 minutes max
+        boolean hasMoreRecords = true;
+
+        while (hasMoreRecords && System.currentTimeMillis() - consumeStartTime < maxConsumeTimeMs) {
+
+            SourceRecords records = consumeRecordsByTopic(10_000, false);
+            if (records == null || records.allRecordsInOrder().isEmpty()) {
+                LOGGER.info("No more records available after consuming {} total records", totalRecordsConsumed);
+                hasMoreRecords = false;
+                break;
+            }
+
+            for (SourceRecord record : records.allRecordsInOrder()) {
+                totalRecordsConsumed++;
+
+                Struct key = (Struct) record.key();
+                Integer pk = (Integer) key.get(PK_FIELD);
+                if (pk != null) {
+                    lastPkSeen = pk;
+                }
+
+                Struct source = ((Struct) record.value()).getStruct("source");
+                String origin = source.getString(SourceInfo.ORIGIN_KEY);
+                Long originLsn = source.getInt64(SourceInfo.ORIGIN_LSN_KEY);
+
+                if (origin != null && originLsn != null) {
+                    recordsWithOrigin++;
+                    Assertions.assertThat(origin).isEqualTo(originName);
+                    // YB Note: In YugabyteDB, LSN won't be 0, so just verify it's non-zero
+                    Assertions.assertThat(originLsn).isNotEqualTo(0L);
+                }
+                else {
+                    recordsWithoutOrigin++;
+                }
+            }
+
+            if (totalRecordsConsumed % 100_000 < 10_000) {
+                LOGGER.info("Consumed {} records so far, last pk={}, with origin={}, without origin={}",
+                        totalRecordsConsumed, lastPkSeen, recordsWithOrigin, recordsWithoutOrigin);
+            }
+        }
+
+        LOGGER.info("After restart: consumed {} total records, last pk={}, {} with origin, {} without origin",
+                totalRecordsConsumed, lastPkSeen, recordsWithOrigin, recordsWithoutOrigin);
+
+        Assertions.assertThat(totalRecordsConsumed)
+                .describedAs("Should have consumed records after restart")
+                .isGreaterThan(0);
+        Assertions.assertThat(recordsWithOrigin)
+                .describedAs("All records after restart should have origin info (proves ORIGIN was re-processed during replay)")
+                .isEqualTo(totalRecordsConsumed);
+        Assertions.assertThat(recordsWithoutOrigin)
+                .describedAs("No records should be missing origin info")
+                .isEqualTo(0);
+
+        try {
+            TestHelper.execute("SELECT pg_replication_origin_drop('" + originName + "');");
+        }
+        catch (Exception e) {
+        }
+    }
+
     @Override
     protected Consumer<SourceRecord> getConsumer(Predicate<SourceRecord> isStopRecord, Consumer<SourceRecord> recordArrivedListener, boolean ignoreRecordsAfterStop) {
         return (record) -> {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBRecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBRecordsStreamProducerIT.java
@@ -3614,7 +3614,6 @@ public class YBRecordsStreamProducerIT extends AbstractRecordsProducerTest {
             TestHelper.execute("SELECT pg_replication_origin_drop('" + originName + "');");
         }
         catch (Exception e) {
-            // Ignore cleanup errors
         }
     }
 


### PR DESCRIPTION
## Problem 
PostgreSQL's logical replication protocol includes ORIGIN messages that identify the source of transactions in cascaded replication setups. This is particularly important for hub-and-spoke replication topologies where changes may originate from different clusters and need to be tracked to prevent replication loops.

**Current Limitation: When a PostgreSQL connector receives an ORIGIN message, it simply acknowledges and skips it without processing.**

Read more about the Origin message format at [Logical Replication Message Formats](https://www.postgresql.org/docs/12/protocol-logicalrep-message-formats.html)

## Solution

Extend the PostgreSQL connector to capture and propagate replication origin metadata from PostgreSQL's logical replication stream.

### Implementation Details

1. **Add ORIGIN as a ReplicationMessage Operation**
   - Added `ORIGIN` to the `ReplicationMessage.Operation` enum
   - Created `OriginMessage` class (similar to `TransactionMessage`) to represent ORIGIN messages

2. **Parse and Emit ORIGIN Messages in PgOutputMessageDecoder**
   - Parse `origin_name` and `origin_lsn` when an ORIGIN message is received
   - ORIGIN message format: Int64 (origin LSN) followed by null-terminated string (origin name)
   - Emit `OriginMessage` to the processor instead of caching values in the decoder

3. **Handle ORIGIN in PostgresStreamingChangeEventSource**
   - Process `Operation.ORIGIN` messages to update origin state in `PostgresOffsetContext`
   - ORIGIN messages are "swallowed" (not dispatched to EventDispatcher) - they only update state
   - Subsequent DML events automatically include origin info from `SourceInfo`

4. **Propagate Origin to Change Events**
   - `SourceInfo` stores origin metadata (`originName`, `originLsn`)
   - `PostgresSourceInfoStructMaker` adds optional `origin` and `origin_lsn` fields to the source schema
   - All DML events within a transaction include the origin info in their source block

5. **Restart Recovery Handling**
   - Always process ORIGIN messages even during WAL position recovery (skip phase)
   - `shouldMessageBeSkipped()` explicitly returns `false` for ORIGIN messages
   - This ensures that when replaying from transaction BEGIN after a crash, the origin state is populated before processing resumed events

Example:
```
{
  "before": null,
  "after": {
    "id": {
      "value": 48417,
      "set": true
    }
  },
  "source": {
    "version": "dz.2.5.2.yb.2025.1.SNAPSHOT.3",
    "connector": "postgresql",
    "name": "dbserver2",
    "ts_ms": 1767343556846,
    "snapshot": "false",
    "db": "yugabyte",
    "sequence": "[\"5\",\"38423\"]",
    "schema": "public",
    "table": "t1",
    "txId": 3,
    "lsn": 38423,
    "xmin": null,
    "origin": "origin1",  // ← New field added
    "origin_lsn": 100006        // ← New field added
  },
  "op": "c",
  "ts_ms": 1767343722393,
  "transaction": null
}
```


## Test plan

```
# Unit tests
SourceInfoTest#originInfoIsNullByDefault+originInfoCanBeSetAndCleared+originInfoIncludedInToString"

# Integration tests
YBRecordsStreamProducerIT#shouldIncludeOriginInfoInSourceMetadataWhenOriginIsSet+shouldHaveNullOriginInfoWhenNoOriginIsSet+shouldNotLeakOriginInfoBetweenTransactions+shouldCorrectlyTrackDifferentOriginsAcrossTransactions+shouldPreserveOriginInfoAfterConnectorRestartMidTransaction
```