### PR TITLE
[DBZ-PGYB][yugabyte/yugabyte-db#31289] Support upstream heartbeat behavior during streaming phase

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -1574,16 +1574,29 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                                      HeartbeatConnectionProvider connectionProvider,
                                      HeartbeatErrorHandler errorHandler) {
         if (YugabyteDBServer.isEnabled()) {
-            // We do not need any heartbeat when snapshot is never required.
-            if (snapshotMode.equals(SnapshotMode.NEVER)) {
+            boolean transitionNeeded = !snapshotMode.equals(SnapshotMode.NEVER);
+            boolean streamingHeartbeatEnabled = !getHeartbeatInterval().isZero();
+
+            // No transition wait needed and no streaming heartbeat requested: nothing to do.
+            if (!transitionNeeded && !streamingHeartbeatEnabled) {
                 return Heartbeat.DEFAULT_NOOP_HEARTBEAT;
+            }
+
+            if (streamingHeartbeatEnabled && !Strings.isNullOrBlank(getHeartbeatActionQuery())) {
+                return new YBDatabaseHeartbeatImpl(
+                        getHeartbeatInterval(),
+                        topicNamingStrategy.heartbeatTopic(),
+                        getLogicalName(),
+                        connectionProvider.get(),
+                        getHeartbeatActionQuery(),
+                        errorHandler,
+                        schemaNameAdjuster);
             }
 
             return new YBHeartbeatImpl(getHeartbeatInterval(), topicNamingStrategy.heartbeatTopic(),
                     getLogicalName(), schemaNameAdjuster);
-        } else {
-            return super.createHeartbeat(topicNamingStrategy, schemaNameAdjuster, connectionProvider, errorHandler);
         }
+        return super.createHeartbeat(topicNamingStrategy, schemaNameAdjuster, connectionProvider, errorHandler);
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YBDatabaseHeartbeatImpl.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YBDatabaseHeartbeatImpl.java
@@ -1,0 +1,50 @@
+package io.debezium.connector.postgresql;
+
+import io.debezium.function.BlockingConsumer;
+import io.debezium.heartbeat.DatabaseHeartbeatImpl;
+import io.debezium.heartbeat.HeartbeatErrorHandler;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.schema.SchemaNameAdjuster;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * YugabyteDB specific database heartbeat implementation that allows the forcedBeat method
+ * during the snapshot-to-streaming transition phase, and the regular heartbeat method only
+ * during the streaming phase.
+ *
+ * @author bakul-gupta
+ */
+public class YBDatabaseHeartbeatImpl extends DatabaseHeartbeatImpl {
+
+    private final Duration heartbeatInterval;
+
+    public YBDatabaseHeartbeatImpl(Duration heartbeatInterval, String topicName, String key, JdbcConnection jdbcConnection,
+                                   String heartBeatActionQuery, HeartbeatErrorHandler errorHandler,
+                                   SchemaNameAdjuster schemaNameAdjuster) {
+        super(heartbeatInterval, topicName, key, jdbcConnection, heartBeatActionQuery, errorHandler, schemaNameAdjuster);
+        this.heartbeatInterval = heartbeatInterval;
+    }
+
+    @Override
+    public void heartbeat(Map<String, ?> partition, Map<String, ?> offset, BlockingConsumer<SourceRecord> consumer) throws InterruptedException {
+        if (heartbeatInterval.isZero() || YBHeartbeatImpl.isInSnapshot(offset)) {
+            return;
+        }
+        super.heartbeat(partition, offset, consumer);
+    }
+
+    @Override
+    public void heartbeat(Map<String, ?> partition, OffsetProducer offsetProducer, BlockingConsumer<SourceRecord> consumer) throws InterruptedException {
+        if (heartbeatInterval.isZero()) {
+            return;
+        }
+        Map<String, ?> resolved = offsetProducer.offset();
+        if (YBHeartbeatImpl.isInSnapshot(resolved)) {
+            return;
+        }
+        super.heartbeat(partition, () -> resolved, consumer);
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YBHeartbeatImpl.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YBHeartbeatImpl.java
@@ -1,5 +1,6 @@
 package io.debezium.connector.postgresql;
 
+import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.function.BlockingConsumer;
 import io.debezium.heartbeat.HeartbeatImpl;
 import io.debezium.schema.SchemaNameAdjuster;
@@ -9,25 +10,45 @@ import java.time.Duration;
 import java.util.Map;
 
 /**
- * YugabyteDB specific heartbeat implementation to only allow the forcedHeartbeat method which
- * will be called in the transition phase when we are waiting for transitioning from snapshot to
- * streaming.
+ * YugabyteDB specific heartbeat implementation that allows the forcedBeat method during the
+ * snapshot-to-streaming transition phase, and the regular heartbeat method only during the
+ * streaming phase.
  */
 public class YBHeartbeatImpl extends HeartbeatImpl {
-  public YBHeartbeatImpl(Duration heartbeatInterval, String topicName, String key, SchemaNameAdjuster schemaNameAdjuster) {
-    super(heartbeatInterval, topicName, key, schemaNameAdjuster);
-  }
 
-  @Override
-  public void heartbeat(Map<String, ?> partition, Map<String, ?> offset, BlockingConsumer<SourceRecord> consumer) throws InterruptedException {
-  }
+    private final Duration heartbeatInterval;
 
-  @Override
-  public void heartbeat(Map<String, ?> partition, OffsetProducer offsetProducer, BlockingConsumer<SourceRecord> consumer) throws InterruptedException {
-  }
+    public YBHeartbeatImpl(Duration heartbeatInterval, String topicName, String key, SchemaNameAdjuster schemaNameAdjuster) {
+        super(heartbeatInterval, topicName, key, schemaNameAdjuster);
+        this.heartbeatInterval = heartbeatInterval;
+    }
 
-  @Override
-  public void forcedBeat(Map<String, ?> partition, Map<String, ?> offset, BlockingConsumer<SourceRecord> consumer) throws InterruptedException {
-    super.forcedBeat(partition, offset, consumer);
-  }
+    static boolean isInSnapshot(Map<String, ?> offset) {
+        return offset != null && Boolean.TRUE.equals(offset.get(AbstractSourceInfo.SNAPSHOT_KEY));
+    }
+
+    @Override
+    public void heartbeat(Map<String, ?> partition, Map<String, ?> offset, BlockingConsumer<SourceRecord> consumer) throws InterruptedException {
+        if (heartbeatInterval.isZero() || isInSnapshot(offset)) {
+            return;
+        }
+        super.heartbeat(partition, offset, consumer);
+    }
+
+    @Override
+    public void heartbeat(Map<String, ?> partition, OffsetProducer offsetProducer, BlockingConsumer<SourceRecord> consumer) throws InterruptedException {
+        if (heartbeatInterval.isZero()) {
+            return;
+        }
+        Map<String, ?> resolved = offsetProducer.offset();
+        if (isInSnapshot(resolved)) {
+            return;
+        }
+        super.heartbeat(partition, () -> resolved, consumer);
+    }
+
+    @Override
+    public void forcedBeat(Map<String, ?> partition, Map<String, ?> offset, BlockingConsumer<SourceRecord> consumer) throws InterruptedException {
+        super.forcedBeat(partition, offset, consumer);
+    }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBDatabaseHeartbeatImplTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBDatabaseHeartbeatImplTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.function.BlockingConsumer;
+import io.debezium.heartbeat.Heartbeat;
+import io.debezium.heartbeat.HeartbeatErrorHandler;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.schema.SchemaNameAdjuster;
+
+/**
+ * Unit tests for the YB-specific snapshot/streaming gating in
+ * {@link YBDatabaseHeartbeatImpl}, plus verification that the action query is
+ * (or is not) executed on each phase.
+ */
+public class YBDatabaseHeartbeatImplTest {
+
+    private static final String TOPIC = "__debezium-heartbeat.test";
+    private static final String KEY = "test_server";
+    private static final String ACTION_QUERY = "INSERT INTO heartbeat VALUES (now())";
+
+    @Mock
+    private JdbcConnection jdbcConnection;
+
+    @Mock
+    private HeartbeatErrorHandler errorHandler;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    private static Map<String, Object> partition() {
+        return Collections.singletonMap("server", KEY);
+    }
+
+    private static Map<String, Object> snapshotOffset() {
+        Map<String, Object> offset = new HashMap<>();
+        offset.put(AbstractSourceInfo.SNAPSHOT_KEY, Boolean.TRUE);
+        offset.put("lsn", 1L);
+        return offset;
+    }
+
+    private static Map<String, Object> streamingOffset() {
+        Map<String, Object> offset = new HashMap<>();
+        offset.put(AbstractSourceInfo.SNAPSHOT_KEY, Boolean.FALSE);
+        offset.put("lsn", 1L);
+        return offset;
+    }
+
+    private YBDatabaseHeartbeatImpl heartbeatWithInterval(Duration interval) {
+        return new YBDatabaseHeartbeatImpl(
+                interval,
+                TOPIC,
+                KEY,
+                jdbcConnection,
+                ACTION_QUERY,
+                errorHandler,
+                SchemaNameAdjuster.NO_OP);
+    }
+
+    private static final class RecordingConsumer implements BlockingConsumer<SourceRecord> {
+        final List<SourceRecord> records = new ArrayList<>();
+
+        @Override
+        public void accept(SourceRecord record) {
+            records.add(record);
+        }
+    }
+
+    // ---------- zero-interval no-op (both heartbeat overloads) ----------
+
+    @Test
+    public void shouldNotHeartbeatOrRunQueryWhenIntervalIsZero() throws InterruptedException, SQLException {
+        YBDatabaseHeartbeatImpl heartbeat = heartbeatWithInterval(Duration.ZERO);
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        heartbeat.heartbeat(partition(), streamingOffset(), consumer);
+
+        assertThat(consumer.records).isEmpty();
+        verifyZeroInteractions(jdbcConnection);
+    }
+
+    @Test
+    public void shouldNotHeartbeatOrRunQueryWhenIntervalIsZero_offsetProducer() throws InterruptedException, SQLException {
+        YBDatabaseHeartbeatImpl heartbeat = heartbeatWithInterval(Duration.ZERO);
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        boolean[] producerCalled = { false };
+        Heartbeat.OffsetProducer producer = () -> {
+            producerCalled[0] = true;
+            return streamingOffset();
+        };
+
+        heartbeat.heartbeat(partition(), producer, consumer);
+
+        assertThat(consumer.records).isEmpty();
+        assertThat(producerCalled[0]).isFalse();
+        verifyZeroInteractions(jdbcConnection);
+    }
+
+    // ---------- snapshot-phase no-op ----------
+
+    @Test
+    public void shouldNotHeartbeatOrRunQueryWhileInSnapshot() throws InterruptedException, SQLException {
+        YBDatabaseHeartbeatImpl heartbeat = heartbeatWithInterval(Duration.ofMillis(100));
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        heartbeat.heartbeat(partition(), snapshotOffset(), consumer);
+
+        assertThat(consumer.records).isEmpty();
+        verify(jdbcConnection, never()).execute(eq(ACTION_QUERY));
+    }
+
+    @Test
+    public void shouldNotHeartbeatOrRunQueryWhileInSnapshot_offsetProducer() throws InterruptedException, SQLException {
+        YBDatabaseHeartbeatImpl heartbeat = heartbeatWithInterval(Duration.ofMillis(100));
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        heartbeat.heartbeat(partition(), YBDatabaseHeartbeatImplTest::snapshotOffset, consumer);
+
+        assertThat(consumer.records).isEmpty();
+        verify(jdbcConnection, never()).execute(eq(ACTION_QUERY));
+    }
+
+    // ---------- streaming-phase delegation: timer expires → record + action query ----------
+
+    // Threads.Timer uses millisecond resolution and {@code expired()} returns {@code elapsed > intervalMs}.
+    // Use a small non-zero interval plus a sleep that comfortably exceeds it so the timer is reliably
+    // expired by the time {@code heartbeat(...)} is called.
+    private static final Duration STREAMING_INTERVAL = Duration.ofMillis(1);
+    private static final long SLEEP_PAST_INTERVAL_MS = 20L;
+
+    @Test
+    public void shouldEmitRecordAndRunActionQueryOnceTimerExpires() throws InterruptedException, SQLException {
+        YBDatabaseHeartbeatImpl heartbeat = heartbeatWithInterval(STREAMING_INTERVAL);
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        Thread.sleep(SLEEP_PAST_INTERVAL_MS);
+        heartbeat.heartbeat(partition(), streamingOffset(), consumer);
+
+        assertThat(consumer.records).hasSize(1);
+        assertThat(consumer.records.get(0).topic()).isEqualTo(TOPIC);
+        verify(jdbcConnection, times(1)).execute(eq(ACTION_QUERY));
+    }
+
+    @Test
+    public void shouldEmitRecordAndRunActionQueryOnceTimerExpires_offsetProducer() throws InterruptedException, SQLException {
+        YBDatabaseHeartbeatImpl heartbeat = heartbeatWithInterval(STREAMING_INTERVAL);
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        boolean[] producerCalled = { false };
+        Heartbeat.OffsetProducer producer = () -> {
+            producerCalled[0] = true;
+            return streamingOffset();
+        };
+
+        Thread.sleep(SLEEP_PAST_INTERVAL_MS);
+        heartbeat.heartbeat(partition(), producer, consumer);
+
+        assertThat(producerCalled[0]).isTrue();
+        assertThat(consumer.records).hasSize(1);
+        verify(jdbcConnection, times(1)).execute(eq(ACTION_QUERY));
+    }
+
+    // ---------- forcedBeat: inherited path used at snapshot-to-streaming transition ----------
+
+    @Test
+    public void forcedBeatShouldEmitRecordAndRunActionQueryEvenWithSnapshotOffset() throws InterruptedException, SQLException {
+        // The transition wait calls forcedBeat() with an offset that still says snapshot;
+        // the inherited DatabaseHeartbeatImpl.forcedBeat() must run the action query and emit a record.
+        YBDatabaseHeartbeatImpl heartbeat = heartbeatWithInterval(Duration.ofMillis(100));
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        heartbeat.forcedBeat(partition(), snapshotOffset(), consumer);
+
+        assertThat(consumer.records).hasSize(1);
+        verify(jdbcConnection, times(1)).execute(eq(ACTION_QUERY));
+    }
+
+    @Test
+    public void forcedBeatShouldSwallowSqlExceptionAndStillEmitRecord() throws InterruptedException, SQLException {
+        // Action-query failures are logged + forwarded to the error handler; the heartbeat
+        // record itself must still be produced so the slot can advance.
+        when(jdbcConnection.execute(eq(ACTION_QUERY))).thenThrow(new SQLException("boom", "08000"));
+
+        YBDatabaseHeartbeatImpl heartbeat = heartbeatWithInterval(Duration.ofMillis(100));
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        heartbeat.forcedBeat(partition(), streamingOffset(), consumer);
+
+        assertThat(consumer.records).hasSize(1);
+        verify(errorHandler, times(1)).onError(org.mockito.ArgumentMatchers.any(SQLException.class));
+    }
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBHeartbeatIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBHeartbeatIT.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.connector.postgresql.connection.ReplicationConnection;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.embedded.EmbeddedEngineConfig;
+import io.debezium.heartbeat.DatabaseHeartbeatImpl;
+import io.debezium.heartbeat.Heartbeat;
+
+/**
+ * Integration tests for YB streaming-phase heartbeat behaviour.
+ *
+ * @author bakul-gupta
+ */
+public class YBHeartbeatIT extends AbstractConnectorTest {
+
+    // Cap engine shutdown at 30s (default is 5min) so tests stay responsive.
+    private static final long SHUTDOWN_PAUSE_MS = 30_000L;
+
+    // YB MBeans have extra tags that waitForStreamingRunning can't match; use a static wait.
+    private static final Duration STREAMING_STARTUP_WAIT = Duration.ofSeconds(15);
+
+    @Before
+    public void before() throws SQLException {
+        TestHelper.dropAllSchemas();
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.dropPublication();
+        initializeConnectorTestFramework();
+    }
+
+    @After
+    public void after() {
+        try {
+            stopConnector();
+        }
+        catch (Throwable ignored) {
+        }
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.dropPublication();
+    }
+
+    @Test
+    public void test1_actionQueryRunsAndHeartbeatRecordReachesKafka() throws Exception {
+        TestHelper.execute(
+                "DROP SCHEMA IF EXISTS s1 CASCADE;" +
+                        "CREATE SCHEMA s1;" +
+                        "CREATE TABLE s1.a (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
+                        "CREATE TABLE s1.heartbeat (ts TIMESTAMP WITH TIME ZONE PRIMARY KEY);" +
+                        "INSERT INTO s1.heartbeat (ts) VALUES (NOW());");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.getValue())
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1.a")
+                .with(Heartbeat.HEARTBEAT_INTERVAL, 500)
+                .with(DatabaseHeartbeatImpl.HEARTBEAT_ACTION_QUERY, "UPDATE s1.heartbeat SET ts=NOW();")
+                .with(EmbeddedEngineConfig.WAIT_FOR_COMPLETION_BEFORE_INTERRUPT_MS, SHUTDOWN_PAUSE_MS)
+                .build();
+
+        final String initialTs = readHeartbeatTs();
+        assertNotNull("Expected initial heartbeat row from setup", initialTs);
+
+        start(YugabyteDBConnector.class, config);
+        assertConnectorIsRunning();
+        TestHelper.waitFor(STREAMING_STARTUP_WAIT);
+
+        TestHelper.execute("INSERT INTO s1.a (aa) VALUES (1);");
+
+        Awaitility.await()
+                .atMost(60, TimeUnit.SECONDS)
+                .pollInterval(Duration.ofMillis(500))
+                .ignoreExceptions()
+                .untilAsserted(() -> assertThat(readHeartbeatTs()).isNotEqualTo(initialTs));
+
+        SourceRecord heartbeatRecord = pollForFirstHeartbeatRecord(Duration.ofSeconds(30));
+        assertNotNull("Expected a heartbeat record on " + TestHelper.getDefaultHeartbeatTopic(),
+                heartbeatRecord);
+        assertThat(heartbeatRecord.valueSchema().name()).endsWith(".Heartbeat");
+    }
+
+    @Test
+    public void test2_actionQueryTargetTableNotInIncludeList_lsnAdvances() throws Exception {
+        TestHelper.execute(
+                "DROP SCHEMA IF EXISTS s1 CASCADE;" +
+                        "CREATE SCHEMA s1;" +
+                        "CREATE TABLE s1.included (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
+                        "CREATE TABLE s1.heartbeat (ts TIMESTAMP WITH TIME ZONE PRIMARY KEY);" +
+                        "INSERT INTO s1.heartbeat (ts) VALUES (NOW());");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.getValue())
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1.included")
+                .with(Heartbeat.HEARTBEAT_INTERVAL, 500)
+                .with(DatabaseHeartbeatImpl.HEARTBEAT_ACTION_QUERY, "UPDATE s1.heartbeat SET ts=NOW();")
+                .with(EmbeddedEngineConfig.WAIT_FOR_COMPLETION_BEFORE_INTERRUPT_MS, SHUTDOWN_PAUSE_MS)
+                .build();
+
+        start(YugabyteDBConnector.class, config);
+        assertConnectorIsRunning();
+        TestHelper.waitFor(STREAMING_STARTUP_WAIT);
+
+        TestHelper.execute("INSERT INTO s1.included (aa) VALUES (1);");
+        consumeRecord();
+
+        assertLsnAdvances();
+    }
+
+    @Test
+    public void test3_externalActivityOnExcludedTables_lsnAdvances() throws Exception {
+        TestHelper.execute(
+                "DROP SCHEMA IF EXISTS s1 CASCADE;" +
+                        "CREATE SCHEMA s1;" +
+                        "CREATE TABLE s1.t1 (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
+                        "CREATE TABLE s1.t2 (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
+                        "CREATE TABLE s1.t3 (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
+                        "CREATE TABLE s1.t4 (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
+                        "CREATE TABLE s1.t5 (pk SERIAL, aa integer, PRIMARY KEY(pk));");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.getValue())
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1.t1")
+                .with(Heartbeat.HEARTBEAT_INTERVAL, 500)
+                .with(EmbeddedEngineConfig.WAIT_FOR_COMPLETION_BEFORE_INTERRUPT_MS, SHUTDOWN_PAUSE_MS)
+                .build();
+
+        start(YugabyteDBConnector.class, config);
+        assertConnectorIsRunning();
+        TestHelper.waitFor(STREAMING_STARTUP_WAIT);
+
+        TestHelper.execute("INSERT INTO s1.t1 (aa) VALUES (1);");
+        consumeRecord();
+
+        final AtomicBoolean keepWriting = new AtomicBoolean(true);
+        Thread writer = new Thread(() -> {
+            int i = 0;
+            while (keepWriting.get()) {
+                try {
+                    TestHelper.execute(
+                            "INSERT INTO s1.t2 (aa) VALUES (" + i + ");" +
+                                    "INSERT INTO s1.t3 (aa) VALUES (" + i + ");" +
+                                    "INSERT INTO s1.t4 (aa) VALUES (" + i + ");" +
+                                    "INSERT INTO s1.t5 (aa) VALUES (" + i + ");");
+                    i++;
+                    Thread.sleep(500);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                catch (Exception ignored) {
+                }
+            }
+        }, "yb-hb-excluded-writer");
+        writer.setDaemon(true);
+        writer.start();
+
+        try {
+            assertLsnAdvances();
+        }
+        finally {
+            keepWriting.set(false);
+            writer.interrupt();
+            writer.join(5_000);
+        }
+    }
+
+    private void assertLsnAdvances() throws Exception {
+        final Set<String> observedLsns = new HashSet<>();
+        try (PostgresConnection connection = TestHelper.create()) {
+            observedLsns.add(getConfirmedFlushLsn(connection));
+            Awaitility.await()
+                    .atMost(60, TimeUnit.SECONDS)
+                    .pollInterval(Duration.ofSeconds(1))
+                    .ignoreExceptions()
+                    .until(() -> observedLsns.add(getConfirmedFlushLsn(connection)));
+        }
+        assertThat(observedLsns.size())
+                .as("confirmed_flush_lsn should advance via heartbeats")
+                .isGreaterThan(1);
+    }
+
+    private String readHeartbeatTs() throws SQLException {
+        try (PostgresConnection connection = TestHelper.create()) {
+            return connection.queryAndMap("SELECT ts::text FROM s1.heartbeat LIMIT 1;", rs -> {
+                if (rs.next()) {
+                    return rs.getString(1);
+                }
+                return null;
+            });
+        }
+    }
+
+    private SourceRecord pollForFirstHeartbeatRecord(Duration timeout) throws InterruptedException {
+        final String heartbeatTopic = TestHelper.getDefaultHeartbeatTopic();
+        final long deadlineMs = System.currentTimeMillis() + timeout.toMillis();
+        while (System.currentTimeMillis() < deadlineMs) {
+            SourceRecord record = consumeRecord();
+            if (record != null && heartbeatTopic.equals(record.topic())) {
+                return record;
+            }
+        }
+        return null;
+    }
+
+    private String getConfirmedFlushLsn(PostgresConnection connection) throws SQLException {
+        final String lsn = connection.prepareQueryAndMap(
+                "select * from pg_replication_slots where slot_name = ? and database = ? and plugin = ?",
+                statement -> {
+                    statement.setString(1, ReplicationConnection.Builder.DEFAULT_SLOT_NAME);
+                    statement.setString(2, "yugabyte");
+                    statement.setString(3, TestHelper.decoderPlugin().getPostgresPluginName());
+                },
+                rs -> {
+                    if (rs.next()) {
+                        return rs.getString("confirmed_flush_lsn");
+                    }
+                    fail("No replication slot info available");
+                    return null;
+                });
+        connection.rollback();
+        return lsn;
+    }
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBHeartbeatImplTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBHeartbeatImplTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.function.BlockingConsumer;
+import io.debezium.heartbeat.Heartbeat;
+import io.debezium.schema.SchemaNameAdjuster;
+
+/**
+ * Unit tests for the YB-specific snapshot/streaming gating in {@link YBHeartbeatImpl}.
+ *
+ * Streaming-phase delegation is asserted via {@code forcedBeat}, which the
+ * timer-driven path ultimately calls inside the upstream {@link io.debezium.heartbeat.HeartbeatImpl}.
+ * The interval-expiry timing path is owned by upstream and is intentionally not retested here.
+ */
+public class YBHeartbeatImplTest {
+
+    private static final String TOPIC = "__debezium-heartbeat.test";
+    private static final String KEY = "test_server";
+
+    private static Map<String, Object> partition() {
+        return Collections.singletonMap("server", KEY);
+    }
+
+    private static Map<String, Object> snapshotOffset() {
+        Map<String, Object> offset = new HashMap<>();
+        offset.put(AbstractSourceInfo.SNAPSHOT_KEY, Boolean.TRUE);
+        offset.put("lsn", 1L);
+        return offset;
+    }
+
+    private static Map<String, Object> streamingOffset() {
+        Map<String, Object> offset = new HashMap<>();
+        offset.put(AbstractSourceInfo.SNAPSHOT_KEY, Boolean.FALSE);
+        offset.put("lsn", 1L);
+        return offset;
+    }
+
+    private static YBHeartbeatImpl heartbeatWithInterval(Duration interval) {
+        return new YBHeartbeatImpl(interval, TOPIC, KEY, SchemaNameAdjuster.NO_OP);
+    }
+
+    private static final class RecordingConsumer implements BlockingConsumer<SourceRecord> {
+        final List<SourceRecord> records = new ArrayList<>();
+
+        @Override
+        public void accept(SourceRecord record) {
+            records.add(record);
+        }
+    }
+
+    // ---------- zero-interval no-op (both heartbeat overloads) ----------
+
+    @Test
+    public void shouldNotHeartbeatWhenIntervalIsZero() throws InterruptedException {
+        YBHeartbeatImpl heartbeat = heartbeatWithInterval(Duration.ZERO);
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        heartbeat.heartbeat(partition(), streamingOffset(), consumer);
+
+        assertThat(consumer.records).isEmpty();
+    }
+
+    @Test
+    public void shouldNotHeartbeatWhenIntervalIsZero_offsetProducer() throws InterruptedException {
+        YBHeartbeatImpl heartbeat = heartbeatWithInterval(Duration.ZERO);
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        // OffsetProducer should not even be invoked when interval is zero.
+        boolean[] producerCalled = { false };
+        Heartbeat.OffsetProducer producer = () -> {
+            producerCalled[0] = true;
+            return streamingOffset();
+        };
+
+        heartbeat.heartbeat(partition(), producer, consumer);
+
+        assertThat(consumer.records).isEmpty();
+        assertThat(producerCalled[0]).isFalse();
+    }
+
+    // ---------- snapshot-phase no-op ----------
+
+    @Test
+    public void shouldNotHeartbeatWhileInSnapshot() throws InterruptedException {
+        YBHeartbeatImpl heartbeat = heartbeatWithInterval(Duration.ofMillis(100));
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        heartbeat.heartbeat(partition(), snapshotOffset(), consumer);
+
+        assertThat(consumer.records).isEmpty();
+    }
+
+    @Test
+    public void shouldNotHeartbeatWhileInSnapshot_offsetProducer() throws InterruptedException {
+        YBHeartbeatImpl heartbeat = heartbeatWithInterval(Duration.ofMillis(100));
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        heartbeat.heartbeat(partition(), YBHeartbeatImplTest::snapshotOffset, consumer);
+
+        assertThat(consumer.records).isEmpty();
+    }
+
+    // ---------- isInSnapshot helper ----------
+
+    @Test
+    public void isInSnapshotShouldHandleAllOffsetShapes() {
+        assertThat(YBHeartbeatImpl.isInSnapshot(null)).isFalse();
+        assertThat(YBHeartbeatImpl.isInSnapshot(Collections.emptyMap())).isFalse();
+
+        Map<String, Object> snapshotFalse = new HashMap<>();
+        snapshotFalse.put(AbstractSourceInfo.SNAPSHOT_KEY, Boolean.FALSE);
+        assertThat(YBHeartbeatImpl.isInSnapshot(snapshotFalse)).isFalse();
+
+        // Non-boolean values must not be treated as in-snapshot.
+        Map<String, Object> snapshotString = new HashMap<>();
+        snapshotString.put(AbstractSourceInfo.SNAPSHOT_KEY, "true");
+        assertThat(YBHeartbeatImpl.isInSnapshot(snapshotString)).isFalse();
+
+        Map<String, Object> snapshotTrue = new HashMap<>();
+        snapshotTrue.put(AbstractSourceInfo.SNAPSHOT_KEY, Boolean.TRUE);
+        assertThat(YBHeartbeatImpl.isInSnapshot(snapshotTrue)).isTrue();
+    }
+
+    // ---------- forcedBeat: unchanged in this PR, still works in every phase ----------
+
+    @Test
+    public void forcedBeatShouldEmitDuringStreaming() throws InterruptedException {
+        YBHeartbeatImpl heartbeat = heartbeatWithInterval(Duration.ofMillis(100));
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        heartbeat.forcedBeat(partition(), streamingOffset(), consumer);
+
+        assertThat(consumer.records).hasSize(1);
+        SourceRecord record = consumer.records.get(0);
+        assertThat(record.topic()).isEqualTo(TOPIC);
+        assertThat(record.sourcePartition()).isEqualTo(partition());
+        assertThat(record.sourceOffset()).isEqualTo(streamingOffset());
+    }
+
+    @Test
+    public void forcedBeatShouldEmitDuringSnapshotTransition() throws InterruptedException {
+        // forcedBeat() is what the connector uses during the snapshot-to-streaming
+        // transition wait; the snapshot gate in heartbeat() must not apply here.
+        YBHeartbeatImpl heartbeat = heartbeatWithInterval(Duration.ofMillis(100));
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        heartbeat.forcedBeat(partition(), snapshotOffset(), consumer);
+
+        assertThat(consumer.records).hasSize(1);
+        assertThat(consumer.records.get(0).sourceOffset()).isEqualTo(snapshotOffset());
+    }
+
+    @Test
+    public void forcedBeatShouldStillWorkWithZeroInterval() throws InterruptedException {
+        // Snapshot-to-streaming transition uses forcedBeat() regardless of heartbeat.interval.ms.
+        YBHeartbeatImpl heartbeat = heartbeatWithInterval(Duration.ZERO);
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        heartbeat.forcedBeat(partition(), streamingOffset(), consumer);
+
+        assertThat(consumer.records).hasSize(1);
+    }
+
+    // ---------- streaming-phase delegation reaches the timer-driven path ----------
+
+    // Threads.Timer uses millisecond resolution and {@code expired()} returns {@code elapsed > intervalMs}.
+    // Use a small non-zero interval plus a sleep that comfortably exceeds it so the timer is reliably
+    // expired by the time {@code heartbeat(...)} is called.
+    private static final Duration STREAMING_INTERVAL = Duration.ofMillis(1);
+    private static final long SLEEP_PAST_INTERVAL_MS = 20L;
+
+    @Test
+    public void shouldEmitRecordOnceTimerExpires() throws InterruptedException {
+        YBHeartbeatImpl heartbeat = heartbeatWithInterval(STREAMING_INTERVAL);
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        Thread.sleep(SLEEP_PAST_INTERVAL_MS);
+        heartbeat.heartbeat(partition(), streamingOffset(), consumer);
+
+        assertThat(consumer.records).hasSize(1);
+        assertThat(consumer.records.get(0).topic()).isEqualTo(TOPIC);
+    }
+
+    @Test
+    public void shouldEmitRecordOnceTimerExpires_offsetProducer() throws InterruptedException {
+        YBHeartbeatImpl heartbeat = heartbeatWithInterval(STREAMING_INTERVAL);
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        boolean[] producerCalled = { false };
+        Heartbeat.OffsetProducer producer = () -> {
+            producerCalled[0] = true;
+            return streamingOffset();
+        };
+
+        Thread.sleep(SLEEP_PAST_INTERVAL_MS);
+        heartbeat.heartbeat(partition(), producer, consumer);
+
+        assertThat(producerCalled[0]).isTrue();
+        assertThat(consumer.records).hasSize(1);
+    }
+}


### PR DESCRIPTION
## Problem

The YugabyteDB heartbeat implementation only dispatches heartbeats during the snapshot-to-streaming transition phase via `forcedBeat()`. The regular timer-driven `heartbeat()` method is a no-op, so during the streaming phase neither `heartbeat.interval.ms` nor `heartbeat.action.query` has any effect on YugabyteDB.

## Solution

Extend the YB-specific heartbeat to support upstream behavior during the streaming phase, while keeping snapshot-phase behavior and the snapshot-to-streaming transition behavior unchanged.

- `YBHeartbeatImpl`: `heartbeat(...)` now delegates to the upstream timer-driven path when `heartbeat.interval.ms > 0` and the offset shows snapshot is no longer in effect. `forcedBeat(...)` is unchanged.
- `YBDatabaseHeartbeatImpl` (new): extends `DatabaseHeartbeatImpl` with the same streaming-only gate on `heartbeat(...)`. Inherited `forcedBeat(...)` runs `heartbeat.action.query` on each emitted heartbeat.
- `PostgresConnectorConfig.createHeartbeat`: returns the no-op heartbeat only when neither the transition wait nor streaming heartbeats are needed; picks `YBDatabaseHeartbeatImpl` when an interval and an action query are both configured; falls back to `YBHeartbeatImpl` otherwise.

### Behavior after this change

- Snapshot phase: no change.
- Snapshot-to-streaming transition wait: no change.
- Streaming phase: when `heartbeat.interval.ms > 0`, periodic heartbeat records are produced; when `heartbeat.action.query` is also set, the query runs on each tick.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes heartbeat emission and optional database action-query execution for YugabyteDB, which can affect connector liveness/offset behavior and adds periodic DB load during streaming.
> 
> **Overview**
> Restores upstream heartbeat behavior for YugabyteDB during the *streaming* phase: `YBHeartbeatImpl.heartbeat()` is no longer a no-op and now emits periodic heartbeats when `heartbeat.interval.ms > 0`, while still suppressing heartbeats during snapshot based on the offset’s snapshot flag.
> 
> Adds `YBDatabaseHeartbeatImpl` to support `heartbeat.action.query` for YugabyteDB, and updates `PostgresConnectorConfig.createHeartbeat()` to (a) return NOOP only when neither snapshot-to-streaming transition waiting nor streaming heartbeats are needed, and (b) choose `YBDatabaseHeartbeatImpl` when both an interval and action query are configured (otherwise falling back to `YBHeartbeatImpl`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d8eef6e540897a1172e77c928ea18b14629086d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->