### PR TITLE
[DBZ-PGYB][yugabyte/yugabyte-db#30733] Remove out of band query

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -337,8 +337,6 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         // marks Primary Key columns, so we can avoid an out-of-band DB query.
         // For FULL (all flags=1) and NOTHING (all flags=0) the flags are not useful for
         // distinguishing PK columns, so we query the database.
-        // CHANGE is YugabyteDB-specific: we try flags first but fall back to a DB query
-        // because yboutput may not set the flags for CHANGE identity (YB#22555).
         boolean useFlags = (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.DEFAULT
                 || replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.INDEX
                 || replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.CHANGE);
@@ -379,16 +377,6 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
 
             columns.add(new ColumnMetaData(columnName, postgresType, key, true, false, null, attypmod));
             columnNames.add(columnName);
-        }
-
-        // CHANGE identity fallback: yboutput may not set flags for CHANGE in earlier versions of
-        // YugabyteDB (YB#22555).
-        // If no key columns were found from flags, fall back to DB query.
-        if (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.CHANGE && primaryKeyColumns.isEmpty()) {
-            LOGGER.trace("No key columns from flags for CHANGE identity on '{}.{}', falling back to DB query",
-                    schemaName, tableName);
-            primaryKeyColumns = queryPrimaryKeysFromDatabase(tableId);
-            LOGGER.debug("DB fallback resolved PKs for '{}.{}': {}", schemaName, tableName, primaryKeyColumns);
         }
 
         // Remove any PKs that do not exist as part of this this relation message. This can occur when issuing


### PR DESCRIPTION
## Problem
The PgOutput relation-message handler contained a fallback path that issued an out-of-band DB query whenever CHANGE replica identity yielded no primary-key columns from the relation message flags. This was originally added while testing table rewrite, since older yboutput builds did not set the PK flag for CHANGE identity (YB#22555), leaving Debezium without a key.

The fallback is no longer needed and is in fact undesirable:

The table-rewrite feature is only supported from YugabyteDB 2026.1, and that version already includes the fix for yboutput correctly setting the PK flag for CHANGE replica identity in relation messages.
In any prior version, dropping/altering a primary key is not possible, so the "missing PK on CHANGE" condition that motivated the fallback cannot occur.
The fallback issues a synchronous metadata query inline with relation-message processing, which is undesirable on a hot path that runs frequently.

## Solution
Remove the CHANGE-identity DB fallback from PgOutputMessageDecoder#decodeRelation. The flags byte in the relation message is now the sole source of PK information for DEFAULT, INDEX, and CHANGE replica identities (matching upstream behavior); FULL / NOTHING continue to use the DB-backed lookup as before, and queryPrimaryKeysFromDatabase is retained for that path.

## Test plan
Existing PgOutput relation-message tests continue to pass.