### PR TITLE
[DBZ-PGYB][yugabyte/yugabyte-db#30977] Selectively call ALTER PUBLICATION for filtered publication

### DIFF
--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -110,6 +110,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-avro-converter</artifactId>
             <scope>test</scope>

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -10,6 +10,7 @@ import static java.lang.Math.toIntExact;
 
 import java.nio.ByteBuffer;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
@@ -28,14 +29,15 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.yugabyte.core.BaseConnection;
 import com.yugabyte.core.ServerVersion;
 import com.yugabyte.replication.PGReplicationStream;
 import com.yugabyte.replication.fluent.logical.ChainedLogicalStreamBuilder;
 import com.yugabyte.util.PSQLException;
 import com.yugabyte.util.PSQLState;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
@@ -193,7 +195,9 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                                             publicationName, plugin, database()));
                                 }
                                 else {
-                                    createOrUpdatePublicationModeFilterted(stmt, true);
+                                    if (isPublicationUpdateRequired(stmt)) {
+                                        createOrUpdatePublicationModeFilterted(stmt, true);
+                                    }
                                 }
                                 break;
                             default:
@@ -232,6 +236,80 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             throw new ConnectException(String.format("Unable to %s filtered publication %s for %s", isUpdate ? "update" : "create", publicationName, tableFilterString),
                     e);
         }
+    }
+
+    /**
+     * Gets the list of tables currently configured in the publication by querying pg_publication_tables.
+     *
+     * @param stmt the statement to use for the query
+     * @return Optional containing the Set of TableId objects in the publication, empty if unable to query
+     */
+    private Optional<Set<TableId>> getCurrentPublicationTables(Statement stmt) {
+        String query = String.format(
+                "SELECT schemaname, tablename FROM pg_publication_tables WHERE pubname = '%s'", publicationName);
+
+        Set<TableId> publicationTables = new HashSet<>();
+        try (PreparedStatement prepStmt = stmt.getConnection().prepareStatement(query)) {
+            try (ResultSet rs = prepStmt.executeQuery()) {
+                while (rs.next()) {
+                    String schemaName = rs.getString("schemaname");
+                    String tableName = rs.getString("tablename");
+                    TableId tableId = jdbcConnection.createTableId(connectorConfig.databaseName(), schemaName, tableName);
+                    publicationTables.add(tableId);
+                }
+            }
+        }
+        catch (SQLException e) {
+            LOGGER.warn("Unable to query pg_publication_tables for publication '{}'. "
+                    + "Publication will be updated to ensure synchronization. Error: {}", publicationName, e.getMessage());
+            return Optional.empty();
+        }
+        return Optional.of(publicationTables);
+    }
+
+    /**
+     * Checks whether the publication's current table set differs from the desired captured tables.
+     *
+     * @param stmt the statement to use for database queries
+     * @return true if the publication needs to be updated, false otherwise
+     * @throws SQLException if database queries fail
+     */
+    public boolean isPublicationUpdateRequired(Statement stmt) throws SQLException {
+        Optional<Set<TableId>> currentPublicationTables = getCurrentPublicationTables(stmt);
+
+        if (currentPublicationTables.isEmpty()) {
+            LOGGER.info("Unable to determine current publication tables for '{}', will update publication to ensure synchronization",
+                    publicationName);
+            return true;
+        }
+
+        Set<TableId> desiredTables;
+        try {
+            desiredTables = determineCapturedTables();
+        }
+        catch (Exception e) {
+            throw new SQLException("Failed to determine captured tables", e);
+        }
+
+        if (desiredTables.isEmpty()) {
+            LOGGER.warn("No table filters found for filtered publication {}", publicationName);
+            return false;
+        }
+
+        Set<TableId> currentTables = currentPublicationTables.get();
+        if (currentTables.equals(desiredTables)) {
+            LOGGER.info("Publication '{}' is already up to date with desired tables", publicationName);
+            return false;
+        }
+
+        Set<TableId> toAdd = new HashSet<>(desiredTables);
+        toAdd.removeAll(currentTables);
+        Set<TableId> toRemove = new HashSet<>(currentTables);
+        toRemove.removeAll(desiredTables);
+
+        LOGGER.info("Publication '{}' needs update. Tables to add: {}, Tables to remove: {}",
+                publicationName, toAdd, toRemove);
+        return true;
     }
 
     /**
@@ -512,18 +590,17 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
     public String getReplicationSlotCreationCommand(String tempPart, boolean canExportSnapshot) throws SQLException {
         return String.format(
-            "CREATE_REPLICATION_SLOT \"%s\" %s LOGICAL %s %s %s",
-            slotName,
-            tempPart,
-            plugin.getPostgresPluginName(),
-            lsnType.getLsnTypeName().equalsIgnoreCase("SEQUENCE") ? "" : "HYBRID_TIME",
-            canExportSnapshot ? "EXPORT_SNAPSHOT" : "USE_SNAPSHOT");
+                "CREATE_REPLICATION_SLOT \"%s\" %s LOGICAL %s %s %s",
+                slotName,
+                tempPart,
+                plugin.getPostgresPluginName(),
+                lsnType.getLsnTypeName().equalsIgnoreCase("SEQUENCE") ? "" : "HYBRID_TIME",
+                canExportSnapshot ? "EXPORT_SNAPSHOT" : "USE_SNAPSHOT");
     }
 
     public Boolean isExportSnapshotSupported(Exception exception) throws SQLException {
-        if (exception.getMessage() != null && (
-            exception.getMessage().contains("cannot export or import snapshot when ysql_enable_pg_export_snapshot is disabled") ||
-            exception.getMessage().contains("Exporting snapshot is not yet supported"))) {
+        if (exception.getMessage() != null && (exception.getMessage().contains("cannot export or import snapshot when ysql_enable_pg_export_snapshot is disabled") ||
+                exception.getMessage().contains("Exporting snapshot is not yet supported"))) {
             return false;
         }
         return true;
@@ -576,7 +653,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
                     // Begin a read-only transaction when it is the parallel streaming mode because
                     // we will be using this read-only transaction to take the snapshot further.
-                    if (connectorConfig.streamingMode().isParallel() ) {
+                    if (connectorConfig.streamingMode().isParallel()) {
                         LOGGER.info("executing: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY");
                         stmt.execute("BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY");
                     }
@@ -607,7 +684,8 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             if (rs.next()) {
                 return rs.getString("backend_pid");
             }
-        } catch (SQLException sqle) {
+        }
+        catch (SQLException sqle) {
             LOGGER.warn("Unable to get the backend PID", sqle);
         }
 
@@ -621,7 +699,8 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             if (rs.next()) {
                 return rs.getString("connected_to_host");
             }
-        } catch (SQLException sqle) {
+        }
+        catch (SQLException sqle) {
             LOGGER.warn("Unable to get the connected host node", sqle);
         }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -29,15 +29,14 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.errors.ConnectException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.yugabyte.core.BaseConnection;
 import com.yugabyte.core.ServerVersion;
 import com.yugabyte.replication.PGReplicationStream;
 import com.yugabyte.replication.fluent.logical.ChainedLogicalStreamBuilder;
 import com.yugabyte.util.PSQLException;
 import com.yugabyte.util.PSQLState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
@@ -590,17 +589,18 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
     public String getReplicationSlotCreationCommand(String tempPart, boolean canExportSnapshot) throws SQLException {
         return String.format(
-                "CREATE_REPLICATION_SLOT \"%s\" %s LOGICAL %s %s %s",
-                slotName,
-                tempPart,
-                plugin.getPostgresPluginName(),
-                lsnType.getLsnTypeName().equalsIgnoreCase("SEQUENCE") ? "" : "HYBRID_TIME",
-                canExportSnapshot ? "EXPORT_SNAPSHOT" : "USE_SNAPSHOT");
+            "CREATE_REPLICATION_SLOT \"%s\" %s LOGICAL %s %s %s",
+            slotName,
+            tempPart,
+            plugin.getPostgresPluginName(),
+            lsnType.getLsnTypeName().equalsIgnoreCase("SEQUENCE") ? "" : "HYBRID_TIME",
+            canExportSnapshot ? "EXPORT_SNAPSHOT" : "USE_SNAPSHOT");
     }
 
     public Boolean isExportSnapshotSupported(Exception exception) throws SQLException {
-        if (exception.getMessage() != null && (exception.getMessage().contains("cannot export or import snapshot when ysql_enable_pg_export_snapshot is disabled") ||
-                exception.getMessage().contains("Exporting snapshot is not yet supported"))) {
+        if (exception.getMessage() != null && (
+            exception.getMessage().contains("cannot export or import snapshot when ysql_enable_pg_export_snapshot is disabled") ||
+            exception.getMessage().contains("Exporting snapshot is not yet supported"))) {
             return false;
         }
         return true;
@@ -653,7 +653,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
                     // Begin a read-only transaction when it is the parallel streaming mode because
                     // we will be using this read-only transaction to take the snapshot further.
-                    if (connectorConfig.streamingMode().isParallel()) {
+                    if (connectorConfig.streamingMode().isParallel() ) {
                         LOGGER.info("executing: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY");
                         stmt.execute("BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY");
                     }
@@ -684,8 +684,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             if (rs.next()) {
                 return rs.getString("backend_pid");
             }
-        }
-        catch (SQLException sqle) {
+        } catch (SQLException sqle) {
             LOGGER.warn("Unable to get the backend PID", sqle);
         }
 
@@ -699,8 +698,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             if (rs.next()) {
                 return rs.getString("connected_to_host");
             }
-        }
-        catch (SQLException sqle) {
+        } catch (SQLException sqle) {
             LOGGER.warn("Unable to get the connected host node", sqle);
         }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -244,11 +244,11 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
      * @return Optional containing the Set of TableId objects in the publication, empty if unable to query
      */
     private Optional<Set<TableId>> getCurrentPublicationTables(Statement stmt) {
-        String query = String.format(
+        String getPublicationTablesQuery = String.format(
                 "SELECT schemaname, tablename FROM pg_publication_tables WHERE pubname = '%s'", publicationName);
 
         Set<TableId> publicationTables = new HashSet<>();
-        try (PreparedStatement prepStmt = stmt.getConnection().prepareStatement(query)) {
+        try (PreparedStatement prepStmt = stmt.getConnection().prepareStatement(getPublicationTablesQuery)) {
             try (ResultSet rs = prepStmt.executeQuery()) {
                 while (rs.next()) {
                     String schemaName = rs.getString("schemaname");

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresPublicationTableComparisonTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresPublicationTableComparisonTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.PostgresSchema;
+import io.debezium.connector.postgresql.TypeRegistry;
+import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.relational.RelationalTableFilters;
+import io.debezium.relational.TableId;
+
+/**
+ * Unit tests for PostgresReplicationConnection publication table comparison logic.
+ * Adapted from upstream DBZ-9395 for the YugabyteDB Debezium 2.5.2 fork.
+ */
+public class PostgresPublicationTableComparisonTest {
+
+    @Mock
+    private PostgresConnectorConfig connectorConfig;
+
+    @Mock
+    private PostgresConnection jdbcConnection;
+
+    @Mock
+    private RelationalTableFilters tableFilter;
+
+    @Mock
+    private TypeRegistry typeRegistry;
+
+    @Mock
+    private PostgresSchema schema;
+
+    @Mock
+    private Statement statement;
+
+    @Mock
+    private Connection connection;
+
+    @Mock
+    private PreparedStatement preparedStatement;
+
+    @Mock
+    private ResultSet resultSet;
+
+    private PostgresReplicationConnection replicationConnection;
+    private static final String TEST_PUBLICATION_NAME = "test_publication";
+    private static final String TEST_DATABASE_NAME = "test_db";
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        when(connectorConfig.databaseName()).thenReturn(TEST_DATABASE_NAME);
+        when(connectorConfig.getJdbcConfig()).thenReturn(JdbcConfiguration.create().build());
+
+        replicationConnection = createTestReplicationConnection();
+
+        when(statement.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+    }
+
+    private PostgresReplicationConnection createTestReplicationConnection() throws Exception {
+        return (PostgresReplicationConnection) ReplicationConnection.builder(connectorConfig)
+                .withSlot("test_slot")
+                .withPublication(TEST_PUBLICATION_NAME)
+                .withTableFilter(tableFilter)
+                .withPublicationAutocreateMode(PostgresConnectorConfig.AutoCreateMode.FILTERED)
+                .withPlugin(PostgresConnectorConfig.LogicalDecoder.PGOUTPUT)
+                .dropSlotOnClose(false)
+                .statusUpdateInterval(Duration.ofSeconds(10))
+                .jdbcMetadataConnection(jdbcConnection)
+                .withTypeRegistry(typeRegistry)
+                .streamParams("")
+                .withSchema(schema)
+                .build();
+    }
+
+    @Test
+    public void testPublicationUpdateRequiredWhenTablesAdded() throws Exception {
+        Set<TableId> currentTables = new HashSet<>(Arrays.asList(
+                new TableId(null, "public", "customers"),
+                new TableId(null, "inventory", "orders")));
+        mockGetCurrentPublicationTables(currentTables);
+
+        Set<TableId> capturedTables = new HashSet<>(Arrays.asList(
+                new TableId(null, "public", "customers"),
+                new TableId(null, "inventory", "orders"),
+                new TableId(null, "public", "products")));
+        mockDetermineCapturedTables(capturedTables);
+
+        boolean result = replicationConnection.isPublicationUpdateRequired(statement);
+
+        assertThat(result).isTrue();
+        verify(connection).prepareStatement(eq(String.format(
+                "SELECT schemaname, tablename FROM pg_publication_tables WHERE pubname = '%s'",
+                TEST_PUBLICATION_NAME)));
+        verify(preparedStatement).executeQuery();
+    }
+
+    @Test
+    public void testPublicationUpdateRequiredOnSQLException() throws Exception {
+        when(preparedStatement.executeQuery()).thenThrow(
+                new SQLException("permission denied for relation pg_publication_tables"));
+
+        Set<TableId> capturedTables = new HashSet<>(Arrays.asList(
+                new TableId(null, "public", "customers")));
+        mockDetermineCapturedTables(capturedTables);
+
+        boolean result = replicationConnection.isPublicationUpdateRequired(statement);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void testPublicationUpdateRequiredWhenPublicationEmpty() throws Exception {
+        when(resultSet.next()).thenReturn(false);
+
+        Set<TableId> capturedTables = new HashSet<>(Arrays.asList(
+                new TableId(null, "public", "customers")));
+        mockDetermineCapturedTables(capturedTables);
+
+        boolean result = replicationConnection.isPublicationUpdateRequired(statement);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void testNoUpdateRequiredWhenTablesMatch() throws Exception {
+        Set<TableId> tables = new HashSet<>(Arrays.asList(
+                new TableId(null, "public", "customers"),
+                new TableId(null, "inventory", "orders")));
+
+        mockGetCurrentPublicationTables(tables);
+        mockDetermineCapturedTables(tables);
+
+        boolean result = replicationConnection.isPublicationUpdateRequired(statement);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    public void testPublicationUpdateRequiredWhenTablesDiffer() throws Exception {
+        Set<TableId> currentTables = new HashSet<>(Arrays.asList(
+                new TableId(null, "public", "customers")));
+
+        Set<TableId> desiredTables = new HashSet<>(Arrays.asList(
+                new TableId(null, "public", "customers"),
+                new TableId(null, "inventory", "orders")));
+
+        mockGetCurrentPublicationTables(currentTables);
+        mockDetermineCapturedTables(desiredTables);
+
+        boolean result = replicationConnection.isPublicationUpdateRequired(statement);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void testPublicationUpdateRequiredWhenQueryFails() throws Exception {
+        mockGetCurrentPublicationTables(null);
+
+        Set<TableId> desiredTables = new HashSet<>(Arrays.asList(
+                new TableId(null, "public", "customers")));
+        mockDetermineCapturedTables(desiredTables);
+
+        boolean result = replicationConnection.isPublicationUpdateRequired(statement);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void testNoUpdateRequiredWhenNoDesiredTables() throws Exception {
+        Set<TableId> currentTables = new HashSet<>(Arrays.asList(
+                new TableId(null, "public", "customers")));
+
+        mockGetCurrentPublicationTables(currentTables);
+        mockDetermineCapturedTables(new HashSet<>());
+
+        boolean result = replicationConnection.isPublicationUpdateRequired(statement);
+
+        assertThat(result).isFalse();
+    }
+
+    private void mockGetCurrentPublicationTables(Set<TableId> tables) throws Exception {
+        if (tables == null) {
+            when(preparedStatement.executeQuery()).thenThrow(new SQLException("permission denied"));
+        }
+        else if (tables.isEmpty()) {
+            when(resultSet.next()).thenReturn(false);
+        }
+        else {
+            Boolean[] nextResults = new Boolean[tables.size() + 1];
+            String[] schemaNames = new String[tables.size()];
+            String[] tableNames = new String[tables.size()];
+
+            int i = 0;
+            for (TableId tableId : tables) {
+                nextResults[i] = true;
+                schemaNames[i] = tableId.schema();
+                tableNames[i] = tableId.table();
+                when(jdbcConnection.createTableId(TEST_DATABASE_NAME, tableId.schema(), tableId.table()))
+                        .thenReturn(tableId);
+                i++;
+            }
+            nextResults[i] = false;
+
+            when(resultSet.next()).thenReturn(nextResults[0], Arrays.copyOfRange(nextResults, 1, nextResults.length));
+            when(resultSet.getString("schemaname")).thenReturn(schemaNames[0], Arrays.copyOfRange(schemaNames, 1, schemaNames.length));
+            when(resultSet.getString("tablename")).thenReturn(tableNames[0], Arrays.copyOfRange(tableNames, 1, tableNames.length));
+        }
+    }
+
+    private void mockDetermineCapturedTables(Set<TableId> tables) throws Exception {
+        when(jdbcConnection.getAllTableIds(TEST_DATABASE_NAME)).thenReturn(tables);
+        when(tableFilter.dataCollectionFilter()).thenReturn(tableId -> tables.contains(tableId));
+    }
+}


### PR DESCRIPTION
## Problem

When `publication.autocreate.mode=filtered` is configured, the connector unconditionally executes `ALTER PUBLICATION ... SET TABLE ...` on **every restart**, even when the publication's table list has not changed. This causes unnecessary DDL operations against the database on each connector startup, which can:

- Cause unnecessary lock contention on the database (ALTER PUBLICATION acquires locks)
- Potentially interfere with ongoing database operations.

## Solution

Cherry-pick of upstream Debezium [DBZ-9395](https://issues.redhat.com/browse/DBZ-9395) ([PR #6709](https://github.com/debezium/debezium/pull/6709), merged as [a8e1557](https://github.com/debezium/debezium/commit/a8e1557)).

Before issuing `ALTER PUBLICATION`, query `pg_publication_tables` to compare the publication's current table set against the desired captured tables. Only issue the DDL when the sets actually differ.

### Modifications from upstream

The upstream PR targets Debezium 3.x (`main` branch) which has diverged significantly from our 2.5.2 fork. A direct `git cherry-pick` was not possible due to:

- **Missing upstream-only code**: The 3.x codebase has `isReadOnlyDb()`, `SQL_LOCK_NOT_AVAILABLE`, `validatePublications()`, `executeWithTimeout()`, and `createSlotCommandTimeout()` none of which exist in 2.5.2
- **Method name difference**: Our fork has `createOrUpdatePublicationModeFilterted` (typo preserved from 2.5.2 base), upstream fixed it to `createOrUpdatePublicationModeFiltered`
- **`setQueryTimeout` → `statement_timeout` replacement**: The upstream PR also replaced client-side `Statement.setQueryTimeout()` with server-side `SET statement_timeout`. This part is **not applicable** to our fork since we don't use `setQueryTimeout` in this code path

The following parts were manually adapted for 2.5.2:

1. **`getCurrentPublicationTables(Statement)`**: queries `pg_publication_tables` for the publication's current table list. Uses `jdbcConnection.createTableId()` (returns `TableId(null, schema, table)`) to match the format from `determineCapturedTables()` for correct `Set.equals()` comparison
2. **`isPublicationUpdateRequired(Statement)`**: compares current vs desired tables, logs additions/removals, returns `false` if already in sync
3. **Guard in `initPublication()`**: wraps the existing `createOrUpdatePublicationModeFilterted(stmt, true)` call with the `isPublicationUpdateRequired()` check
4. **`mockito-core` test dependency**: added to `debezium-connector-postgres/pom.xml` (version managed by BOM, was not previously a direct dependency of this module)

### Implementation Details

- `getCurrentPublicationTables()` returns `Optional.empty()` on SQL exceptions (e.g., insufficient privileges), causing the guard to fall through to `ALTER PUBLICATION` as a safe default
- `isPublicationUpdateRequired()` returns `false` when desired tables are empty to avoid clearing the publication
- Detailed logging of which tables need to be added/removed when an update is required

## Test plan

```
PostgresPublicationTableComparisonTest#testPublicationUpdateRequiredWhenTablesAdded
PostgresPublicationTableComparisonTest#testPublicationUpdateRequiredOnSQLException
PostgresPublicationTableComparisonTest#testPublicationUpdateRequiredWhenPublicationEmpty
PostgresPublicationTableComparisonTest#testNoUpdateRequiredWhenTablesMatch
PostgresPublicationTableComparisonTest#testPublicationUpdateRequiredWhenTablesDiffer
PostgresPublicationTableComparisonTest#testPublicationUpdateRequiredWhenQueryFails
PostgresPublicationTableComparisonTest#testNoUpdateRequiredWhenNoDesiredTables
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes publication initialization logic to conditionally run `ALTER PUBLICATION` based on live catalog comparison, which affects startup behavior and DDL execution in a replication-critical code path.
> 
> **Overview**
> Avoids running `ALTER PUBLICATION ... SET TABLE ...` on every restart when `publication.autocreate.mode=filtered` by querying `pg_publication_tables` and only updating the publication when the current and desired table sets differ (with a safe fallback to update if the query fails).
> 
> Adds unit coverage for the table-set comparison logic and includes `mockito-core` as a test dependency to support the new tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63d4d59e9b553549352b58a7174f971bb768c612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->