### PR TITLE
[DBZ-PGYB][yugabyte/yugabyte-db#30733] Fix null Kafka key when connector resumes after table drop

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -5,8 +5,6 @@
  */
 package io.debezium.connector.postgresql.connection.pgoutput;
 
-import static java.util.stream.Collectors.toMap;
-
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.sql.DatabaseMetaData;
@@ -21,21 +19,20 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
-import com.yugabyte.replication.fluent.logical.ChainedLogicalStreamBuilder;
-import io.debezium.connector.postgresql.YugabyteDBServer;
-import io.debezium.connector.postgresql.connection.ReplicaIdentityInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.yugabyte.replication.fluent.logical.ChainedLogicalStreamBuilder;
 
 import io.debezium.connector.postgresql.PostgresStreamingChangeEventSource.PgConnectionSupplier;
 import io.debezium.connector.postgresql.PostgresType;
 import io.debezium.connector.postgresql.TypeRegistry;
 import io.debezium.connector.postgresql.UnchangedToastedReplicationMessageColumn;
+import io.debezium.connector.postgresql.YugabyteDBServer;
 import io.debezium.connector.postgresql.connection.AbstractMessageDecoder;
 import io.debezium.connector.postgresql.connection.AbstractReplicationMessageColumn;
 import io.debezium.connector.postgresql.connection.LogicalDecodingMessage;
@@ -43,6 +40,7 @@ import io.debezium.connector.postgresql.connection.Lsn;
 import io.debezium.connector.postgresql.connection.MessageDecoderContext;
 import io.debezium.connector.postgresql.connection.OriginMessage;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.connector.postgresql.connection.ReplicaIdentityInfo;
 import io.debezium.connector.postgresql.connection.ReplicationMessage.Column;
 import io.debezium.connector.postgresql.connection.ReplicationMessage.NoopMessage;
 import io.debezium.connector.postgresql.connection.ReplicationMessage.Operation;
@@ -332,24 +330,28 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         LOGGER.trace("Event: {}, RelationId: {}, Replica Identity: {}, Columns: {}", MessageType.RELATION, relationId, replicaIdentityId, columnCount);
         LOGGER.trace("Schema: '{}', Table: '{}'", schemaName, tableName);
 
-        // Perform several out-of-bands database metadata queries
-        Map<String, Optional<String>> columnDefaults;
-        Map<String, Boolean> columnOptionality;
-        List<String> primaryKeyColumns;
-
-        final DatabaseMetaData databaseMetadata = connection.connection().getMetaData();
         final TableId tableId = new TableId(null, schemaName, tableName);
+        final ReplicaIdentityInfo.ReplicaIdentity replicaIdentity = parseReplicaIdentity(replicaIdentityId);
 
-        final List<io.debezium.relational.Column> readColumns = getTableColumnsFromDatabase(connection, databaseMetadata, tableId);
-        columnDefaults = readColumns.stream()
-                .filter(io.debezium.relational.Column::hasDefaultValue)
-                .collect(toMap(io.debezium.relational.Column::name, io.debezium.relational.Column::defaultValueExpression));
+        // For DEFAULT, INDEX, and CHANGE identities the relation message flags byte reliably
+        // marks Primary Key columns, so we can avoid an out-of-band DB query.
+        // For FULL (all flags=1) and NOTHING (all flags=0) the flags are not useful for
+        // distinguishing PK columns, so we query the database.
+        // CHANGE is YugabyteDB-specific: we try flags first but fall back to a DB query
+        // because yboutput may not set the flags for CHANGE identity (YB#22555).
+        boolean useFlags = (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.DEFAULT
+                || replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.INDEX
+                || replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.CHANGE);
 
-        columnOptionality = readColumns.stream().collect(toMap(io.debezium.relational.Column::name, io.debezium.relational.Column::isOptional));
-        primaryKeyColumns = connection.readPrimaryKeyNames(databaseMetadata, tableId);
-        if (primaryKeyColumns == null || primaryKeyColumns.isEmpty()) {
-            LOGGER.warn("Primary keys are not defined for table '{}', defaulting to unique indices", tableName);
-            primaryKeyColumns = connection.readTableUniqueIndices(databaseMetadata, tableId);
+        List<String> primaryKeyColumns;
+        if (useFlags) {
+            LOGGER.debug("Using relation message flags to resolve PKs for '{}.{}'", schemaName, tableName);
+            primaryKeyColumns = new ArrayList<>();
+        }
+        else {
+            LOGGER.debug("Using DB metadata query to resolve PKs for '{}.{}' (replicaIdentity={})",
+                    schemaName, tableName, replicaIdentity);
+            primaryKeyColumns = queryPrimaryKeysFromDatabase(tableId);
         }
 
         List<ColumnMetaData> columns = new ArrayList<>();
@@ -360,27 +362,35 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
             int columnType = buffer.getInt();
             int attypmod = buffer.getInt();
 
+            LOGGER.debug("Column '{}' in '{}.{}': flags={}, typeOid={}", columnName, schemaName, tableName, flags, columnType);
+
             final PostgresType postgresType = typeRegistry.get(columnType);
-            boolean key = isColumnInPrimaryKey(schemaName, tableName, columnName, primaryKeyColumns);
 
-            Boolean optional = columnOptionality.get(columnName);
-            if (optional == null) {
-                if (decoderContext.getConfig().getColumnFilter().matches(tableId.catalog(), tableId.schema(), tableId.table(), columnName)) {
-                    LOGGER.warn("Column '{}' optionality could not be determined, defaulting to true", columnName);
+            boolean key;
+            if (useFlags) {
+                key = (flags & 1) == 1;
+                if (key) {
+                    primaryKeyColumns.add(columnName);
                 }
-                optional = true;
+            }
+            else {
+                key = isColumnInPrimaryKey(schemaName, tableName, columnName, primaryKeyColumns);
             }
 
-            if (YugabyteDBServer.isEnabled() && !key && isReplicaIdentityChange(replicaIdentityId)) {
-                LOGGER.trace("Marking column {} optional for replica identity CHANGE", columnName);
-                optional = true;
-            }
+            boolean optional = true;
 
-            final boolean hasDefault = columnDefaults.containsKey(columnName);
-            final String defaultValueExpression = columnDefaults.getOrDefault(columnName, Optional.empty()).orElse(null);
-
-            columns.add(new ColumnMetaData(columnName, postgresType, key, optional, hasDefault, defaultValueExpression, attypmod));
+            columns.add(new ColumnMetaData(columnName, postgresType, key, optional, false, null, attypmod));
             columnNames.add(columnName);
+        }
+
+        // CHANGE identity fallback: yboutput may not set flags for CHANGE in earlier versions of
+        // YugabyteDB (YB#22555).
+        // If no key columns were found from flags, fall back to DB query.
+        if (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.CHANGE && primaryKeyColumns.isEmpty()) {
+            LOGGER.trace("No key columns from flags for CHANGE identity on '{}.{}', falling back to DB query",
+                    schemaName, tableName);
+            primaryKeyColumns = queryPrimaryKeysFromDatabase(tableId);
+            LOGGER.debug("DB fallback resolved PKs for '{}.{}': {}", schemaName, tableName, primaryKeyColumns);
         }
 
         // Remove any PKs that do not exist as part of this this relation message. This can occur when issuing
@@ -400,12 +410,37 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         // to reflect the actual primary key state at time `t0`.
         primaryKeyColumns.retainAll(columnNames);
 
+        LOGGER.trace("Final primaryKeyColumns for '{}.{}': {}", schemaName, tableName, primaryKeyColumns);
+
         Table table = resolveRelationFromMetadata(new PgOutputRelationMetaData(relationId, schemaName, tableName, columns, primaryKeyColumns));
         if (YugabyteDBServer.isEnabled()) {
             decoderContext.getSchema().applySchemaChangesForTableWithReplicaIdentity(relationId, table, replicaIdentityId);
-        } else {
+        }
+        else {
             decoderContext.getSchema().applySchemaChangesForTable(relationId, table);
         }
+    }
+
+    /**
+     * Queries the database for primary key columns of the given table.
+     * Falls back to unique indices if no primary keys are found.
+     */
+    private List<String> queryPrimaryKeysFromDatabase(TableId tableId) throws SQLException {
+        final DatabaseMetaData databaseMetadata = connection.connection().getMetaData();
+        List<String> primaryKeyColumns = connection.readPrimaryKeyNames(databaseMetadata, tableId);
+        if (primaryKeyColumns == null || primaryKeyColumns.isEmpty()) {
+            LOGGER.warn("Primary keys are not defined for table '{}', defaulting to unique indices", tableId);
+            primaryKeyColumns = connection.readTableUniqueIndices(databaseMetadata, tableId);
+        }
+        return primaryKeyColumns;
+    }
+
+    /**
+     * @param replicaIdentityId the integer representation of the character for denoting replica identity.
+     * @return the parsed {@link ReplicaIdentityInfo.ReplicaIdentity} enum value.
+     */
+    private ReplicaIdentityInfo.ReplicaIdentity parseReplicaIdentity(int replicaIdentityId) {
+        return ReplicaIdentityInfo.ReplicaIdentity.parseFromDB(String.valueOf((char) replicaIdentityId));
     }
 
     /**
@@ -413,8 +448,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
      * @return true if the replica identity is change, false otherwise.
      */
     private boolean isReplicaIdentityChange(int replicaIdentityId) {
-        return ReplicaIdentityInfo.ReplicaIdentity.CHANGE
-                 == ReplicaIdentityInfo.ReplicaIdentity.parseFromDB(String.valueOf((char) replicaIdentityId));
+        return ReplicaIdentityInfo.ReplicaIdentity.CHANGE == parseReplicaIdentity(replicaIdentityId);
     }
 
     private List<io.debezium.relational.Column> getTableColumnsFromDatabase(PostgresConnection connection, DatabaseMetaData databaseMetadata, TableId tableId)

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -377,9 +377,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
                 key = isColumnInPrimaryKey(schemaName, tableName, columnName, primaryKeyColumns);
             }
 
-            boolean optional = true;
-
-            columns.add(new ColumnMetaData(columnName, postgresType, key, optional, false, null, attypmod));
+            columns.add(new ColumnMetaData(columnName, postgresType, key, true, false, null, attypmod));
             columnNames.add(columnName);
         }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBHandleRelationMessageIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBHandleRelationMessageIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Debezium Authors.
+ * Copyright YugabyteDB Authors.
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBHandleRelationMessageIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBHandleRelationMessageIT.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import static io.debezium.connector.postgresql.TestHelper.PK_FIELD;
+import static io.debezium.connector.postgresql.TestHelper.topicName;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.embedded.AbstractConnectorTest;
+
+/**
+ * Integration tests for PK resolution in {@code PgOutputMessageDecoder.handleRelationMessage}.
+ *
+ * Validates that Kafka record keys are correctly resolved for each replica identity
+ * (DEFAULT, FULL, CHANGE), including a table-drop scenario where the connector is
+ * stopped, the table is dropped, and the connector resumes processing pending WAL events.
+ *
+ * @author Shishir Sharma (ssharma@yugabyte.com)
+ */
+public class YBHandleRelationMessageIT extends AbstractConnectorTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(YBHandleRelationMessageIT.class);
+
+    private static final String TABLE_NAME = "pk_test";
+    private static final String QUALIFIED_TABLE = "public." + TABLE_NAME;
+    private static final String CREATE_TABLE = "CREATE TABLE " + TABLE_NAME + " (pk SERIAL PRIMARY KEY, val INTEGER);";
+    private static final String PUBLICATION_NAME = "dbz_publication";
+
+    @BeforeClass
+    public static void beforeClass() throws SQLException {
+        TestHelper.dropAllSchemas();
+    }
+
+    @Before
+    public void before() {
+        initializeConnectorTestFramework();
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.dropPublication();
+        TestHelper.execute("DROP TABLE IF EXISTS " + TABLE_NAME + ";");
+        TestHelper.execute(CREATE_TABLE);
+    }
+
+    @After
+    public void after() {
+        stopConnector();
+        try {
+            TestHelper.execute(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity " +
+                    "WHERE pid <> pg_backend_pid() " +
+                    "AND (backend_type='walsender' OR application_name LIKE 'Debezium%')");
+            Thread.sleep(5_000);
+        }
+        catch (Exception e) {
+            LOGGER.warn("Failed to terminate backends during teardown", e);
+        }
+        try {
+            TestHelper.dropDefaultReplicationSlot();
+        }
+        catch (Exception e) {
+            LOGGER.warn("Failed to drop replication slot during teardown", e);
+        }
+        TestHelper.dropPublication();
+    }
+
+    @Test
+    public void shouldResolvePkWithReplicaIdentityDefault() throws Exception {
+        verifyPkResolution("DEFAULT");
+    }
+
+    @Test
+    public void shouldResolvePkWithReplicaIdentityFull() throws Exception {
+        verifyPkResolution("FULL");
+    }
+
+    @Test
+    public void shouldResolvePkWithReplicaIdentityChange() throws Exception {
+        verifyPkResolution("CHANGE");
+    }
+
+    @Test
+    public void shouldResolvePkAfterTableDropWithReplicaIdentityDefault() throws Exception {
+        verifyPkAfterTableDrop("DEFAULT");
+    }
+
+    @Test
+    public void shouldResolvePkAfterTableDropWithReplicaIdentityFull() throws Exception {
+        verifyPkAfterTableDrop("FULL");
+    }
+
+    @Test
+    public void shouldResolvePkAfterTableDropWithReplicaIdentityChange() throws Exception {
+        verifyPkAfterTableDrop("CHANGE");
+    }
+
+    /**
+     * Verifies that PK columns are correctly resolved during normal streaming
+     * for the given replica identity.
+     */
+    private void verifyPkResolution(String replicaIdentity) throws Exception {
+        TestHelper.execute("ALTER TABLE " + TABLE_NAME + " REPLICA IDENTITY " + replicaIdentity + ";");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+                .build();
+
+        start(YugabyteDBConnector.class, config);
+        assertConnectorIsRunning();
+        TestHelper.waitFor(Duration.ofSeconds(10));
+        waitForAvailableRecords(10_000, TimeUnit.MILLISECONDS);
+        assertNoRecordsToConsume();
+
+        TestHelper.execute(
+                "INSERT INTO " + TABLE_NAME + " (val) VALUES (10);" +
+                "INSERT INTO " + TABLE_NAME + " (val) VALUES (20);" +
+                "INSERT INTO " + TABLE_NAME + " (val) VALUES (30);");
+
+        SourceRecords records = consumeRecordsByTopic(3);
+        List<SourceRecord> tableRecords = records.recordsForTopic(topicName(QUALIFIED_TABLE));
+
+        assertThat(tableRecords).hasSize(3);
+        for (int i = 0; i < tableRecords.size(); i++) {
+            SourceRecord record = tableRecords.get(i);
+            assertThat(record.key()).as("Kafka key should not be null for record %d", i).isNotNull();
+            assertThat(record.keySchema().fields()).as("Key schema should have fields").isNotEmpty();
+            YBVerifyRecord.isValidInsert(record, PK_FIELD, i + 1);
+        }
+    }
+
+    /**
+     * Verifies that PK columns survive a table-drop scenario: the connector is stopped,
+     * rows are inserted, the table is dropped from the publication and then dropped entirely,
+     * the walsender is killed, and the connector is restarted to process the pending WAL events.
+     */
+    private void verifyPkAfterTableDrop(String replicaIdentity) throws Exception {
+        TestHelper.execute("ALTER TABLE " + TABLE_NAME + " REPLICA IDENTITY " + replicaIdentity + ";");
+
+        // Create a table-specific publication so we can later DROP TABLE from it.
+        // FOR ALL TABLES publications do not allow per-table removal.
+        TestHelper.execute("CREATE PUBLICATION " + PUBLICATION_NAME + " FOR TABLE " + TABLE_NAME + ";");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
+                .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE,
+                        PostgresConnectorConfig.AutoCreateMode.DISABLED.getValue())
+                .build();
+
+        // Start connector, insert a baseline row, verify it has a valid key
+        start(YugabyteDBConnector.class, config);
+        assertConnectorIsRunning();
+        TestHelper.waitFor(Duration.ofSeconds(10));
+        waitForAvailableRecords(10_000, TimeUnit.MILLISECONDS);
+        assertNoRecordsToConsume();
+
+        TestHelper.execute("INSERT INTO " + TABLE_NAME + " (val) VALUES (100);");
+
+        SourceRecords baseline = consumeRecordsByTopic(1);
+        List<SourceRecord> baselineRecords = baseline.recordsForTopic(topicName(QUALIFIED_TABLE));
+        assertThat(baselineRecords).hasSize(1);
+        assertThat(baselineRecords.get(0).key()).as("Baseline key should not be null").isNotNull();
+        assertThat(baselineRecords.get(0).keySchema().fields()).as("Baseline key schema should have fields").isNotEmpty();
+        YBVerifyRecord.isValidInsert(baselineRecords.get(0), true);
+
+        // Stop connector
+        stopConnector();
+        Thread.sleep(2_000);
+
+        // Insert rows while connector is down
+        int pendingRows = 5;
+        StringBuilder insertBatch = new StringBuilder();
+        for (int i = 0; i < pendingRows; i++) {
+            insertBatch.append("INSERT INTO " + TABLE_NAME + " (val) VALUES (" + (200 + i) + ");");
+        }
+        TestHelper.execute(insertBatch.toString());
+
+        Thread.sleep(1_000);
+
+        // Drop table from publication, then drop the table itself
+        TestHelper.execute("ALTER PUBLICATION " + PUBLICATION_NAME + " DROP TABLE " + TABLE_NAME + ";");
+        TestHelper.execute("DROP TABLE " + TABLE_NAME + ";");
+
+        // Kill the walsender to force a fresh connection on restart
+        TestHelper.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE backend_type='walsender'");
+        Thread.sleep(10_000);
+
+        // Restart connector and consume the pending rows
+        start(YugabyteDBConnector.class, config);
+        assertConnectorIsRunning();
+        TestHelper.waitFor(Duration.ofSeconds(10));
+
+        SourceRecords pending = consumeRecordsByTopic(pendingRows);
+        List<SourceRecord> pendingRecords = pending.recordsForTopic(topicName(QUALIFIED_TABLE));
+
+        assertThat(pendingRecords).as("Should receive all %d pending records", pendingRows).hasSize(pendingRows);
+        for (int i = 0; i < pendingRecords.size(); i++) {
+            SourceRecord record = pendingRecords.get(i);
+            assertThat(record.key()).as("Key should not be null for pending record %d", i).isNotNull();
+            assertThat(record.keySchema().fields()).as("Key schema should have fields for record %d", i).isNotEmpty();
+            YBVerifyRecord.isValidInsert(record, true);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`PgOutputMessageDecoder.handleRelationMessage()` resolves primary key columns by querying the live database via `connection.readPrimaryKeyNames()`. When the connector is stopped, rows are inserted (accumulating in WAL), the table is dropped, and the walsender is killed, upon restart the connector establishes a fresh replication connection, receives a new relation message for the dropped table, and the PK query returns empty. This results in all pending Kafka records being produced with a **null key**.

The WAL relation message already carries a per-column `flags` byte that identifies PK columns, but the existing code reads it without using it for PK resolution.

## Solution

Refactor PK resolution in `handleRelationMessage()` to use the relation message `flags` byte instead of querying the database.

### Implementation Details

1. **Use Relation message flags for DEFAULT/INDEX/CHANGE replica identities**
   - Derive `primaryKeyColumns` from the relation message `flags` byte (`flags & 1 == 1` means PK column)
   - No out-of-band DB query needed — works even if the table has been dropped

2. **Fall back to DB query for FULL/NOTHING replica identities**
   - `FULL` sets all flags to 1, `NOTHING` sets all to 0, flags are ambiguous for PK resolution
   - Query `connection.readPrimaryKeyNames()` only for these cases

3. **Backward-compatible CHANGE fallback**
   - YugabyteDB's `yboutput` may not set flags for CHANGE identity in older versions (YB#22555)
   - If CHANGE yields an empty PK list from flags, fall back to a DB query

4. **Remove unnecessary out-of-band DB queries**
   - Removed queries for `columnDefaults` and `columnOptionality`, use safe defaults (`optional=true`, `hasDefault=false`) instead
   - Extracted `queryPrimaryKeysFromDatabase()` and `parseReplicaIdentity()` helper methods

5. **Integration tests (`YBHandleRelationMessageIT`)**
   - PK resolution tests for DEFAULT, FULL, and CHANGE replica identities
   - Table-drop + connector restart scenario: stop connector, insert rows, drop table, kill walsender, restart, verify all records have non-null keys
   - Red-green verified: test fails with null key on original code, passes with the fix
 

### Trade-off: Column metadata defaults
The previous code queried the database for per-column optionality (`IS NOT NULL` constraints) and default value expressions. With this change, all columns default to `optional=true` and `hasDefault=false`. This means the connector's schema metadata for columns will not reflect `NOT NULL` constraints or default values from the database. This is an acceptable trade-off because:
- These metadata fields do not affect the Kafka record key (the core fix)
- The relation message protocol does not carry optionality or default info
- Querying the DB for this metadata is what causes the failure when the table is dropped


## Test plan

```
YBHandleRelationMessageIT#shouldResolvePkWithReplicaIdentityDefault
YBHandleRelationMessageIT#shouldResolvePkWithReplicaIdentityFull
YBHandleRelationMessageIT#shouldResolvePkWithReplicaIdentityChange
YBHandleRelationMessageIT#shouldResolvePkAfterTableDropWithReplicaIdentityDefault
YBHandleRelationMessageIT#shouldResolvePkAfterTableDropWithReplicaIdentityFull
YBHandleRelationMessageIT#shouldResolvePkAfterTableDropWithReplicaIdentityChange

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes primary-key resolution during pgoutput relation decoding and removes DB-derived column metadata, which can affect emitted record keys and schema details during streaming/restarts. Adds new Yugabyte-focused integration tests covering multiple replica identities and restart-after-drop scenarios.
> 
> **Overview**
> Fixes a restart edge case where pending WAL events could be emitted with **null Kafka keys** after a table is dropped by changing `PgOutputMessageDecoder.handleRelationMessage()` to derive primary-key columns from the replication relation message `flags` (with DB-metadata fallback for `FULL/NOTHING`, and a `CHANGE` fallback for older `yboutput`).
> 
> Reduces reliance on out-of-band metadata by dropping per-column default/optionality lookups and defaulting columns to `optional=true` / `hasDefault=false`, and adds `YBHandleRelationMessageIT` to verify non-null keys across replica identities and a stop/insert/drop/restart scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4052df0b50496c94087586f6e863da07df6a861b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->