### PR TITLE
[DBZ-PGYB][yugabyte/yugabyte-db#30885] Filter UPDATE/DELETE on non-PK tables with non-FULL replica identity

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -23,6 +23,7 @@ import io.debezium.connector.postgresql.connection.Lsn;
 import io.debezium.connector.postgresql.connection.OriginMessage;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.PostgresReplicationConnection;
+import io.debezium.connector.postgresql.connection.ReplicaIdentityInfo;
 import io.debezium.connector.postgresql.connection.ReplicationConnection;
 import io.debezium.connector.postgresql.connection.ReplicationMessage;
 import io.debezium.connector.postgresql.connection.ReplicationMessage.Operation;
@@ -32,6 +33,7 @@ import io.debezium.connector.postgresql.spi.Snapshotter;
 import io.debezium.heartbeat.Heartbeat;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
+import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
 import io.debezium.util.DelayStrategy;
@@ -407,7 +409,23 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                     tableId,
                     message.getOperation());
 
-            boolean dispatched = message.getOperation() != Operation.NOOP && dispatcher.dispatchDataChangeEvent(
+            boolean shouldFilterNoPkRecord = false;
+            if (YugabyteDBServer.isEnabled() && tableId != null
+                    && (message.getOperation() == Operation.UPDATE || message.getOperation() == Operation.DELETE)) {
+                Table table = schema.tableFor(tableId);
+                if (table != null && table.primaryKeyColumnNames().isEmpty()) {
+                    ReplicaIdentityInfo.ReplicaIdentity ri = schema.getReplicaIdentity(tableId);
+                    if (ri != ReplicaIdentityInfo.ReplicaIdentity.FULL) {
+                        shouldFilterNoPkRecord = true;
+                        LOGGER.info("Filtering {} record for table '{}': table has no primary key and "
+                                + "stream replica identity is {} (non-FULL). Record will be skipped.",
+                                message.getOperation(), tableId, ri);
+                    }
+                }
+            }
+
+            boolean dispatched = !shouldFilterNoPkRecord
+                    && message.getOperation() != Operation.NOOP && dispatcher.dispatchDataChangeEvent(
                     partition,
                     tableId,
                     new PostgresChangeRecordEmitter(

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -53,6 +53,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
      * trigger a "WAL backlog growing" warning.
      */
     private static final int GROWING_WAL_WARNING_LOG_INTERVAL = 10_000;
+    private static final long FILTERED_NO_PK_LOG_INTERVAL_MS = 5 * 60 * 1000L;
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgresStreamingChangeEventSource.class);
 
     // PGOUTPUT decoder sends the messages with larger time gaps than other decoders
@@ -94,6 +95,9 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
      */
     private OptionalLong lastTxnidForWhichCommitSeen = OptionalLong.empty();
     private long recordCount = 0;
+    private long totalFilteredNoPkRecords = 0;
+    private long filteredNoPkRecordsSinceLastLog = 0;
+    private long lastFilteredNoPkLogTimeMs = 0;
 
     public PostgresStreamingChangeEventSource(PostgresConnectorConfig connectorConfig, Snapshotter snapshotter,
                                               PostgresConnection connection, PostgresEventDispatcher<TableId> dispatcher, ErrorHandler errorHandler, Clock clock,
@@ -414,31 +418,59 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                     && (message.getOperation() == Operation.UPDATE || message.getOperation() == Operation.DELETE)) {
                 Table table = schema.tableFor(tableId);
                 if (table != null && table.primaryKeyColumnNames().isEmpty()) {
-                    ReplicaIdentityInfo.ReplicaIdentity ri = schema.getReplicaIdentity(tableId);
-                    if (ri != ReplicaIdentityInfo.ReplicaIdentity.FULL) {
+                    ReplicaIdentityInfo.ReplicaIdentity replicaIdentity = schema.getReplicaIdentity(tableId);
+                    if (replicaIdentity != ReplicaIdentityInfo.ReplicaIdentity.FULL) {
                         shouldFilterNoPkRecord = true;
-                        LOGGER.info("Filtering {} record for table '{}': table has no primary key and "
-                                + "stream replica identity is {} (non-FULL). Record will be skipped.",
-                                message.getOperation(), tableId, ri);
+                        maybeLogNoPkRecordFiltering(message.getOperation(), tableId, replicaIdentity);
                     }
                 }
             }
 
-            boolean dispatched = !shouldFilterNoPkRecord
-                    && message.getOperation() != Operation.NOOP && dispatcher.dispatchDataChangeEvent(
-                    partition,
-                    tableId,
-                    new PostgresChangeRecordEmitter(
-                            partition,
-                            offsetContext,
-                            clock,
-                            connectorConfig,
-                            schema,
-                            connection,
-                            tableId,
-                            message));
+            boolean dispatched = false;
+            if (!shouldFilterNoPkRecord && message.getOperation() != Operation.NOOP) {
+                dispatched = dispatcher.dispatchDataChangeEvent(
+                        partition,
+                        tableId,
+                        new PostgresChangeRecordEmitter(
+                                partition,
+                                offsetContext,
+                                clock,
+                                connectorConfig,
+                                schema,
+                                connection,
+                                tableId,
+                                message));
+            }
 
             maybeWarnAboutGrowingWalBacklog(dispatched);
+        }
+    }
+
+    private void maybeLogNoPkRecordFiltering(Operation operation, TableId tableId,
+                                             ReplicaIdentityInfo.ReplicaIdentity replicaIdentity) {
+        totalFilteredNoPkRecords++;
+        filteredNoPkRecordsSinceLastLog++;
+
+        if (!LOGGER.isDebugEnabled()) {
+            return;
+        }
+
+        final long currentTimeMs = clock.currentTimeAsInstant().toEpochMilli();
+        if (lastFilteredNoPkLogTimeMs == 0L) {
+            lastFilteredNoPkLogTimeMs = currentTimeMs;
+            LOGGER.debug("Filtered {} UPDATE/DELETE record(s) in the last 5 minutes ({} total). "
+                    + "Most recent skipped record: operation={}, table='{}', stream replica identity={} (non-FULL).",
+                    filteredNoPkRecordsSinceLastLog, totalFilteredNoPkRecords, operation, tableId, replicaIdentity);
+            filteredNoPkRecordsSinceLastLog = 0;
+            return;
+        }
+
+        if (currentTimeMs - lastFilteredNoPkLogTimeMs >= FILTERED_NO_PK_LOG_INTERVAL_MS) {
+            LOGGER.debug("Filtered {} UPDATE/DELETE record(s) in the last 5 minutes ({} total). "
+                    + "Most recent skipped record: operation={}, table='{}', stream replica identity={} (non-FULL).",
+                    filteredNoPkRecordsSinceLastLog, totalFilteredNoPkRecords, operation, tableId, replicaIdentity);
+            filteredNoPkRecordsSinceLastLog = 0;
+            lastFilteredNoPkLogTimeMs = currentTimeMs;
         }
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -451,22 +451,15 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
         totalFilteredNoPkRecords++;
         filteredNoPkRecordsSinceLastLog++;
 
-        if (!LOGGER.isDebugEnabled()) {
-            return;
-        }
+        // DEBUG: log every filtered record.
+        LOGGER.debug("Filtering {} record for table '{}' (stream replica identity={} non-FULL, no primary key)",
+                operation, tableId, replicaIdentity);
 
+        // INFO: rate-limited summary, at most once per 5 minutes.
         final long currentTimeMs = clock.currentTimeAsInstant().toEpochMilli();
-        if (lastFilteredNoPkLogTimeMs == 0L) {
-            lastFilteredNoPkLogTimeMs = currentTimeMs;
-            LOGGER.debug("Filtered {} UPDATE/DELETE record(s) in the last 5 minutes ({} total). "
-                    + "Most recent skipped record: operation={}, table='{}', stream replica identity={} (non-FULL).",
-                    filteredNoPkRecordsSinceLastLog, totalFilteredNoPkRecords, operation, tableId, replicaIdentity);
-            filteredNoPkRecordsSinceLastLog = 0;
-            return;
-        }
-
-        if (currentTimeMs - lastFilteredNoPkLogTimeMs >= FILTERED_NO_PK_LOG_INTERVAL_MS) {
-            LOGGER.debug("Filtered {} UPDATE/DELETE record(s) in the last 5 minutes ({} total). "
+        if (lastFilteredNoPkLogTimeMs == 0L
+                || currentTimeMs - lastFilteredNoPkLogTimeMs >= FILTERED_NO_PK_LOG_INTERVAL_MS) {
+            LOGGER.info("Filtered {} UPDATE/DELETE record(s) in the last 5 minutes ({} total). "
                     + "Most recent skipped record: operation={}, table='{}', stream replica identity={} (non-FULL).",
                     filteredNoPkRecordsSinceLastLog, totalFilteredNoPkRecords, operation, tableId, replicaIdentity);
             filteredNoPkRecordsSinceLastLog = 0;

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteReplicaIdentityIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteReplicaIdentityIT.java
@@ -660,11 +660,6 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
 
     // Phase 2: ALTER to FULL -- server now allows UPDATE/DELETE.
     // But the stream RI stays CHANGE (stale).
-    // NOTE: On YB debug builds, mid-stream ALTER REPLICA IDENTITY bumps the
-    // schema version and the next CDC poll's SchemaPackingStorage lookup hits
-    // a DCHECK in schema_packing.cc that aborts the tserver. Run with
-    // --TEST_dcheck_for_missing_schema_packing=false. Release builds self-heal
-    // via the recovery path in cdcsdk_producer.cc (AddSchema).
     TestHelper.execute("ALTER TABLE s2.nopk_alter REPLICA IDENTITY FULL;");
     TestHelper.waitFor(Duration.ofSeconds(5));
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteReplicaIdentityIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteReplicaIdentityIT.java
@@ -51,40 +51,36 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
   }
 
   @Before
-  public void before() {
+  public void before() throws InterruptedException {
     initializeConnectorTestFramework();
     terminateAndDropSlot();
     TestHelper.execute(CREATE_TABLES_STMT);
   }
 
   @After
-  public void after() {
+  public void after() throws InterruptedException {
     stopConnector();
     terminateAndDropSlot();
     TestHelper.dropPublication();
   }
 
-  private void terminateAndDropSlot() {
-    for (int attempt = 1; attempt <= 3; attempt++) {
+  private void terminateAndDropSlot() throws InterruptedException {
+    for (int attempt = 0; attempt < 3; attempt++) {
       try {
         TestHelper.execute(
             "SELECT pg_terminate_backend(active_pid) "
                 + "FROM pg_replication_slots "
-                + "WHERE slot_name = 'debezium' AND active = true;");
-        Thread.sleep(20_000);
+                + "WHERE slot_name = 'debezium' AND active = true");
+        TestHelper.waitFor(Duration.ofSeconds(3));
         TestHelper.dropDefaultReplicationSlot();
         return;
       }
       catch (Exception e) {
-        LOGGER.warn("terminateAndDropSlot attempt {} failed: {}", attempt, e.getMessage());
-        if (attempt == 3) {
-          LOGGER.warn("Could not drop slot after 3 attempts, continuing anyway");
+        if (attempt < 2) {
+          TestHelper.waitFor(Duration.ofSeconds(5));
         }
-        try {
-          Thread.sleep(10_000);
-        }
-        catch (InterruptedException ie) {
-          Thread.currentThread().interrupt();
+        else {
+          LOGGER.warn("Failed to drop replication slot after 3 attempts: {}", e.getMessage());
         }
       }
     }
@@ -480,328 +476,461 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
 
   @Test
   public void shouldFilterUpdateAndDeleteForNoPkTableWithNonFullRI() throws Exception {
-    TestHelper.execute("DROP TABLE IF EXISTS nopk_change;");
-    TestHelper.execute("CREATE TABLE nopk_change (id INT, val TEXT);");
-    TestHelper.execute("ALTER TABLE nopk_change REPLICA IDENTITY CHANGE;");
+    final LogInterceptor streamLog = new LogInterceptor(PostgresStreamingChangeEventSource.class);
+
+    TestHelper.execute("CREATE TABLE s2.nopk (aa integer, bb varchar(20));");
+    TestHelper.execute("ALTER TABLE s2.nopk REPLICA IDENTITY CHANGE;");
 
     TestHelper.dropPublication();
     TestHelper.execute(
         "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
-            + "CREATE PUBLICATION dbz_publication FOR TABLE nopk_change;");
+            + "CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk;");
 
     Configuration config = TestHelper.defaultConfig()
         .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
         .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
-        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.nopk_change")
-        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, "disabled")
+        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE,
+            PostgresConnectorConfig.AutoCreateMode.DISABLED.getValue())
+        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s2.nopk")
         .build();
 
     start(YugabyteDBConnector.class, config);
     assertConnectorIsRunning();
 
-    TestHelper.waitFor(Duration.ofSeconds(10));
-    waitForAvailableRecords(10_000, TimeUnit.MILLISECONDS);
-    assertNoRecordsToConsume();
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> streamLog.containsMessage("Processing messages"));
 
-    LogInterceptor logInterceptor = new LogInterceptor(PostgresStreamingChangeEventSource.class);
-
-    TestHelper.execute("INSERT INTO nopk_change VALUES (1, 'hello');");
+    TestHelper.execute("INSERT INTO s2.nopk VALUES (1, 'test');");
     TestHelper.execute(
         "SET yb_cdcsdk_allow_dml_without_pk = true; "
-            + "UPDATE nopk_change SET val = 'world' WHERE id = 1;");
+            + "UPDATE s2.nopk SET aa = 99 WHERE aa = 1;");
     TestHelper.execute(
         "SET yb_cdcsdk_allow_dml_without_pk = true; "
-            + "DELETE FROM nopk_change WHERE id = 1;");
+            + "DELETE FROM s2.nopk WHERE aa = 99;");
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> streamLog.containsMessage("Filtering UPDATE record for table")
+            && streamLog.containsMessage("Filtering DELETE record for table"));
 
     SourceRecords records = consumeRecordsByTopic(1);
-    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("nopk_change"));
+    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("s2.nopk"));
 
     assertThat(nopkRecords).hasSize(1);
-    assertThat(((Struct) nopkRecords.get(0).value()).get("op")).isEqualTo("c");
 
-    Awaitility.await().atMost(60, TimeUnit.SECONDS).until(
-        () -> logInterceptor.containsMessage("Filtering UPDATE record for table")
-            || logInterceptor.containsMessage("Filtering DELETE record for table"));
+    Struct value = (Struct) nopkRecords.get(0).value();
+    assertThat(value.getString("op")).isEqualTo(Envelope.Operation.CREATE.code());
   }
 
   @Test
   public void shouldNotFilterUpdateAndDeleteForNoPkTableWithFullRI() throws Exception {
-    TestHelper.execute("DROP TABLE IF EXISTS nopk_full;");
-    TestHelper.execute("CREATE TABLE nopk_full (id INT, val TEXT);");
-    TestHelper.execute("ALTER TABLE nopk_full REPLICA IDENTITY FULL;");
+    final LogInterceptor streamLog = new LogInterceptor(PostgresStreamingChangeEventSource.class);
+
+    TestHelper.execute("CREATE TABLE s2.nopk_full (aa integer, bb varchar(20));");
+    TestHelper.execute("ALTER TABLE s2.nopk_full REPLICA IDENTITY FULL;");
 
     TestHelper.dropPublication();
     TestHelper.execute(
         "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
-            + "CREATE PUBLICATION dbz_publication FOR TABLE nopk_full;");
+            + "CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_full;");
 
     Configuration config = TestHelper.defaultConfig()
         .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
         .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
-        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.nopk_full")
-        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, "disabled")
+        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE,
+            PostgresConnectorConfig.AutoCreateMode.DISABLED.getValue())
+        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s2.nopk_full")
         .build();
 
     start(YugabyteDBConnector.class, config);
     assertConnectorIsRunning();
 
-    TestHelper.waitFor(Duration.ofSeconds(10));
-    waitForAvailableRecords(10_000, TimeUnit.MILLISECONDS);
-    assertNoRecordsToConsume();
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> streamLog.containsMessage("Processing messages"));
 
-    TestHelper.execute("INSERT INTO nopk_full VALUES (1, 'hello');");
-    TestHelper.execute("UPDATE nopk_full SET val = 'world' WHERE id = 1;");
-    TestHelper.execute("DELETE FROM nopk_full WHERE id = 1;");
+    TestHelper.execute("INSERT INTO s2.nopk_full VALUES (1, 'test');");
+    TestHelper.execute("UPDATE s2.nopk_full SET aa = 99 WHERE aa = 1;");
+    TestHelper.execute("DELETE FROM s2.nopk_full WHERE aa = 99;");
 
+    // All 3 records (INSERT, UPDATE, DELETE) should come through since RI is FULL.
+    waitForAvailableRecords(30_000, TimeUnit.MILLISECONDS);
     SourceRecords records = consumeRecordsByTopic(3);
-    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("nopk_full"));
+    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("s2.nopk_full"));
 
     assertThat(nopkRecords).hasSize(3);
-    assertThat(((Struct) nopkRecords.get(0).value()).get("op")).isEqualTo("c");
-    assertThat(((Struct) nopkRecords.get(1).value()).get("op")).isEqualTo("u");
-    assertThat(((Struct) nopkRecords.get(2).value()).get("op")).isEqualTo("d");
+
+    Struct insertValue = (Struct) nopkRecords.get(0).value();
+    Struct updateValue = (Struct) nopkRecords.get(1).value();
+    Struct deleteValue = (Struct) nopkRecords.get(2).value();
+
+    assertThat(insertValue.getString("op")).isEqualTo(Envelope.Operation.CREATE.code());
+    assertThat(updateValue.getString("op")).isEqualTo(Envelope.Operation.UPDATE.code());
+    assertThat(deleteValue.getString("op")).isEqualTo(Envelope.Operation.DELETE.code());
+
+    // Verify no filtering log was emitted.
+    assertThat(streamLog.containsMessage("Filtering UPDATE record for table")).isFalse();
+    assertThat(streamLog.containsMessage("Filtering DELETE record for table")).isFalse();
   }
 
   @Test
   public void shouldNotFilterInsertForNoPkTableRegardlessOfRI() throws Exception {
-    TestHelper.execute("DROP TABLE IF EXISTS nopk_insert;");
-    TestHelper.execute("CREATE TABLE nopk_insert (id INT, val TEXT);");
-    TestHelper.execute("ALTER TABLE nopk_insert REPLICA IDENTITY CHANGE;");
+    final LogInterceptor streamLog = new LogInterceptor(PostgresStreamingChangeEventSource.class);
+
+    TestHelper.execute("CREATE TABLE s2.nopk_insert (aa integer, bb varchar(20));");
+    TestHelper.execute("ALTER TABLE s2.nopk_insert REPLICA IDENTITY CHANGE;");
 
     TestHelper.dropPublication();
     TestHelper.execute(
         "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
-            + "CREATE PUBLICATION dbz_publication FOR TABLE nopk_insert;");
+            + "CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_insert;");
 
     Configuration config = TestHelper.defaultConfig()
         .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
         .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
-        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.nopk_insert")
-        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, "disabled")
+        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE,
+            PostgresConnectorConfig.AutoCreateMode.DISABLED.getValue())
+        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s2.nopk_insert")
         .build();
 
     start(YugabyteDBConnector.class, config);
     assertConnectorIsRunning();
 
-    TestHelper.waitFor(Duration.ofSeconds(10));
-    waitForAvailableRecords(10_000, TimeUnit.MILLISECONDS);
-    assertNoRecordsToConsume();
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> streamLog.containsMessage("Processing messages"));
 
-    TestHelper.execute("INSERT INTO nopk_insert VALUES (1, 'hello');");
-    TestHelper.execute("INSERT INTO nopk_insert VALUES (2, 'world');");
+    TestHelper.execute("INSERT INTO s2.nopk_insert VALUES (10, 'first');");
+    TestHelper.execute("INSERT INTO s2.nopk_insert VALUES (20, 'second');");
+    TestHelper.execute("INSERT INTO s2.nopk_insert VALUES (30, 'third');");
 
-    SourceRecords records = consumeRecordsByTopic(2);
-    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("nopk_insert"));
+    waitForAvailableRecords(30_000, TimeUnit.MILLISECONDS);
+    SourceRecords records = consumeRecordsByTopic(3);
+    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("s2.nopk_insert"));
 
-    assertThat(nopkRecords).hasSize(2);
-    assertThat(((Struct) nopkRecords.get(0).value()).get("op")).isEqualTo("c");
-    assertThat(((Struct) nopkRecords.get(1).value()).get("op")).isEqualTo("c");
+    assertThat(nopkRecords).hasSize(3);
+
+    for (SourceRecord record : nopkRecords) {
+      Struct value = (Struct) record.value();
+      assertThat(value.getString("op")).isEqualTo(Envelope.Operation.CREATE.code());
+    }
+
+    // No filtering should have occurred for INSERTs.
+    assertThat(streamLog.containsMessage("Filtering INSERT record for table")).isFalse();
   }
 
   @Test
   public void shouldBlockUpdateAndDeleteForNoPkTableWithFlagFalse() throws Exception {
-    TestHelper.execute("DROP TABLE IF EXISTS nopk_default;");
-    TestHelper.execute("CREATE TABLE nopk_default (id INT, val TEXT);");
+    // Scenarios 1 & 2: With flag=false (default), server BLOCKS UPDATE/DELETE on
+    // non-PK tables for BOTH DEFAULT and CHANGE RI. With the new server code (D51670),
+    // CHANGE and DEFAULT are treated identically.
 
-    TestHelper.execute("DROP TABLE IF EXISTS nopk_change_block;");
-    TestHelper.execute("CREATE TABLE nopk_change_block (id INT, val TEXT);");
-    TestHelper.execute("ALTER TABLE nopk_change_block REPLICA IDENTITY CHANGE;");
+    // --- DEFAULT RI ---
+    TestHelper.execute("CREATE TABLE s2.nopk_default (aa integer, bb varchar(20));");
+    TestHelper.execute("ALTER TABLE s2.nopk_default REPLICA IDENTITY DEFAULT;");
 
-    TestHelper.execute("INSERT INTO nopk_default VALUES (1, 'a');");
-    TestHelper.execute("INSERT INTO nopk_change_block VALUES (1, 'a');");
+    TestHelper.dropPublication();
+    TestHelper.execute(
+        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
+            + "CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_default;");
 
-    assertThatThrownBy(() -> TestHelper.execute("UPDATE nopk_default SET val = 'b' WHERE id = 1;"))
-        .hasMessageContaining("does not have a replica identity")
-        .hasMessageContaining("publishes updates");
+    TestHelper.execute("INSERT INTO s2.nopk_default VALUES (1, 'test');");
 
-    assertThatThrownBy(() -> TestHelper.execute("UPDATE nopk_change_block SET val = 'b' WHERE id = 1;"))
-        .hasMessageContaining("UPDATE and DELETE are not allowed on table")
-        .hasMessageContaining("without primary key");
+    assertThatThrownBy(() -> TestHelper.execute("UPDATE s2.nopk_default SET aa = 99 WHERE aa = 1;"))
+        .hasMessageContaining("does not have a replica identity and publishes updates");
+
+    assertThatThrownBy(() -> TestHelper.execute("DELETE FROM s2.nopk_default WHERE aa = 1;"))
+        .hasMessageContaining("does not have a replica identity and publishes deletes");
+
+    // --- CHANGE RI ---
+    TestHelper.execute("CREATE TABLE s2.nopk_change_block (aa integer, bb varchar(20));");
+    TestHelper.execute("ALTER TABLE s2.nopk_change_block REPLICA IDENTITY CHANGE;");
+
+    TestHelper.dropPublication();
+    TestHelper.execute(
+        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
+            + "CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_change_block;");
+
+    TestHelper.execute("INSERT INTO s2.nopk_change_block VALUES (1, 'test');");
+
+    assertThatThrownBy(() -> TestHelper.execute("UPDATE s2.nopk_change_block SET aa = 99 WHERE aa = 1;"))
+        .hasMessageContaining("does not have a replica identity and publishes updates");
+
+    assertThatThrownBy(() -> TestHelper.execute("DELETE FROM s2.nopk_change_block WHERE aa = 1;"))
+        .hasMessageContaining("does not have a replica identity and publishes deletes");
   }
 
   @Test
   public void shouldFilterUpdateAndDeleteForNoPkTableWithDefaultRIAndFlagTrue() throws Exception {
-    TestHelper.execute("DROP TABLE IF EXISTS nopk_default_flag;");
-    TestHelper.execute("CREATE TABLE nopk_default_flag (id INT, val TEXT);");
+    final LogInterceptor streamLog = new LogInterceptor(PostgresStreamingChangeEventSource.class);
+
+    TestHelper.execute("CREATE TABLE s2.nopk_default_flag (aa integer, bb varchar(20));");
+    TestHelper.execute("ALTER TABLE s2.nopk_default_flag REPLICA IDENTITY DEFAULT;");
 
     TestHelper.dropPublication();
     TestHelper.execute(
         "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
-            + "CREATE PUBLICATION dbz_publication FOR TABLE nopk_default_flag;");
+            + "CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_default_flag;");
 
     Configuration config = TestHelper.defaultConfig()
         .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
         .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
-        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.nopk_default_flag")
-        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, "disabled")
+        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE,
+            PostgresConnectorConfig.AutoCreateMode.DISABLED.getValue())
+        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s2.nopk_default_flag")
         .build();
 
     start(YugabyteDBConnector.class, config);
     assertConnectorIsRunning();
 
-    TestHelper.waitFor(Duration.ofSeconds(10));
-    waitForAvailableRecords(10_000, TimeUnit.MILLISECONDS);
-    assertNoRecordsToConsume();
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> streamLog.containsMessage("Processing messages"));
 
-    LogInterceptor logInterceptor = new LogInterceptor(PostgresStreamingChangeEventSource.class);
-
-    TestHelper.execute("INSERT INTO nopk_default_flag VALUES (1, 'hello');");
+    TestHelper.execute("INSERT INTO s2.nopk_default_flag VALUES (1, 'test');");
     TestHelper.execute(
         "SET yb_cdcsdk_allow_dml_without_pk = true; "
-            + "UPDATE nopk_default_flag SET val = 'world' WHERE id = 1;");
+            + "UPDATE s2.nopk_default_flag SET aa = 99 WHERE aa = 1;");
     TestHelper.execute(
         "SET yb_cdcsdk_allow_dml_without_pk = true; "
-            + "DELETE FROM nopk_default_flag WHERE id = 1;");
+            + "DELETE FROM s2.nopk_default_flag WHERE aa = 99;");
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> streamLog.containsMessage("Filtering UPDATE record for table")
+            && streamLog.containsMessage("Filtering DELETE record for table"));
 
     SourceRecords records = consumeRecordsByTopic(1);
-    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("nopk_default_flag"));
+    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("s2.nopk_default_flag"));
 
     assertThat(nopkRecords).hasSize(1);
-    assertThat(((Struct) nopkRecords.get(0).value()).get("op")).isEqualTo("c");
 
-    Awaitility.await().atMost(60, TimeUnit.SECONDS).until(
-        () -> logInterceptor.containsMessage("Filtering UPDATE record for table")
-            || logInterceptor.containsMessage("Filtering DELETE record for table"));
+    Struct value = (Struct) nopkRecords.get(0).value();
+    assertThat(value.getString("op")).isEqualTo(Envelope.Operation.CREATE.code());
   }
 
   @Test
   public void shouldFilterUpdateDeleteAfterAlterToFullBecauseStreamRIIsStale() throws Exception {
-    TestHelper.execute("DROP TABLE IF EXISTS nopk_alter_change;");
-    TestHelper.execute("CREATE TABLE nopk_alter_change (id INT, val TEXT);");
-    TestHelper.execute("ALTER TABLE nopk_alter_change REPLICA IDENTITY CHANGE;");
+    // flag=false (default) scenario:
+    // Phase 1: RI=CHANGE, no PK -> server BLOCKS UPDATE/DELETE.
+    // Phase 2: ALTER to FULL -> server ALLOWS UPDATE/DELETE (FULL always works).
+    // But stream RI stays CHANGE (stale) -> connector FILTERS them.
+    final LogInterceptor schemaLog = new LogInterceptor(PostgresSchema.class);
+    final LogInterceptor streamLog = new LogInterceptor(PostgresStreamingChangeEventSource.class);
 
-    assertThatThrownBy(
-        () -> TestHelper.execute("UPDATE nopk_alter_change SET val = 'x' WHERE id = 1;"))
-        .hasMessageContaining("UPDATE and DELETE are not allowed on table")
-        .hasMessageContaining("without primary key");
+    TestHelper.execute("CREATE TABLE s2.nopk_alter (aa integer, bb varchar(20));");
+    TestHelper.execute("ALTER TABLE s2.nopk_alter REPLICA IDENTITY CHANGE;");
 
     TestHelper.dropPublication();
     TestHelper.execute(
         "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
-            + "CREATE PUBLICATION dbz_publication FOR TABLE nopk_alter_change;");
+            + "CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_alter;");
 
     Configuration config = TestHelper.defaultConfig()
         .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
         .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
-        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.nopk_alter_change")
-        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, "disabled")
+        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE,
+            PostgresConnectorConfig.AutoCreateMode.DISABLED.getValue())
+        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s2.nopk_alter")
         .build();
 
     start(YugabyteDBConnector.class, config);
     assertConnectorIsRunning();
 
-    TestHelper.waitFor(Duration.ofSeconds(10));
-    waitForAvailableRecords(10_000, TimeUnit.MILLISECONDS);
-    assertNoRecordsToConsume();
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> streamLog.containsMessage("Processing messages"));
 
-    LogInterceptor logInterceptor = new LogInterceptor(PostgresStreamingChangeEventSource.class);
+    // INSERT works regardless -- confirm stream RI is CHANGE.
+    TestHelper.execute("INSERT INTO s2.nopk_alter VALUES (1, 'before alter');");
 
-    TestHelper.execute("ALTER TABLE nopk_alter_change REPLICA IDENTITY FULL;");
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> schemaLog.containsMessage("Replica identity being stored for table s2.nopk_alter is CHANGE"));
 
-    TestHelper.execute("INSERT INTO nopk_alter_change VALUES (1, 'hello');");
-    TestHelper.execute("UPDATE nopk_alter_change SET val = 'world' WHERE id = 1;");
-    TestHelper.execute("DELETE FROM nopk_alter_change WHERE id = 1;");
+    LOGGER.info("Confirmed: stream stored RI=CHANGE for nopk_alter");
 
-    SourceRecords records = consumeRecordsByTopic(1);
-    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("nopk_alter_change"));
+    waitForAvailableRecords(30_000, TimeUnit.MILLISECONDS);
+    SourceRecords insertRecords = consumeRecordsByTopic(1);
+    assertThat(insertRecords.recordsForTopic(topicName("s2.nopk_alter"))).hasSize(1);
 
-    assertThat(nopkRecords).hasSize(1);
-    assertThat(((Struct) nopkRecords.get(0).value()).get("op")).isEqualTo("c");
+    // Phase 1: With flag=false and RI=CHANGE, server blocks UPDATE/DELETE.
+    assertThatThrownBy(() -> TestHelper.execute("UPDATE s2.nopk_alter SET aa = 99 WHERE aa = 1;"))
+        .hasMessageContaining("does not have a replica identity and publishes updates");
 
-    Awaitility.await().atMost(60, TimeUnit.SECONDS).until(
-        () -> logInterceptor.containsMessage("Filtering UPDATE record for table")
-            || logInterceptor.containsMessage("Filtering DELETE record for table"));
+    assertThatThrownBy(() -> TestHelper.execute("DELETE FROM s2.nopk_alter WHERE aa = 1;"))
+        .hasMessageContaining("does not have a replica identity and publishes deletes");
+
+    LOGGER.info("Phase 1 confirmed: UPDATE/DELETE blocked by server with RI=CHANGE");
+
+    // Phase 2: ALTER to FULL -- server now allows UPDATE/DELETE.
+    // But the stream RI stays CHANGE (stale).
+    TestHelper.execute("ALTER TABLE s2.nopk_alter REPLICA IDENTITY FULL;");
+    TestHelper.waitFor(Duration.ofSeconds(5));
+
+    // DMLs go through because actual table RI is now FULL.
+    TestHelper.execute("UPDATE s2.nopk_alter SET aa = 99 WHERE aa = 1;");
+    TestHelper.execute("DELETE FROM s2.nopk_alter WHERE aa = 99;");
+
+    // Connector should STILL filter because stream RI = CHANGE (stale, non-FULL).
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> streamLog.containsMessage("Filtering UPDATE record for table")
+            && streamLog.containsMessage("Filtering DELETE record for table"));
+
+    // Only the initial INSERT should have been dispatched after the ALTER.
+    // No additional records should be available.
+    assertThat(consumeAvailableRecords(record -> { })).isEqualTo(0);
+
+    LOGGER.info("Verified: UPDATE/DELETE filtered after ALTER to FULL because stream RI is stale (CHANGE)");
   }
 
   @Test
   public void shouldFilterUpdateDeleteForDefaultRIAfterAlterToFull() throws Exception {
-    TestHelper.execute("DROP TABLE IF EXISTS nopk_alter_default;");
-    TestHelper.execute("CREATE TABLE nopk_alter_default (id INT, val TEXT);");
+    // Scenario 2 with ALTER: DEFAULT RI, no PK, flag=false.
+    // Phase 1: server blocks. Phase 2: ALTER to FULL, DMLs go through,
+    // connector filters because stream RI is still DEFAULT (stale).
+    final LogInterceptor schemaLog = new LogInterceptor(PostgresSchema.class);
+    final LogInterceptor streamLog = new LogInterceptor(PostgresStreamingChangeEventSource.class);
 
-    assertThatThrownBy(
-        () -> TestHelper.execute("UPDATE nopk_alter_default SET val = 'x' WHERE id = 1;"))
-        .hasMessageContaining("does not have a replica identity")
-        .hasMessageContaining("publishes updates");
+    TestHelper.execute("CREATE TABLE s2.nopk_default_alter (aa integer, bb varchar(20));");
 
     TestHelper.dropPublication();
     TestHelper.execute(
         "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
-            + "CREATE PUBLICATION dbz_publication FOR TABLE nopk_alter_default;");
+            + "CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_default_alter;");
 
     Configuration config = TestHelper.defaultConfig()
         .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
         .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
-        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.nopk_alter_default")
-        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, "disabled")
+        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE,
+            PostgresConnectorConfig.AutoCreateMode.DISABLED.getValue())
+        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s2.nopk_default_alter")
         .build();
 
     start(YugabyteDBConnector.class, config);
     assertConnectorIsRunning();
 
-    TestHelper.waitFor(Duration.ofSeconds(10));
-    waitForAvailableRecords(10_000, TimeUnit.MILLISECONDS);
-    assertNoRecordsToConsume();
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> streamLog.containsMessage("Processing messages"));
 
-    LogInterceptor logInterceptor = new LogInterceptor(PostgresStreamingChangeEventSource.class);
+    TestHelper.execute("INSERT INTO s2.nopk_default_alter VALUES (1, 'before alter');");
 
-    TestHelper.execute("ALTER TABLE nopk_alter_default REPLICA IDENTITY FULL;");
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> schemaLog.containsMessage("Replica identity being stored for table s2.nopk_default_alter is CHANGE"));
 
-    TestHelper.execute("INSERT INTO nopk_alter_default VALUES (1, 'hello');");
-    TestHelper.execute("UPDATE nopk_alter_default SET val = 'world' WHERE id = 1;");
-    TestHelper.execute("DELETE FROM nopk_alter_default WHERE id = 1;");
+    LOGGER.info("Confirmed: stream stored RI=CHANGE (YB maps DEFAULT to CHANGE) for nopk_default_alter");
 
-    SourceRecords records = consumeRecordsByTopic(1);
-    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("nopk_alter_default"));
+    waitForAvailableRecords(30_000, TimeUnit.MILLISECONDS);
+    SourceRecords insertRecords = consumeRecordsByTopic(1);
+    assertThat(insertRecords.recordsForTopic(topicName("s2.nopk_default_alter"))).hasSize(1);
 
-    assertThat(nopkRecords).hasSize(1);
-    assertThat(((Struct) nopkRecords.get(0).value()).get("op")).isEqualTo("c");
+    // Phase 1: With flag=false and RI=DEFAULT, server blocks UPDATE/DELETE.
+    assertThatThrownBy(() -> TestHelper.execute("UPDATE s2.nopk_default_alter SET aa = 99 WHERE aa = 1;"))
+        .hasMessageContaining("does not have a replica identity and publishes updates");
 
-    Awaitility.await().atMost(60, TimeUnit.SECONDS).until(
-        () -> logInterceptor.containsMessage("Filtering UPDATE record for table")
-            || logInterceptor.containsMessage("Filtering DELETE record for table"));
+    assertThatThrownBy(() -> TestHelper.execute("DELETE FROM s2.nopk_default_alter WHERE aa = 1;"))
+        .hasMessageContaining("does not have a replica identity and publishes deletes");
+
+    LOGGER.info("Phase 1 confirmed: UPDATE/DELETE blocked by server with RI=DEFAULT");
+
+    // Phase 2: ALTER to FULL -- server now allows UPDATE/DELETE.
+    // But the stream RI stays CHANGE (YB maps DEFAULT->CHANGE, and it's stale).
+    TestHelper.execute("ALTER TABLE s2.nopk_default_alter REPLICA IDENTITY FULL;");
+    TestHelper.waitFor(Duration.ofSeconds(5));
+
+    TestHelper.execute("UPDATE s2.nopk_default_alter SET aa = 99 WHERE aa = 1;");
+    TestHelper.execute("DELETE FROM s2.nopk_default_alter WHERE aa = 99;");
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> streamLog.containsMessage("Filtering UPDATE record for table")
+            && streamLog.containsMessage("Filtering DELETE record for table"));
+
+    assertThat(consumeAvailableRecords(record -> { })).isEqualTo(0);
+
+    LOGGER.info("Verified: UPDATE/DELETE filtered after ALTER to FULL because stream RI is stale (CHANGE)");
   }
 
   @Test
   public void shouldVerifyStreamReplicaIdentityAfterAlterToFull() throws Exception {
-    TestHelper.execute("DROP TABLE IF EXISTS nopk_ri_verify;");
-    TestHelper.execute("CREATE TABLE nopk_ri_verify (id INT, val TEXT);");
-    TestHelper.execute("ALTER TABLE nopk_ri_verify REPLICA IDENTITY CHANGE;");
+    final LogInterceptor schemaLog = new LogInterceptor(PostgresSchema.class);
+    final LogInterceptor streamLog = new LogInterceptor(PostgresStreamingChangeEventSource.class);
 
-    TestHelper.dropPublication();
-    TestHelper.execute(
-        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
-            + "CREATE PUBLICATION dbz_publication FOR TABLE nopk_ri_verify;");
+    TestHelper.execute("ALTER TABLE s2.a REPLICA IDENTITY CHANGE;");
 
     Configuration config = TestHelper.defaultConfig()
         .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
         .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
-        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.nopk_ri_verify")
-        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, "disabled")
         .build();
 
     start(YugabyteDBConnector.class, config);
     assertConnectorIsRunning();
 
-    TestHelper.waitFor(Duration.ofSeconds(10));
-    waitForAvailableRecords(10_000, TimeUnit.MILLISECONDS);
-    assertNoRecordsToConsume();
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> streamLog.containsMessage("Processing messages"));
 
-    TestHelper.execute("INSERT INTO nopk_ri_verify VALUES (1, 'hello');");
+    LOGGER.info("Streaming started, inserting first record...");
+    TestHelper.execute("INSERT INTO s2.a VALUES (1, 22, 'before alter');");
 
-    SourceRecords records = consumeRecordsByTopic(1);
-    assertThat(records.recordsForTopic(topicName("nopk_ri_verify"))).hasSize(1);
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> schemaLog.containsMessage("Replica identity being stored for table s2.a is CHANGE"));
 
-    LogInterceptor logInterceptor = new LogInterceptor(PostgresStreamingChangeEventSource.class);
+    LOGGER.info("Confirmed: stream initially stored RI=CHANGE");
 
-    TestHelper.execute("ALTER TABLE nopk_ri_verify REPLICA IDENTITY FULL;");
+    SourceRecords records1 = consumeRecordsByTopic(1);
+    assertThat(records1.allRecordsInOrder()).isNotEmpty();
 
-    TestHelper.execute("INSERT INTO nopk_ri_verify VALUES (2, 'world');");
-    TestHelper.execute("UPDATE nopk_ri_verify SET val = 'updated' WHERE id = 2;");
+    schemaLog.clear();
+
+    TestHelper.execute("ALTER TABLE s2.a REPLICA IDENTITY FULL;");
+    TestHelper.waitFor(Duration.ofSeconds(5));
+
+    LOGGER.info("Inserting second record after ALTER to FULL...");
+    TestHelper.execute("INSERT INTO s2.a VALUES (2, 33, 'after alter');");
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> schemaLog.containsMessage("Replica identity being stored for table s2.a is FULL")
+            || schemaLog.containsMessage("Replica identity being stored for table s2.a is CHANGE"));
 
     SourceRecords records2 = consumeRecordsByTopic(1);
-    assertThat(records2.recordsForTopic(topicName("nopk_ri_verify"))).hasSize(1);
+    assertThat(records2.allRecordsInOrder()).isNotEmpty();
 
-    Awaitility.await().atMost(60, TimeUnit.SECONDS).until(
-        () -> logInterceptor.containsMessage("Filtering UPDATE record for table"));
+    boolean riChangedToFull = schemaLog.containsMessage("Replica identity being stored for table s2.a is FULL");
+    boolean riStillChange = schemaLog.containsMessage("Replica identity being stored for table s2.a is CHANGE");
+
+    LOGGER.info("=== RESULT: After ALTER TABLE REPLICA IDENTITY FULL ===");
+    LOGGER.info("  Stream reported RI=FULL: {}", riChangedToFull);
+    LOGGER.info("  Stream reported RI=CHANGE: {}", riStillChange);
+
+    if (riChangedToFull) {
+      LOGGER.warn("FINDING: Stream RI DOES change after ALTER! "
+          + "Connector filtering needs putIfAbsent() or offset persistence.");
+    }
+    else {
+      LOGGER.info("FINDING: Stream RI does NOT change after ALTER. "
+          + "Stale RI confirmed as expected.");
+    }
   }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteReplicaIdentityIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteReplicaIdentityIT.java
@@ -563,8 +563,7 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
     assertThat(deleteValue.getString("op")).isEqualTo(Envelope.Operation.DELETE.code());
 
     // Verify no filtering log was emitted.
-    assertThat(streamLog.containsMessage("Filtering UPDATE record for table")).isFalse();
-    assertThat(streamLog.containsMessage("Filtering DELETE record for table")).isFalse();
+    assertThat(streamLog.containsMessage("UPDATE/DELETE record(s) in the last 5 minutes")).isFalse();
   }
 
   @Test
@@ -661,6 +660,11 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
 
     // Phase 2: ALTER to FULL -- server now allows UPDATE/DELETE.
     // But the stream RI stays CHANGE (stale).
+    // NOTE: On YB debug builds, mid-stream ALTER REPLICA IDENTITY bumps the
+    // schema version and the next CDC poll's SchemaPackingStorage lookup hits
+    // a DCHECK in schema_packing.cc that aborts the tserver. Run with
+    // --TEST_dcheck_for_missing_schema_packing=false. Release builds self-heal
+    // via the recovery path in cdcsdk_producer.cc (AddSchema).
     TestHelper.execute("ALTER TABLE s2.nopk_alter REPLICA IDENTITY FULL;");
     TestHelper.waitFor(Duration.ofSeconds(5));
 
@@ -669,11 +673,13 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
     TestHelper.execute("DELETE FROM s2.nopk_alter WHERE aa = 99;");
 
     // Connector should STILL filter because stream RI = CHANGE (stale, non-FULL).
+    // The throttled summary log fires once per 5 minutes, so we wait for a single
+    // emission. The "0 additional records" assertion below proves both UPDATE and
+    // DELETE were filtered.
     Awaitility.await()
         .atMost(Duration.ofSeconds(60))
         .pollInterval(Duration.ofSeconds(1))
-        .until(() -> streamLog.containsMessage("Filtering UPDATE record for table")
-            && streamLog.containsMessage("Filtering DELETE record for table"));
+        .until(() -> streamLog.containsMessage("UPDATE/DELETE record(s) in the last 5 minutes"));
 
     // Only the initial INSERT should have been dispatched after the ALTER.
     // No additional records should be available.

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteReplicaIdentityIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteReplicaIdentityIT.java
@@ -1,5 +1,6 @@
 package io.debezium.connector.postgresql;
 
+import ch.qos.logback.classic.Level;
 import io.debezium.config.Configuration;
 import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
@@ -472,19 +473,14 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
     assertThat(deleteRecordValue.getStruct(Envelope.FieldName.BEFORE).getStruct("bb").getString("value")).isNull();
   }
 
-  // --- Tests for filtering UPDATE/DELETE on tables without primary key ---
 
   @Test
   public void shouldFilterUpdateAndDeleteForNoPkTableWithNonFullRI() throws Exception {
-    final LogInterceptor streamLog = new LogInterceptor(PostgresStreamingChangeEventSource.class);
-
     TestHelper.execute("CREATE TABLE s2.nopk (aa integer, bb varchar(20));");
     TestHelper.execute("ALTER TABLE s2.nopk REPLICA IDENTITY CHANGE;");
 
     TestHelper.dropPublication();
-    TestHelper.execute(
-        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
-            + "CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk;");
+    TestHelper.execute("CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk;");
 
     Configuration config = TestHelper.defaultConfig()
         .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
@@ -496,11 +492,7 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
 
     start(YugabyteDBConnector.class, config);
     assertConnectorIsRunning();
-
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(60))
-        .pollInterval(Duration.ofSeconds(1))
-        .until(() -> streamLog.containsMessage("Processing messages"));
+    TestHelper.waitFor(Duration.ofSeconds(5));
 
     TestHelper.execute("INSERT INTO s2.nopk VALUES (1, 'test');");
     TestHelper.execute(
@@ -509,33 +501,31 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
     TestHelper.execute(
         "SET yb_cdcsdk_allow_dml_without_pk = true; "
             + "DELETE FROM s2.nopk WHERE aa = 99;");
+    TestHelper.execute("INSERT INTO s2.nopk VALUES (2, 'after-filter');");
 
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofSeconds(1))
-        .until(() -> streamLog.containsMessage("Filtering UPDATE record for table")
-            && streamLog.containsMessage("Filtering DELETE record for table"));
-
-    SourceRecords records = consumeRecordsByTopic(1);
+    SourceRecords records = consumeRecordsByTopic(2);
     List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("s2.nopk"));
 
-    assertThat(nopkRecords).hasSize(1);
+    assertThat(nopkRecords).hasSize(2);
 
-    Struct value = (Struct) nopkRecords.get(0).value();
-    assertThat(value.getString("op")).isEqualTo(Envelope.Operation.CREATE.code());
+    Struct firstInsertValue = (Struct) nopkRecords.get(0).value();
+    Struct secondInsertValue = (Struct) nopkRecords.get(1).value();
+    assertThat(firstInsertValue.getString("op")).isEqualTo(Envelope.Operation.CREATE.code());
+    assertThat(firstInsertValue.getStruct(Envelope.FieldName.AFTER).getStruct("aa").getInt32("value")).isEqualTo(1);
+    assertThat(secondInsertValue.getString("op")).isEqualTo(Envelope.Operation.CREATE.code());
+    assertThat(secondInsertValue.getStruct(Envelope.FieldName.AFTER).getStruct("aa").getInt32("value")).isEqualTo(2);
   }
 
   @Test
   public void shouldNotFilterUpdateAndDeleteForNoPkTableWithFullRI() throws Exception {
     final LogInterceptor streamLog = new LogInterceptor(PostgresStreamingChangeEventSource.class);
+    streamLog.setLoggerLevel(PostgresStreamingChangeEventSource.class, Level.DEBUG);
 
     TestHelper.execute("CREATE TABLE s2.nopk_full (aa integer, bb varchar(20));");
     TestHelper.execute("ALTER TABLE s2.nopk_full REPLICA IDENTITY FULL;");
 
     TestHelper.dropPublication();
-    TestHelper.execute(
-        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
-            + "CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_full;");
+    TestHelper.execute("CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_full;");
 
     Configuration config = TestHelper.defaultConfig()
         .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
@@ -578,53 +568,6 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
   }
 
   @Test
-  public void shouldNotFilterInsertForNoPkTableRegardlessOfRI() throws Exception {
-    final LogInterceptor streamLog = new LogInterceptor(PostgresStreamingChangeEventSource.class);
-
-    TestHelper.execute("CREATE TABLE s2.nopk_insert (aa integer, bb varchar(20));");
-    TestHelper.execute("ALTER TABLE s2.nopk_insert REPLICA IDENTITY CHANGE;");
-
-    TestHelper.dropPublication();
-    TestHelper.execute(
-        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
-            + "CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_insert;");
-
-    Configuration config = TestHelper.defaultConfig()
-        .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
-        .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
-        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE,
-            PostgresConnectorConfig.AutoCreateMode.DISABLED.getValue())
-        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s2.nopk_insert")
-        .build();
-
-    start(YugabyteDBConnector.class, config);
-    assertConnectorIsRunning();
-
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(60))
-        .pollInterval(Duration.ofSeconds(1))
-        .until(() -> streamLog.containsMessage("Processing messages"));
-
-    TestHelper.execute("INSERT INTO s2.nopk_insert VALUES (10, 'first');");
-    TestHelper.execute("INSERT INTO s2.nopk_insert VALUES (20, 'second');");
-    TestHelper.execute("INSERT INTO s2.nopk_insert VALUES (30, 'third');");
-
-    waitForAvailableRecords(30_000, TimeUnit.MILLISECONDS);
-    SourceRecords records = consumeRecordsByTopic(3);
-    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("s2.nopk_insert"));
-
-    assertThat(nopkRecords).hasSize(3);
-
-    for (SourceRecord record : nopkRecords) {
-      Struct value = (Struct) record.value();
-      assertThat(value.getString("op")).isEqualTo(Envelope.Operation.CREATE.code());
-    }
-
-    // No filtering should have occurred for INSERTs.
-    assertThat(streamLog.containsMessage("Filtering INSERT record for table")).isFalse();
-  }
-
-  @Test
   public void shouldBlockUpdateAndDeleteForNoPkTableWithFlagFalse() throws Exception {
     // Scenarios 1 & 2: With flag=false (default), server BLOCKS UPDATE/DELETE on
     // non-PK tables for BOTH DEFAULT and CHANGE RI. With the new server code (D51670),
@@ -635,9 +578,7 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
     TestHelper.execute("ALTER TABLE s2.nopk_default REPLICA IDENTITY DEFAULT;");
 
     TestHelper.dropPublication();
-    TestHelper.execute(
-        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
-            + "CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_default;");
+    TestHelper.execute("CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_default;");
 
     TestHelper.execute("INSERT INTO s2.nopk_default VALUES (1, 'test');");
 
@@ -652,9 +593,7 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
     TestHelper.execute("ALTER TABLE s2.nopk_change_block REPLICA IDENTITY CHANGE;");
 
     TestHelper.dropPublication();
-    TestHelper.execute(
-        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
-            + "CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_change_block;");
+    TestHelper.execute("CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_change_block;");
 
     TestHelper.execute("INSERT INTO s2.nopk_change_block VALUES (1, 'test');");
 
@@ -666,57 +605,6 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
   }
 
   @Test
-  public void shouldFilterUpdateAndDeleteForNoPkTableWithDefaultRIAndFlagTrue() throws Exception {
-    final LogInterceptor streamLog = new LogInterceptor(PostgresStreamingChangeEventSource.class);
-
-    TestHelper.execute("CREATE TABLE s2.nopk_default_flag (aa integer, bb varchar(20));");
-    TestHelper.execute("ALTER TABLE s2.nopk_default_flag REPLICA IDENTITY DEFAULT;");
-
-    TestHelper.dropPublication();
-    TestHelper.execute(
-        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
-            + "CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_default_flag;");
-
-    Configuration config = TestHelper.defaultConfig()
-        .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
-        .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
-        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE,
-            PostgresConnectorConfig.AutoCreateMode.DISABLED.getValue())
-        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s2.nopk_default_flag")
-        .build();
-
-    start(YugabyteDBConnector.class, config);
-    assertConnectorIsRunning();
-
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(60))
-        .pollInterval(Duration.ofSeconds(1))
-        .until(() -> streamLog.containsMessage("Processing messages"));
-
-    TestHelper.execute("INSERT INTO s2.nopk_default_flag VALUES (1, 'test');");
-    TestHelper.execute(
-        "SET yb_cdcsdk_allow_dml_without_pk = true; "
-            + "UPDATE s2.nopk_default_flag SET aa = 99 WHERE aa = 1;");
-    TestHelper.execute(
-        "SET yb_cdcsdk_allow_dml_without_pk = true; "
-            + "DELETE FROM s2.nopk_default_flag WHERE aa = 99;");
-
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofSeconds(1))
-        .until(() -> streamLog.containsMessage("Filtering UPDATE record for table")
-            && streamLog.containsMessage("Filtering DELETE record for table"));
-
-    SourceRecords records = consumeRecordsByTopic(1);
-    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("s2.nopk_default_flag"));
-
-    assertThat(nopkRecords).hasSize(1);
-
-    Struct value = (Struct) nopkRecords.get(0).value();
-    assertThat(value.getString("op")).isEqualTo(Envelope.Operation.CREATE.code());
-  }
-
-  @Test
   public void shouldFilterUpdateDeleteAfterAlterToFullBecauseStreamRIIsStale() throws Exception {
     // flag=false (default) scenario:
     // Phase 1: RI=CHANGE, no PK -> server BLOCKS UPDATE/DELETE.
@@ -724,14 +612,13 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
     // But stream RI stays CHANGE (stale) -> connector FILTERS them.
     final LogInterceptor schemaLog = new LogInterceptor(PostgresSchema.class);
     final LogInterceptor streamLog = new LogInterceptor(PostgresStreamingChangeEventSource.class);
+    streamLog.setLoggerLevel(PostgresStreamingChangeEventSource.class, Level.DEBUG);
 
     TestHelper.execute("CREATE TABLE s2.nopk_alter (aa integer, bb varchar(20));");
     TestHelper.execute("ALTER TABLE s2.nopk_alter REPLICA IDENTITY CHANGE;");
 
     TestHelper.dropPublication();
-    TestHelper.execute(
-        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
-            + "CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_alter;");
+    TestHelper.execute("CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_alter;");
 
     Configuration config = TestHelper.defaultConfig()
         .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
@@ -795,142 +682,4 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
     LOGGER.info("Verified: UPDATE/DELETE filtered after ALTER to FULL because stream RI is stale (CHANGE)");
   }
 
-  @Test
-  public void shouldFilterUpdateDeleteForDefaultRIAfterAlterToFull() throws Exception {
-    // Scenario 2 with ALTER: DEFAULT RI, no PK, flag=false.
-    // Phase 1: server blocks. Phase 2: ALTER to FULL, DMLs go through,
-    // connector filters because stream RI is still DEFAULT (stale).
-    final LogInterceptor schemaLog = new LogInterceptor(PostgresSchema.class);
-    final LogInterceptor streamLog = new LogInterceptor(PostgresStreamingChangeEventSource.class);
-
-    TestHelper.execute("CREATE TABLE s2.nopk_default_alter (aa integer, bb varchar(20));");
-
-    TestHelper.dropPublication();
-    TestHelper.execute(
-        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
-            + "CREATE PUBLICATION dbz_publication FOR TABLE s2.nopk_default_alter;");
-
-    Configuration config = TestHelper.defaultConfig()
-        .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
-        .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
-        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE,
-            PostgresConnectorConfig.AutoCreateMode.DISABLED.getValue())
-        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s2.nopk_default_alter")
-        .build();
-
-    start(YugabyteDBConnector.class, config);
-    assertConnectorIsRunning();
-
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(60))
-        .pollInterval(Duration.ofSeconds(1))
-        .until(() -> streamLog.containsMessage("Processing messages"));
-
-    TestHelper.execute("INSERT INTO s2.nopk_default_alter VALUES (1, 'before alter');");
-
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(60))
-        .pollInterval(Duration.ofSeconds(1))
-        .until(() -> schemaLog.containsMessage("Replica identity being stored for table s2.nopk_default_alter is CHANGE"));
-
-    LOGGER.info("Confirmed: stream stored RI=CHANGE (YB maps DEFAULT to CHANGE) for nopk_default_alter");
-
-    waitForAvailableRecords(30_000, TimeUnit.MILLISECONDS);
-    SourceRecords insertRecords = consumeRecordsByTopic(1);
-    assertThat(insertRecords.recordsForTopic(topicName("s2.nopk_default_alter"))).hasSize(1);
-
-    // Phase 1: With flag=false and RI=DEFAULT, server blocks UPDATE/DELETE.
-    assertThatThrownBy(() -> TestHelper.execute("UPDATE s2.nopk_default_alter SET aa = 99 WHERE aa = 1;"))
-        .hasMessageContaining("does not have a replica identity and publishes updates");
-
-    assertThatThrownBy(() -> TestHelper.execute("DELETE FROM s2.nopk_default_alter WHERE aa = 1;"))
-        .hasMessageContaining("does not have a replica identity and publishes deletes");
-
-    LOGGER.info("Phase 1 confirmed: UPDATE/DELETE blocked by server with RI=DEFAULT");
-
-    // Phase 2: ALTER to FULL -- server now allows UPDATE/DELETE.
-    // But the stream RI stays CHANGE (YB maps DEFAULT->CHANGE, and it's stale).
-    TestHelper.execute("ALTER TABLE s2.nopk_default_alter REPLICA IDENTITY FULL;");
-    TestHelper.waitFor(Duration.ofSeconds(5));
-
-    TestHelper.execute("UPDATE s2.nopk_default_alter SET aa = 99 WHERE aa = 1;");
-    TestHelper.execute("DELETE FROM s2.nopk_default_alter WHERE aa = 99;");
-
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(60))
-        .pollInterval(Duration.ofSeconds(1))
-        .until(() -> streamLog.containsMessage("Filtering UPDATE record for table")
-            && streamLog.containsMessage("Filtering DELETE record for table"));
-
-    assertThat(consumeAvailableRecords(record -> { })).isEqualTo(0);
-
-    LOGGER.info("Verified: UPDATE/DELETE filtered after ALTER to FULL because stream RI is stale (CHANGE)");
-  }
-
-  @Test
-  public void shouldVerifyStreamReplicaIdentityAfterAlterToFull() throws Exception {
-    final LogInterceptor schemaLog = new LogInterceptor(PostgresSchema.class);
-    final LogInterceptor streamLog = new LogInterceptor(PostgresStreamingChangeEventSource.class);
-
-    TestHelper.execute("ALTER TABLE s2.a REPLICA IDENTITY CHANGE;");
-
-    Configuration config = TestHelper.defaultConfig()
-        .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
-        .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
-        .build();
-
-    start(YugabyteDBConnector.class, config);
-    assertConnectorIsRunning();
-
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(60))
-        .pollInterval(Duration.ofSeconds(1))
-        .until(() -> streamLog.containsMessage("Processing messages"));
-
-    LOGGER.info("Streaming started, inserting first record...");
-    TestHelper.execute("INSERT INTO s2.a VALUES (1, 22, 'before alter');");
-
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofSeconds(1))
-        .until(() -> schemaLog.containsMessage("Replica identity being stored for table s2.a is CHANGE"));
-
-    LOGGER.info("Confirmed: stream initially stored RI=CHANGE");
-
-    SourceRecords records1 = consumeRecordsByTopic(1);
-    assertThat(records1.allRecordsInOrder()).isNotEmpty();
-
-    schemaLog.clear();
-
-    TestHelper.execute("ALTER TABLE s2.a REPLICA IDENTITY FULL;");
-    TestHelper.waitFor(Duration.ofSeconds(5));
-
-    LOGGER.info("Inserting second record after ALTER to FULL...");
-    TestHelper.execute("INSERT INTO s2.a VALUES (2, 33, 'after alter');");
-
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofSeconds(1))
-        .until(() -> schemaLog.containsMessage("Replica identity being stored for table s2.a is FULL")
-            || schemaLog.containsMessage("Replica identity being stored for table s2.a is CHANGE"));
-
-    SourceRecords records2 = consumeRecordsByTopic(1);
-    assertThat(records2.allRecordsInOrder()).isNotEmpty();
-
-    boolean riChangedToFull = schemaLog.containsMessage("Replica identity being stored for table s2.a is FULL");
-    boolean riStillChange = schemaLog.containsMessage("Replica identity being stored for table s2.a is CHANGE");
-
-    LOGGER.info("=== RESULT: After ALTER TABLE REPLICA IDENTITY FULL ===");
-    LOGGER.info("  Stream reported RI=FULL: {}", riChangedToFull);
-    LOGGER.info("  Stream reported RI=CHANGE: {}", riStillChange);
-
-    if (riChangedToFull) {
-      LOGGER.warn("FINDING: Stream RI DOES change after ALTER! "
-          + "Connector filtering needs putIfAbsent() or offset persistence.");
-    }
-    else {
-      LOGGER.info("FINDING: Stream RI does NOT change after ALTER. "
-          + "Stale RI confirmed as expected.");
-    }
-  }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteReplicaIdentityIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteReplicaIdentityIT.java
@@ -4,8 +4,10 @@ import io.debezium.config.Configuration;
 import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
 import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.junit.logging.LogInterceptor;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -21,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import static io.debezium.connector.postgresql.TestHelper.PK_FIELD;
 import static io.debezium.connector.postgresql.TestHelper.topicName;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests to validate the functionality of replica identities with YugabyteDB.
@@ -50,15 +53,41 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
   @Before
   public void before() {
     initializeConnectorTestFramework();
-    TestHelper.dropDefaultReplicationSlot();
+    terminateAndDropSlot();
     TestHelper.execute(CREATE_TABLES_STMT);
   }
 
   @After
   public void after() {
     stopConnector();
-    TestHelper.dropDefaultReplicationSlot();
+    terminateAndDropSlot();
     TestHelper.dropPublication();
+  }
+
+  private void terminateAndDropSlot() {
+    for (int attempt = 1; attempt <= 3; attempt++) {
+      try {
+        TestHelper.execute(
+            "SELECT pg_terminate_backend(active_pid) "
+                + "FROM pg_replication_slots "
+                + "WHERE slot_name = 'debezium' AND active = true;");
+        Thread.sleep(20_000);
+        TestHelper.dropDefaultReplicationSlot();
+        return;
+      }
+      catch (Exception e) {
+        LOGGER.warn("terminateAndDropSlot attempt {} failed: {}", attempt, e.getMessage());
+        if (attempt == 3) {
+          LOGGER.warn("Could not drop slot after 3 attempts, continuing anyway");
+        }
+        try {
+          Thread.sleep(10_000);
+        }
+        catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }
   }
 
   @Test
@@ -445,5 +474,334 @@ public class YugabyteReplicaIdentityIT extends AbstractConnectorTest {
     assertThat(deleteRecordValue.getStruct(Envelope.FieldName.BEFORE).getStruct("pk").getInt32("value")).isEqualTo(1);
     assertThat(deleteRecordValue.getStruct(Envelope.FieldName.BEFORE).getStruct("aa").getInt32("value")).isNull();
     assertThat(deleteRecordValue.getStruct(Envelope.FieldName.BEFORE).getStruct("bb").getString("value")).isNull();
+  }
+
+  // --- Tests for filtering UPDATE/DELETE on tables without primary key ---
+
+  @Test
+  public void shouldFilterUpdateAndDeleteForNoPkTableWithNonFullRI() throws Exception {
+    TestHelper.execute("DROP TABLE IF EXISTS nopk_change;");
+    TestHelper.execute("CREATE TABLE nopk_change (id INT, val TEXT);");
+    TestHelper.execute("ALTER TABLE nopk_change REPLICA IDENTITY CHANGE;");
+
+    TestHelper.dropPublication();
+    TestHelper.execute(
+        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
+            + "CREATE PUBLICATION dbz_publication FOR TABLE nopk_change;");
+
+    Configuration config = TestHelper.defaultConfig()
+        .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
+        .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.nopk_change")
+        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, "disabled")
+        .build();
+
+    start(YugabyteDBConnector.class, config);
+    assertConnectorIsRunning();
+
+    TestHelper.waitFor(Duration.ofSeconds(10));
+    waitForAvailableRecords(10_000, TimeUnit.MILLISECONDS);
+    assertNoRecordsToConsume();
+
+    LogInterceptor logInterceptor = new LogInterceptor(PostgresStreamingChangeEventSource.class);
+
+    TestHelper.execute("INSERT INTO nopk_change VALUES (1, 'hello');");
+    TestHelper.execute(
+        "SET yb_cdcsdk_allow_dml_without_pk = true; "
+            + "UPDATE nopk_change SET val = 'world' WHERE id = 1;");
+    TestHelper.execute(
+        "SET yb_cdcsdk_allow_dml_without_pk = true; "
+            + "DELETE FROM nopk_change WHERE id = 1;");
+
+    SourceRecords records = consumeRecordsByTopic(1);
+    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("nopk_change"));
+
+    assertThat(nopkRecords).hasSize(1);
+    assertThat(((Struct) nopkRecords.get(0).value()).get("op")).isEqualTo("c");
+
+    Awaitility.await().atMost(60, TimeUnit.SECONDS).until(
+        () -> logInterceptor.containsMessage("Filtering UPDATE record for table")
+            || logInterceptor.containsMessage("Filtering DELETE record for table"));
+  }
+
+  @Test
+  public void shouldNotFilterUpdateAndDeleteForNoPkTableWithFullRI() throws Exception {
+    TestHelper.execute("DROP TABLE IF EXISTS nopk_full;");
+    TestHelper.execute("CREATE TABLE nopk_full (id INT, val TEXT);");
+    TestHelper.execute("ALTER TABLE nopk_full REPLICA IDENTITY FULL;");
+
+    TestHelper.dropPublication();
+    TestHelper.execute(
+        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
+            + "CREATE PUBLICATION dbz_publication FOR TABLE nopk_full;");
+
+    Configuration config = TestHelper.defaultConfig()
+        .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
+        .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.nopk_full")
+        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, "disabled")
+        .build();
+
+    start(YugabyteDBConnector.class, config);
+    assertConnectorIsRunning();
+
+    TestHelper.waitFor(Duration.ofSeconds(10));
+    waitForAvailableRecords(10_000, TimeUnit.MILLISECONDS);
+    assertNoRecordsToConsume();
+
+    TestHelper.execute("INSERT INTO nopk_full VALUES (1, 'hello');");
+    TestHelper.execute("UPDATE nopk_full SET val = 'world' WHERE id = 1;");
+    TestHelper.execute("DELETE FROM nopk_full WHERE id = 1;");
+
+    SourceRecords records = consumeRecordsByTopic(3);
+    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("nopk_full"));
+
+    assertThat(nopkRecords).hasSize(3);
+    assertThat(((Struct) nopkRecords.get(0).value()).get("op")).isEqualTo("c");
+    assertThat(((Struct) nopkRecords.get(1).value()).get("op")).isEqualTo("u");
+    assertThat(((Struct) nopkRecords.get(2).value()).get("op")).isEqualTo("d");
+  }
+
+  @Test
+  public void shouldNotFilterInsertForNoPkTableRegardlessOfRI() throws Exception {
+    TestHelper.execute("DROP TABLE IF EXISTS nopk_insert;");
+    TestHelper.execute("CREATE TABLE nopk_insert (id INT, val TEXT);");
+    TestHelper.execute("ALTER TABLE nopk_insert REPLICA IDENTITY CHANGE;");
+
+    TestHelper.dropPublication();
+    TestHelper.execute(
+        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
+            + "CREATE PUBLICATION dbz_publication FOR TABLE nopk_insert;");
+
+    Configuration config = TestHelper.defaultConfig()
+        .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
+        .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.nopk_insert")
+        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, "disabled")
+        .build();
+
+    start(YugabyteDBConnector.class, config);
+    assertConnectorIsRunning();
+
+    TestHelper.waitFor(Duration.ofSeconds(10));
+    waitForAvailableRecords(10_000, TimeUnit.MILLISECONDS);
+    assertNoRecordsToConsume();
+
+    TestHelper.execute("INSERT INTO nopk_insert VALUES (1, 'hello');");
+    TestHelper.execute("INSERT INTO nopk_insert VALUES (2, 'world');");
+
+    SourceRecords records = consumeRecordsByTopic(2);
+    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("nopk_insert"));
+
+    assertThat(nopkRecords).hasSize(2);
+    assertThat(((Struct) nopkRecords.get(0).value()).get("op")).isEqualTo("c");
+    assertThat(((Struct) nopkRecords.get(1).value()).get("op")).isEqualTo("c");
+  }
+
+  @Test
+  public void shouldBlockUpdateAndDeleteForNoPkTableWithFlagFalse() throws Exception {
+    TestHelper.execute("DROP TABLE IF EXISTS nopk_default;");
+    TestHelper.execute("CREATE TABLE nopk_default (id INT, val TEXT);");
+
+    TestHelper.execute("DROP TABLE IF EXISTS nopk_change_block;");
+    TestHelper.execute("CREATE TABLE nopk_change_block (id INT, val TEXT);");
+    TestHelper.execute("ALTER TABLE nopk_change_block REPLICA IDENTITY CHANGE;");
+
+    TestHelper.execute("INSERT INTO nopk_default VALUES (1, 'a');");
+    TestHelper.execute("INSERT INTO nopk_change_block VALUES (1, 'a');");
+
+    assertThatThrownBy(() -> TestHelper.execute("UPDATE nopk_default SET val = 'b' WHERE id = 1;"))
+        .hasMessageContaining("does not have a replica identity")
+        .hasMessageContaining("publishes updates");
+
+    assertThatThrownBy(() -> TestHelper.execute("UPDATE nopk_change_block SET val = 'b' WHERE id = 1;"))
+        .hasMessageContaining("UPDATE and DELETE are not allowed on table")
+        .hasMessageContaining("without primary key");
+  }
+
+  @Test
+  public void shouldFilterUpdateAndDeleteForNoPkTableWithDefaultRIAndFlagTrue() throws Exception {
+    TestHelper.execute("DROP TABLE IF EXISTS nopk_default_flag;");
+    TestHelper.execute("CREATE TABLE nopk_default_flag (id INT, val TEXT);");
+
+    TestHelper.dropPublication();
+    TestHelper.execute(
+        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
+            + "CREATE PUBLICATION dbz_publication FOR TABLE nopk_default_flag;");
+
+    Configuration config = TestHelper.defaultConfig()
+        .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
+        .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.nopk_default_flag")
+        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, "disabled")
+        .build();
+
+    start(YugabyteDBConnector.class, config);
+    assertConnectorIsRunning();
+
+    TestHelper.waitFor(Duration.ofSeconds(10));
+    waitForAvailableRecords(10_000, TimeUnit.MILLISECONDS);
+    assertNoRecordsToConsume();
+
+    LogInterceptor logInterceptor = new LogInterceptor(PostgresStreamingChangeEventSource.class);
+
+    TestHelper.execute("INSERT INTO nopk_default_flag VALUES (1, 'hello');");
+    TestHelper.execute(
+        "SET yb_cdcsdk_allow_dml_without_pk = true; "
+            + "UPDATE nopk_default_flag SET val = 'world' WHERE id = 1;");
+    TestHelper.execute(
+        "SET yb_cdcsdk_allow_dml_without_pk = true; "
+            + "DELETE FROM nopk_default_flag WHERE id = 1;");
+
+    SourceRecords records = consumeRecordsByTopic(1);
+    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("nopk_default_flag"));
+
+    assertThat(nopkRecords).hasSize(1);
+    assertThat(((Struct) nopkRecords.get(0).value()).get("op")).isEqualTo("c");
+
+    Awaitility.await().atMost(60, TimeUnit.SECONDS).until(
+        () -> logInterceptor.containsMessage("Filtering UPDATE record for table")
+            || logInterceptor.containsMessage("Filtering DELETE record for table"));
+  }
+
+  @Test
+  public void shouldFilterUpdateDeleteAfterAlterToFullBecauseStreamRIIsStale() throws Exception {
+    TestHelper.execute("DROP TABLE IF EXISTS nopk_alter_change;");
+    TestHelper.execute("CREATE TABLE nopk_alter_change (id INT, val TEXT);");
+    TestHelper.execute("ALTER TABLE nopk_alter_change REPLICA IDENTITY CHANGE;");
+
+    assertThatThrownBy(
+        () -> TestHelper.execute("UPDATE nopk_alter_change SET val = 'x' WHERE id = 1;"))
+        .hasMessageContaining("UPDATE and DELETE are not allowed on table")
+        .hasMessageContaining("without primary key");
+
+    TestHelper.dropPublication();
+    TestHelper.execute(
+        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
+            + "CREATE PUBLICATION dbz_publication FOR TABLE nopk_alter_change;");
+
+    Configuration config = TestHelper.defaultConfig()
+        .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
+        .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.nopk_alter_change")
+        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, "disabled")
+        .build();
+
+    start(YugabyteDBConnector.class, config);
+    assertConnectorIsRunning();
+
+    TestHelper.waitFor(Duration.ofSeconds(10));
+    waitForAvailableRecords(10_000, TimeUnit.MILLISECONDS);
+    assertNoRecordsToConsume();
+
+    LogInterceptor logInterceptor = new LogInterceptor(PostgresStreamingChangeEventSource.class);
+
+    TestHelper.execute("ALTER TABLE nopk_alter_change REPLICA IDENTITY FULL;");
+
+    TestHelper.execute("INSERT INTO nopk_alter_change VALUES (1, 'hello');");
+    TestHelper.execute("UPDATE nopk_alter_change SET val = 'world' WHERE id = 1;");
+    TestHelper.execute("DELETE FROM nopk_alter_change WHERE id = 1;");
+
+    SourceRecords records = consumeRecordsByTopic(1);
+    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("nopk_alter_change"));
+
+    assertThat(nopkRecords).hasSize(1);
+    assertThat(((Struct) nopkRecords.get(0).value()).get("op")).isEqualTo("c");
+
+    Awaitility.await().atMost(60, TimeUnit.SECONDS).until(
+        () -> logInterceptor.containsMessage("Filtering UPDATE record for table")
+            || logInterceptor.containsMessage("Filtering DELETE record for table"));
+  }
+
+  @Test
+  public void shouldFilterUpdateDeleteForDefaultRIAfterAlterToFull() throws Exception {
+    TestHelper.execute("DROP TABLE IF EXISTS nopk_alter_default;");
+    TestHelper.execute("CREATE TABLE nopk_alter_default (id INT, val TEXT);");
+
+    assertThatThrownBy(
+        () -> TestHelper.execute("UPDATE nopk_alter_default SET val = 'x' WHERE id = 1;"))
+        .hasMessageContaining("does not have a replica identity")
+        .hasMessageContaining("publishes updates");
+
+    TestHelper.dropPublication();
+    TestHelper.execute(
+        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
+            + "CREATE PUBLICATION dbz_publication FOR TABLE nopk_alter_default;");
+
+    Configuration config = TestHelper.defaultConfig()
+        .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
+        .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.nopk_alter_default")
+        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, "disabled")
+        .build();
+
+    start(YugabyteDBConnector.class, config);
+    assertConnectorIsRunning();
+
+    TestHelper.waitFor(Duration.ofSeconds(10));
+    waitForAvailableRecords(10_000, TimeUnit.MILLISECONDS);
+    assertNoRecordsToConsume();
+
+    LogInterceptor logInterceptor = new LogInterceptor(PostgresStreamingChangeEventSource.class);
+
+    TestHelper.execute("ALTER TABLE nopk_alter_default REPLICA IDENTITY FULL;");
+
+    TestHelper.execute("INSERT INTO nopk_alter_default VALUES (1, 'hello');");
+    TestHelper.execute("UPDATE nopk_alter_default SET val = 'world' WHERE id = 1;");
+    TestHelper.execute("DELETE FROM nopk_alter_default WHERE id = 1;");
+
+    SourceRecords records = consumeRecordsByTopic(1);
+    List<SourceRecord> nopkRecords = records.recordsForTopic(topicName("nopk_alter_default"));
+
+    assertThat(nopkRecords).hasSize(1);
+    assertThat(((Struct) nopkRecords.get(0).value()).get("op")).isEqualTo("c");
+
+    Awaitility.await().atMost(60, TimeUnit.SECONDS).until(
+        () -> logInterceptor.containsMessage("Filtering UPDATE record for table")
+            || logInterceptor.containsMessage("Filtering DELETE record for table"));
+  }
+
+  @Test
+  public void shouldVerifyStreamReplicaIdentityAfterAlterToFull() throws Exception {
+    TestHelper.execute("DROP TABLE IF EXISTS nopk_ri_verify;");
+    TestHelper.execute("CREATE TABLE nopk_ri_verify (id INT, val TEXT);");
+    TestHelper.execute("ALTER TABLE nopk_ri_verify REPLICA IDENTITY CHANGE;");
+
+    TestHelper.dropPublication();
+    TestHelper.execute(
+        "SET yb_cdcsdk_stream_tables_without_primary_key = true; "
+            + "CREATE PUBLICATION dbz_publication FOR TABLE nopk_ri_verify;");
+
+    Configuration config = TestHelper.defaultConfig()
+        .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
+        .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+        .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.nopk_ri_verify")
+        .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, "disabled")
+        .build();
+
+    start(YugabyteDBConnector.class, config);
+    assertConnectorIsRunning();
+
+    TestHelper.waitFor(Duration.ofSeconds(10));
+    waitForAvailableRecords(10_000, TimeUnit.MILLISECONDS);
+    assertNoRecordsToConsume();
+
+    TestHelper.execute("INSERT INTO nopk_ri_verify VALUES (1, 'hello');");
+
+    SourceRecords records = consumeRecordsByTopic(1);
+    assertThat(records.recordsForTopic(topicName("nopk_ri_verify"))).hasSize(1);
+
+    LogInterceptor logInterceptor = new LogInterceptor(PostgresStreamingChangeEventSource.class);
+
+    TestHelper.execute("ALTER TABLE nopk_ri_verify REPLICA IDENTITY FULL;");
+
+    TestHelper.execute("INSERT INTO nopk_ri_verify VALUES (2, 'world');");
+    TestHelper.execute("UPDATE nopk_ri_verify SET val = 'updated' WHERE id = 2;");
+
+    SourceRecords records2 = consumeRecordsByTopic(1);
+    assertThat(records2.recordsForTopic(topicName("nopk_ri_verify"))).hasSize(1);
+
+    Awaitility.await().atMost(60, TimeUnit.SECONDS).until(
+        () -> logInterceptor.containsMessage("Filtering UPDATE record for table"));
   }
 }


### PR DESCRIPTION
## Problem

When a table without a primary key is under a CDC publication, UPDATE and DELETE records may reach the connector even though they lack sufficient key data to identify the affected row. This happens when:

- The `yb_cdcsdk_allow_dml_without_pk` GUC is set to `true`, allowing DMLs through on non-PK tables.
- The table's replica identity is changed to FULL after the CDC stream was created — the server allows DMLs, but the stream still has the original non-FULL replica identity.

In both cases, the streamed UPDATE/DELETE records don't have enough information for downstream consumers.

## Solution

Add connector-side filtering to skip UPDATE/DELETE records for tables that have no primary key and a non-FULL stream replica identity. INSERTs are never filtered.

Added a `shouldFilterNoPkRecord`heck in `PostgresStreamingChangeEventSource.processReplicationMessages()`, after `offsetContext.updateWalPosition()` and before `dispatcher.dispatchDataChangeEvent()`. When the check triggers, a log message is emitted at INFO level with the operation type, table name, and stream replica identity value, and the record is skipped. The filtering only applies when running against YugabyteDB (`YugabyteDBServer.isEnabled()`).

## Test Plan

YugabyteReplicaIdentityIT#shouldFilterUpdateAndDeleteForNoPkTableWithNonFullRI
YugabyteReplicaIdentityIT#shouldNotFilterUpdateAndDeleteForNoPkTableWithFullRI
YugabyteReplicaIdentityIT#shouldNotFilterInsertForNoPkTableRegardlessOfRI
YugabyteReplicaIdentityIT#shouldBlockUpdateAndDeleteForNoPkTableWithFlagFalse
YugabyteReplicaIdentityIT#shouldFilterUpdateAndDeleteForNoPkTableWithDefaultRIAndFlagTrue
YugabyteReplicaIdentityIT#shouldFilterUpdateDeleteAfterAlterToFullBecauseStreamRIIsStale
YugabyteReplicaIdentityIT#shouldFilterUpdateDeleteForDefaultRIAfterAlterToFull
YugabyteReplicaIdentityIT#shouldVerifyStreamReplicaIdentityAfterAlterToFull

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes streaming dispatch behavior by dropping certain UPDATE/DELETE events for YugabyteDB, which could affect downstream data completeness if the filtering conditions are mis-detected. Scoped to no-primary-key tables with non-`FULL` stream replica identity and covered by new integration tests.
> 
> **Overview**
> Prevents YugabyteDB CDC from emitting ambiguous `UPDATE`/`DELETE` events by **skipping dispatch** when the target table has *no primary key* and the stream’s replica identity is **non-`FULL`** (in `PostgresStreamingChangeEventSource`). Inserts and `FULL` replica identity tables continue to flow normally.
> 
> Adds *rate-limited debug logging* to track how many events were filtered, and extends `YugabyteReplicaIdentityIT` with new scenarios for filtering vs non-filtering behavior (including stale stream replica identity after `ALTER ... REPLICA IDENTITY FULL`) plus more resilient replication slot cleanup via backend termination retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36a808a1189abd06fb530387e83ecdc882e2898f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->