### PR TITLE
[DBZ-PGYB][yugabyte/yugabyte-db#30378] Return dummy value from currentXLogLocation() for YugabyteDB

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
@@ -245,7 +245,7 @@ public class PostgresOffsetContext extends CommonOffsetContext<SourceInfo> {
                                                        Lsn lastCompletelyProcessedLsn) {
         try {
             LOGGER.info("Creating initial offset context");
-            final Lsn lsn = Lsn.valueOf(jdbcConnection.currentXLogLocation());
+            final Lsn lsn = YugabyteDBServer.isEnabled() ? null : Lsn.valueOf(jdbcConnection.currentXLogLocation());
             final Long txId = jdbcConnection.currentTransactionId();
             LOGGER.info("Read xlogStart at '{}' from transaction '{}'", lsn, txId);
             return new PostgresOffsetContext(

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -574,7 +574,6 @@ public class PostgresConnection extends JdbcConnection {
      * @throws SQLException if anything unexpected fails.
      */
     public long currentXLogLocation() throws SQLException {
-
         AtomicLong result = new AtomicLong(0);
         int majorVersion = connection().getMetaData().getDatabaseMajorVersion();
         query(majorVersion >= 10 ? "select (case pg_is_in_recovery() when 't' then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end) AS pg_current_wal_lsn"

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -574,12 +574,6 @@ public class PostgresConnection extends JdbcConnection {
      * @throws SQLException if anything unexpected fails.
      */
     public long currentXLogLocation() throws SQLException {
-        // YB Note: pg_current_wal_lsn() is not supported in YugabyteDB since each tablet maintains
-        // its own WAL (yugabyte/yugabyte-db#30243).
-        // Returning a dummy value.
-        if (YugabyteDBServer.isEnabled()) {
-            return Long.MAX_VALUE;
-        }
 
         AtomicLong result = new AtomicLong(0);
         int majorVersion = connection().getMetaData().getDatabaseMajorVersion();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -574,6 +574,13 @@ public class PostgresConnection extends JdbcConnection {
      * @throws SQLException if anything unexpected fails.
      */
     public long currentXLogLocation() throws SQLException {
+        // YB Note: pg_current_wal_lsn() is not supported in YugabyteDB since each tablet maintains
+        // its own WAL (yugabyte/yugabyte-db#30243).
+        // Returning a dummy value.
+        if (YugabyteDBServer.isEnabled()) {
+            return Long.MAX_VALUE;
+        }
+
         AtomicLong result = new AtomicLong(0);
         int majorVersion = connection().getMetaData().getDatabaseMajorVersion();
         query(majorVersion >= 10 ? "select (case pg_is_in_recovery() when 't' then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end) AS pg_current_wal_lsn"

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Field;
@@ -60,11 +61,14 @@ public class PostgresConnectionIT {
         }
     }
 
+    // YB: Note: pg_current_wal_lsn() is not supported in YugabyteDB since each tablet
+    // maintains its own WAL (yugabyte/yugabyte-db#30243).
     @Test
     public void shouldReportValidXLogPos() throws SQLException {
         try (PostgresConnection connection = TestHelper.create()) {
             connection.connect();
-            assertTrue(connection.currentXLogLocation() > 0);
+            SQLException exception = assertThrows(SQLException.class, connection::currentXLogLocation);
+            assertTrue(exception.getMessage().contains("pg_current_wal_lsn() is not yet supported"));
         }
     }
 


### PR DESCRIPTION
## Problem
With the commit https://github.com/yugabyte/yugabyte-db/commit/f1d0a1fb6158 we have disabled `pg_current_wal_lsn()` since each tablet maintains its own WAL, making a single global WAL LSN is unsupported. Before this change, the function returned a garbage value (e.g. 0/1000118) that was never meaningful for YugabyteDB. Now calling it throws an error, causing the connector to fail during the streaming init phase:
```
Caused by: com.yugabyte.util.PSQLException: ERROR: pg_current_wal_lsn() is not yet supported
  Hint: See https://github.com/yugabyte/yugabyte-db/issues/30243. React with thumbs up to raise its priority.
```

## Solution

Skip calling `currentXLogLocation()` in `initialContext()` when YugabyteDB is enabled, passing `null` as the LSN instead. This is safe because the value is never meaningfully used for YugabyteDB:


- **Snapshot path** (`determineSnapshotOffset`): The LSN from `initialContext()` is immediately overwritten by `updateOffsetForSnapshot()` → `getTransactionStartLsn()`, which already has a YB-specific path returning `slotLastFlushedLsn()`.
- **Streaming init path** (when `offsetContext` is null): The streaming start position is determined by the replication slot, not this value (`hasStartLsnStoredInContext` is false → `replicationConnection.startStreaming(walPosition)` without an LSN).
- **Pre-snapshot catch-up streaming** (`updateOffsetForPreSnapshotCatchUpStreaming`): Never entered because `shouldStreamEventsStartingFromSnapshot()` defaults to `true` and no snapshotter overrides it.
- **`getTransactionStartLsn()` fallback**: Never reached for YugabyteDB due to the early return at the `YugabyteDBServer.isEnabled()` branch.


## Test Plan
```
mvn test -pl debezium-connector-postgres -Dtest=PostgresConnectionIT#shouldReportValidXLogPos
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup offset initialization behavior by allowing a `null` LSN for YugabyteDB, which could affect any code paths that implicitly assume a non-null starting LSN.
> 
> **Overview**
> Prevents the connector from failing during streaming initialization on YugabyteDB by skipping `currentXLogLocation()` in `PostgresOffsetContext.initialContext()` and initializing the starting LSN as `null` when `YugabyteDBServer.isEnabled()`.
> 
> Updates `PostgresConnectionIT#shouldReportValidXLogPos` to assert that `currentXLogLocation()` throws a `SQLException` with the expected “pg_current_wal_lsn() is not yet supported” message (reflecting YugabyteDB behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7f550a13a4a652ec6246b1dda1ec7ec0f8c65d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->