### PR TITLE
[DBZ-PGYB][yugabyte/yugabyte-db#32007] Reject unsupported slot.seek.to.known.offset.on.start property

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
@@ -58,8 +58,19 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
 
     @Override
     public void start(Map<String, String> props) {
+        rejectUnsupportedProperties(Configuration.from(props));
         this.props = props;
         this.connectorConfig = new PostgresConnectorConfig(Configuration.from(props));
+    }
+
+    /**
+     * Fail fast if the configuration contains a property that is no longer supported by the connector.
+     */
+    protected static void rejectUnsupportedProperties(Configuration config) {
+        if (config.hasKey(PostgresConnectorConfig.SLOT_SEEK_TO_KNOWN_OFFSET)) {
+            throw new DebeziumException("Configuration property '" + PostgresConnectorConfig.SLOT_SEEK_TO_KNOWN_OFFSET.name()
+                    + "' is no longer supported. Please remove it from the connector configuration.");
+        }
     }
 
     protected List<Map<String, String>> getTaskConfigsForParallelStreaming(List<String> slotNames,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBConnector.java
@@ -63,14 +63,14 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
         this.connectorConfig = new PostgresConnectorConfig(Configuration.from(props));
     }
 
-    /**
-     * Fail fast if the configuration contains a property that is no longer supported by the connector.
-     */
     protected static void rejectUnsupportedProperties(Configuration config) {
         if (config.hasKey(PostgresConnectorConfig.SLOT_SEEK_TO_KNOWN_OFFSET)) {
-            throw new DebeziumException("Configuration property '" + PostgresConnectorConfig.SLOT_SEEK_TO_KNOWN_OFFSET.name()
-                    + "' is no longer supported. Please remove it from the connector configuration.");
+            throw new DebeziumException(unsupportedPropertyMessage(PostgresConnectorConfig.SLOT_SEEK_TO_KNOWN_OFFSET.name()));
         }
+    }
+
+    private static String unsupportedPropertyMessage(String propertyName) {
+        return "Configuration property '" + propertyName + "' is not supported. Please remove it from the connector configuration.";
     }
 
     protected List<Map<String, String>> getTaskConfigsForParallelStreaming(List<String> slotNames,
@@ -229,6 +229,14 @@ public class YugabyteDBConnector extends RelationalBaseSourceConnector {
 
     @Override
     protected void validateConnection(Map<String, ConfigValue> configValues, Configuration config) {
+        // Reject properties that are not supported before attempting to connect.
+        if (config.hasKey(PostgresConnectorConfig.SLOT_SEEK_TO_KNOWN_OFFSET)) {
+            final String propertyName = PostgresConnectorConfig.SLOT_SEEK_TO_KNOWN_OFFSET.name();
+            configValues.computeIfAbsent(propertyName, ConfigValue::new)
+                    .addErrorMessage(unsupportedPropertyMessage(propertyName));
+            return;
+        }
+
         final ConfigValue databaseValue = configValues.get(RelationalDatabaseConnectorConfig.DATABASE_NAME.name());
         final ConfigValue slotNameValue = configValues.get(PostgresConnectorConfig.SLOT_NAME.name());
         final ConfigValue pluginNameValue = configValues.get(PostgresConnectorConfig.PLUGIN_NAME.name());

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -43,6 +43,7 @@ import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.postgresql.PostgresSchema;
 import io.debezium.connector.postgresql.ReplicaIdentityMapper;
 import io.debezium.connector.postgresql.TypeRegistry;
+import io.debezium.connector.postgresql.YugabyteDBServer;
 import io.debezium.connector.postgresql.spi.SlotCreationResult;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
@@ -494,7 +495,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         int tryCount = 0;
         while (true) {
             try {
-                if (connectorConfig.slotSeekToKnownOffsetOnStart()) {
+                if (!YugabyteDBServer.isEnabled() && connectorConfig.slotSeekToKnownOffsetOnStart()) {
                     validateSlotIsInExpectedState(walPosition);
                 }
                 return createReplicationStream(lsn, walPosition);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBValidateTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBValidateTest.java
@@ -2,10 +2,13 @@ package io.debezium.connector.postgresql;
 
 import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
+import org.apache.kafka.common.config.ConfigValue;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Tests to verify that our validation methods are working fine.
@@ -69,7 +72,7 @@ public class YBValidateTest {
                 () -> YugabyteDBConnector.rejectUnsupportedProperties(config));
 
         assertTrue(ex.getMessage().contains(PostgresConnectorConfig.SLOT_SEEK_TO_KNOWN_OFFSET.name()));
-        assertTrue(ex.getMessage().contains("no longer supported"));
+        assertTrue(ex.getMessage().contains("not supported"));
     }
 
     @Test
@@ -80,5 +83,21 @@ public class YBValidateTest {
 
         assertThrows(DebeziumException.class,
                 () -> YugabyteDBConnector.rejectUnsupportedProperties(config));
+    }
+
+    @Test
+    public void shouldSurfaceUnsupportedPropertyAsValidationError() {
+        Configuration config = Configuration.create()
+                .with(PostgresConnectorConfig.SLOT_SEEK_TO_KNOWN_OFFSET, true)
+                .build();
+        Map<String, ConfigValue> configValues = new HashMap<>();
+
+        // The validate path records an error rather than attempting to connect to the database.
+        new YugabyteDBConnector().validateConnection(configValues, config);
+
+        ConfigValue value = configValues.get(PostgresConnectorConfig.SLOT_SEEK_TO_KNOWN_OFFSET.name());
+        assertNotNull(value);
+        assertFalse(value.errorMessages().isEmpty());
+        assertTrue(value.errorMessages().get(0).contains("not supported"));
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBValidateTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YBValidateTest.java
@@ -1,6 +1,7 @@
 package io.debezium.connector.postgresql;
 
 import io.debezium.DebeziumException;
+import io.debezium.config.Configuration;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -56,5 +57,28 @@ public class YBValidateTest {
         } catch (DebeziumException ex) {
             assertTrue(ex.getMessage().contains("Tablet range starting from hash_code"));
         }
+    }
+
+    @Test
+    public void shouldRejectUnsupportedSlotSeekToKnownOffsetProperty() {
+        Configuration config = Configuration.create()
+                .with(PostgresConnectorConfig.SLOT_SEEK_TO_KNOWN_OFFSET, true)
+                .build();
+
+        DebeziumException ex = assertThrows(DebeziumException.class,
+                () -> YugabyteDBConnector.rejectUnsupportedProperties(config));
+
+        assertTrue(ex.getMessage().contains(PostgresConnectorConfig.SLOT_SEEK_TO_KNOWN_OFFSET.name()));
+        assertTrue(ex.getMessage().contains("no longer supported"));
+    }
+
+    @Test
+    public void shouldRejectUnsupportedSlotSeekToKnownOffsetPropertyEvenWhenFalse() {
+        Configuration config = Configuration.create()
+                .with(PostgresConnectorConfig.SLOT_SEEK_TO_KNOWN_OFFSET, false)
+                .build();
+
+        assertThrows(DebeziumException.class,
+                () -> YugabyteDBConnector.rejectUnsupportedProperties(config));
     }
 }


### PR DESCRIPTION
## Problem

The internal configuration property `slot.seek.to.known.offset.on.start` is not supported by the YugabyteDB connector. When enabled, the connector calls `validateSlotIsInExpectedState()`, which in turn invokes `pg_replication_slot_advance()` to seek the replication slot to the last known offset. This mechanism is not applicable to YugabyteDB's virtual WAL / CDC implementation, and leaving the option available lets users configure a code path that cannot work correctly against YugabyteDB.

Today the connector silently accepts the property and attempts to use it, instead of telling the user it is unsupported.

## Solution

Reject the property explicitly and make the unsupported code path unreachable for YugabyteDB, with defense in depth across the three layers where the option is consumed:

- Start path: `YugabyteDBConnector.start()` now calls a new `rejectUnsupportedProperties()` helper that throws a `DebeziumException` if `slot.seek.to.known.offset.on.start` is present in the configuration (regardless of its value). This transitions the connector to the FAILED state with a clear message and prevents any task from starting. Following existing precedent in the connector, the thrown `DebeziumException` is not subject to the task-level retry logic in `PostgresErrorHandler`, so a configuration that can never succeed is not retried.
- Validate path: `YugabyteDBConnector.validateConnection()` now surfaces the same condition as a per-property validation error (added to the `ConfigValue` map) before any database connection is attempted, so the failure is reported by the Kafka Connect `/validate` REST endpoint before the connector is even created. Both layers share a single `unsupportedPropertyMessage()` helper so the wording stays consistent.
- Runtime path: `PostgresReplicationConnection.startStreaming()` now guards the `validateSlotIsInExpectedState()` call with `!YugabyteDBServer.isEnabled()`, so even if the flag were somehow set, the `pg_replication_slot_advance()` path is skipped entirely when running against YugabyteDB.

The error message reads: `Configuration property 'slot.seek.to.known.offset.on.start' is not supported. Please remove it from the connector configuration.`

## Test Plan

YBValidateTest#shouldRejectUnsupportedSlotSeekToKnownOffsetProperty
YBValidateTest#shouldRejectUnsupportedSlotSeekToKnownOffsetPropertyEvenWhenFalse
YBValidateTest#shouldSurfaceUnsupportedPropertyAsValidationError
