### PR TITLE
[DBZ-PGYB][yugabyte/yugabyte-db#22555] Version-gate primary-key resolution for CHANGE replica identity

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBVersion.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBVersion.java
@@ -13,23 +13,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Represents a YugabyteDB server version and provides comparison helpers that can be used anywhere
- * in the connector to gate behaviour on the connected server version.
- *
- * <p>YugabyteDB advertises its version inside the standard Postgres {@code version()} string, for
- * example {@code "PostgreSQL 15.12-YB-2.31.0.0-b0 on ..."}. The YugabyteDB portion follows one of
- * two release formats:
- * <ul>
- *   <li><b>Stable / year-based</b> ({@code <year>.<minor>.<patch>.<revision>}) e.g. {@code 2024.1.0.0},
- *       {@code 2025.2.3.0}, {@code 2026.1.0.0}. Ordering: {@code 2024.1 < 2024.2 < 2025.1 < 2025.2}.</li>
- *   <li><b>Preview</b> ({@code <major>.<minor>.<patch>.<revision>}) e.g. {@code 2.27.0.0},
- *       {@code 2.29.0.0}, {@code 2.31.0.0}. Ordering: {@code 2.27 < 2.29 < 2.31}.</li>
- * </ul>
- * Any trailing build identifier such as {@code -b0} is ignored.
- *
- * <p>The two formats are never compared against each other for feature gating; instead a caller
- * compares against the threshold that matches the detected format (see
- * {@link #supportsMutablePrimaryKey()}).
+ * A YugabyteDB server version, parsed from the {@code version()} string (e.g.
+ * {@code "PostgreSQL 15.12-YB-2.31.0.0-b0 ..."}). Two release formats exist: stable/year-based
+ * (e.g. {@code 2025.2.3.0}) and preview (e.g. {@code 2.31.0.0}); any trailing build suffix is ignored.
+ * The two formats are never compared against each other — feature gates compare against the threshold
+ * matching the detected format (see {@link #pkInRelationMessage()}).
  *
  * @author Shishir Sharma (ssharma@yugabyte.com)
  */
@@ -37,37 +25,29 @@ public class YugabyteDBVersion implements Comparable<YugabyteDBVersion> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBVersion.class);
 
-    /** Matches the YugabyteDB version token inside a Postgres {@code version()} string, e.g. {@code YB-2.31.0.0-b0}. */
     private static final Pattern YB_TOKEN_PATTERN = Pattern.compile("YB-([^\\s]+)");
 
-    /** Number of numeric components that are parsed and compared (major/year, minor, patch, revision). */
+    /** Number of numeric components parsed and compared (major/year, minor, patch, revision). */
     private static final int COMPONENTS = 4;
 
-    /**
-     * Major values at or above this boundary denote the stable / year-based release line
-     * (e.g. {@code 2024.x}, {@code 2025.x}); anything below denotes the preview line
-     * (e.g. {@code 2.27}, {@code 2.29}, {@code 2.31}).
-     */
+    /** Major component at/above this is the year-based line (2024.x, 2025.x); below it is preview (2.x). */
     private static final int YEAR_FORMAT_MAJOR_BOUNDARY = 2000;
 
     /** Sentinel used when the version cannot be determined or parsed. */
     public static final YugabyteDBVersion UNKNOWN = new YugabyteDBVersion("unknown", null);
 
     /**
-     * First stable / year-based release that supports table rewrite / add-drop primary key / non-PK
-     * tables. From here the RELATION message is the authoritative PK source for {@code CHANGE}; below
-     * it the connector resolves the PK with a DB query (the PK can't change on older versions).
+     * First stable / year-based release that marks the primary key in the RELATION message for
+     * {@code CHANGE} replica identity. At/above it the connector reads the PK from the message; below
+     * it the message omits the PK, so the connector resolves it with a DB query.
      */
-    private static final YugabyteDBVersion MUTABLE_PK_STABLE = parse("2026.1.0.0");
+    private static final YugabyteDBVersion PK_IN_RELATION_MESSAGE_RI_CHANGE_STABLE = parse("2025.2.3.0");
 
-    /**
-     * Preview-line equivalent of {@link #MUTABLE_PK_STABLE}.
-     * TODO(confirm): set to the preview release corresponding to 2026.1 (best guess: 2.31.0.0).
-     */
-    private static final YugabyteDBVersion MUTABLE_PK_PREVIEW = parse("2.31.0.0");
+    /** Preview equivalent of {@link #PK_IN_RELATION_MESSAGE_RI_CHANGE_STABLE}. */
+    private static final YugabyteDBVersion PK_IN_RELATION_MESSAGE_RI_CHANGE_PREVIEW = parse("2.31.0.0");
 
     private final String raw;
-    /** Numeric version components padded to {@link #COMPONENTS}; {@code null} when the version is unknown. */
+    /** Numeric components padded to {@link #COMPONENTS}; {@code null} when unknown. */
     private final int[] components;
 
     private YugabyteDBVersion(String raw, int[] components) {
@@ -75,13 +55,7 @@ public class YugabyteDBVersion implements Comparable<YugabyteDBVersion> {
         this.components = components;
     }
 
-    /**
-     * Extracts and parses the YugabyteDB version from a full Postgres {@code version()} string,
-     * e.g. {@code "PostgreSQL 15.12-YB-2.31.0.0-b0 on ..."}.
-     *
-     * @param fullVersionString the value returned by {@code SELECT version()}; may be {@code null}
-     * @return the parsed version, or {@link #UNKNOWN} if no YugabyteDB token is present
-     */
+    /** Extracts and parses the YB version from a full {@code version()} string; {@link #UNKNOWN} if absent. */
     public static YugabyteDBVersion fromVersionString(String fullVersionString) {
         if (fullVersionString == null) {
             return UNKNOWN;
@@ -94,14 +68,7 @@ public class YugabyteDBVersion implements Comparable<YugabyteDBVersion> {
         return parse(matcher.group(1));
     }
 
-    /**
-     * Parses a bare YugabyteDB version token such as {@code "2.31.0.0-b0"} or {@code "2025.2.3.0"}.
-     * This is the value produced by {@code SELECT substring(version() from 'YB-([^\\s]+)')}. Any
-     * trailing build / pre-release identifier (e.g. {@code -b0}) is ignored.
-     *
-     * @param versionToken the version token; may be {@code null}
-     * @return the parsed version, or {@link #UNKNOWN} if it cannot be parsed
-     */
+    /** Parses a bare version token (e.g. {@code "2.31.0.0-b0"}); trailing build suffix ignored, {@link #UNKNOWN} on failure. */
     public static YugabyteDBVersion parse(String versionToken) {
         if (versionToken == null || versionToken.trim().isEmpty()) {
             return UNKNOWN;
@@ -122,42 +89,31 @@ public class YugabyteDBVersion implements Comparable<YugabyteDBVersion> {
         return new YugabyteDBVersion(versionToken, parsed);
     }
 
-    /**
-     * @return {@code true} if this version was successfully parsed, {@code false} for {@link #UNKNOWN}.
-     */
+    /** @return {@code true} if parsed; {@code false} for {@link #UNKNOWN}. */
     public boolean isKnown() {
         return components != null;
     }
 
-    /**
-     * @return {@code true} if this is a stable / year-based version (e.g. {@code 2024.x},
-     *         {@code 2025.x}); {@code false} for the preview line (e.g. {@code 2.27}, {@code 2.29})
-     *         or when the version is unknown.
-     */
+    /** @return {@code true} for the year-based line (e.g. 2025.x); {@code false} for preview (2.x) or unknown. */
     public boolean isYearBased() {
         return isKnown() && components[0] >= YEAR_FORMAT_MAJOR_BOUNDARY;
     }
 
     /**
-     * Whether this version supports table rewrite / add-drop primary key / non-PK tables (stable
-     * {@code >= 2026.1.0.0}, preview {@code >= 2.31.0.0}). At/above it the connector trusts the
-     * RELATION message for the {@code CHANGE} primary key; below it, or when unknown, it resolves the
-     * PK with a DB query.
+     * Whether this version marks the primary key in the RELATION message for {@code CHANGE} replica
+     * identity (stable {@code >= 2025.2.3.0}, preview {@code >= 2.31.0.0}). At/above it the connector
+     * reads the PK from the message; below it (or when unknown) it resolves the PK with a DB query.
      */
-    public boolean supportsMutablePrimaryKey() {
+    public boolean pkInRelationMessage() {
         if (!isKnown()) {
             return false;
         }
         return isYearBased()
-                ? compareTo(MUTABLE_PK_STABLE) >= 0
-                : compareTo(MUTABLE_PK_PREVIEW) >= 0;
+                ? compareTo(PK_IN_RELATION_MESSAGE_RI_CHANGE_STABLE) >= 0
+                : compareTo(PK_IN_RELATION_MESSAGE_RI_CHANGE_PREVIEW) >= 0;
     }
 
-    /**
-     * Compares two versions component by component. Note that this is a purely numeric comparison,
-     * so a year-based version always sorts above a preview version (e.g. {@code 2025.x > 2.x}); for
-     * feature gating compare against a threshold of the same format instead.
-     */
+    /** Numeric, component-by-component; note a year-based version sorts above a preview one. */
     @Override
     public int compareTo(YugabyteDBVersion otherVersion) {
         // Unknown sorts lowest.

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBVersion.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBVersion.java
@@ -54,11 +54,9 @@ public class YugabyteDBVersion implements Comparable<YugabyteDBVersion> {
     public static final YugabyteDBVersion UNKNOWN = new YugabyteDBVersion("unknown", null);
 
     /**
-     * First stable / year-based release that supports table rewrite / adding &amp; dropping a primary
-     * key / tables without a primary key. From this version the RELATION message is the authoritative
-     * source of PK information for {@code CHANGE} replica identity; below it the connector resolves
-     * the PK with a DB query (PKs are immutable on older versions, so a current-time query is always
-     * point-in-time correct).
+     * First stable / year-based release that supports table rewrite / add-drop primary key / non-PK
+     * tables. From here the RELATION message is the authoritative PK source for {@code CHANGE}; below
+     * it the connector resolves the PK with a DB query (the PK can't change on older versions).
      */
     private static final YugabyteDBVersion MUTABLE_PK_STABLE = parse("2026.1.0.0");
 
@@ -141,19 +139,10 @@ public class YugabyteDBVersion implements Comparable<YugabyteDBVersion> {
     }
 
     /**
-     * Indicates whether this YugabyteDB version supports table rewrite / adding &amp; dropping a
-     * primary key / tables without a primary key (from 2026.1.0.0).
-     *
-     * <p>At/above this version the connector trusts the RELATION message for the {@code CHANGE}
-     * replica-identity primary key (the message reflects the schema at the event's point in time);
-     * below it the connector resolves the PK with a DB query, which is always correct there because
-     * the primary key cannot change.
-     *
-     * <p>Thresholds: stable / year-based {@code >= 2026.1.0.0}; preview {@code >= 2.31.0.0}. An
-     * unknown version is conservatively treated as <em>not</em> supporting it, so the safe DB-query
-     * path is used.
-     *
-     * @return {@code true} if mutable primary keys are supported (RELATION message is authoritative).
+     * Whether this version supports table rewrite / add-drop primary key / non-PK tables (stable
+     * {@code >= 2026.1.0.0}, preview {@code >= 2.31.0.0}). At/above it the connector trusts the
+     * RELATION message for the {@code CHANGE} primary key; below it, or when unknown, it resolves the
+     * PK with a DB query.
      */
     public boolean supportsMutablePrimaryKey() {
         if (!isKnown()) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBVersion.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBVersion.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The two formats are never compared against each other for feature gating; instead a caller
  * compares against the threshold that matches the detected format (see
- * {@link #supportsChangeReplicaIdentityPkInRelation()}).
+ * {@link #supportsMutablePrimaryKey()}).
  *
  * @author Shishir Sharma (ssharma@yugabyte.com)
  */
@@ -54,16 +54,19 @@ public class YugabyteDBVersion implements Comparable<YugabyteDBVersion> {
     public static final YugabyteDBVersion UNKNOWN = new YugabyteDBVersion("unknown", null);
 
     /**
-     * First stable / year-based release that marks primary-key columns in the relation-message flags
-     * for {@code CHANGE} replica identity (yugabyte-db commit {@code 5de43f9c6f8c}).
+     * First stable / year-based release that supports table rewrite / adding &amp; dropping a primary
+     * key / tables without a primary key. From this version the RELATION message is the authoritative
+     * source of PK information for {@code CHANGE} replica identity; below it the connector resolves
+     * the PK with a DB query (PKs are immutable on older versions, so a current-time query is always
+     * point-in-time correct).
      */
-    private static final YugabyteDBVersion CHANGE_PK_FIX_STABLE = parse("2025.2.3.0");
+    private static final YugabyteDBVersion MUTABLE_PK_STABLE = parse("2026.1.0.0");
 
     /**
-     * First preview release that marks primary-key columns in the relation-message flags for
-     * {@code CHANGE} replica identity (yugabyte-db commit {@code 5de43f9c6f8c}).
+     * Preview-line equivalent of {@link #MUTABLE_PK_STABLE}.
+     * TODO(confirm): set to the preview release corresponding to 2026.1 (best guess: 2.31.0.0).
      */
-    private static final YugabyteDBVersion CHANGE_PK_FIX_PREVIEW = parse("2.29.0.0");
+    private static final YugabyteDBVersion MUTABLE_PK_PREVIEW = parse("2.31.0.0");
 
     private final String raw;
     /** Numeric version components padded to {@link #COMPONENTS}; {@code null} when the version is unknown. */
@@ -138,26 +141,27 @@ public class YugabyteDBVersion implements Comparable<YugabyteDBVersion> {
     }
 
     /**
-     * Indicates whether this YugabyteDB version marks primary-key columns in the relation-message
-     * flags byte for {@code CHANGE} replica identity (yugabyte-db commit {@code 5de43f9c6f8c}).
+     * Indicates whether this YugabyteDB version supports table rewrite / adding &amp; dropping a
+     * primary key / tables without a primary key (from 2026.1.0.0).
      *
-     * <p>When this returns {@code false} the pgoutput decoder must fall back to a DB query to
-     * resolve PKs for {@code CHANGE} replica identity, because the flags do not carry the PK on
-     * these older builds (YB#22555).
+     * <p>At/above this version the connector trusts the RELATION message for the {@code CHANGE}
+     * replica-identity primary key (the message reflects the schema at the event's point in time);
+     * below it the connector resolves the PK with a DB query, which is always correct there because
+     * the primary key cannot change.
      *
-     * <p>Thresholds: stable / year-based {@code >= 2025.2.3.0}; preview {@code >= 2.29.0.0}. An
-     * unknown version is conservatively treated as <em>not</em> having the fix, so the safe DB
-     * fallback is preserved.
+     * <p>Thresholds: stable / year-based {@code >= 2026.1.0.0}; preview {@code >= 2.31.0.0}. An
+     * unknown version is conservatively treated as <em>not</em> supporting it, so the safe DB-query
+     * path is used.
      *
-     * @return {@code true} if the flags reliably carry the PK for {@code CHANGE} replica identity.
+     * @return {@code true} if mutable primary keys are supported (RELATION message is authoritative).
      */
-    public boolean supportsChangeReplicaIdentityPkInRelation() {
+    public boolean supportsMutablePrimaryKey() {
         if (!isKnown()) {
             return false;
         }
         return isYearBased()
-                ? compareTo(CHANGE_PK_FIX_STABLE) >= 0
-                : compareTo(CHANGE_PK_FIX_PREVIEW) >= 0;
+                ? compareTo(MUTABLE_PK_STABLE) >= 0
+                : compareTo(MUTABLE_PK_PREVIEW) >= 0;
     }
 
     /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBVersion.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/YugabyteDBVersion.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright YugabyteDB Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Represents a YugabyteDB server version and provides comparison helpers that can be used anywhere
+ * in the connector to gate behaviour on the connected server version.
+ *
+ * <p>YugabyteDB advertises its version inside the standard Postgres {@code version()} string, for
+ * example {@code "PostgreSQL 15.12-YB-2.31.0.0-b0 on ..."}. The YugabyteDB portion follows one of
+ * two release formats:
+ * <ul>
+ *   <li><b>Stable / year-based</b> ({@code <year>.<minor>.<patch>.<revision>}) e.g. {@code 2024.1.0.0},
+ *       {@code 2025.2.3.0}, {@code 2026.1.0.0}. Ordering: {@code 2024.1 < 2024.2 < 2025.1 < 2025.2}.</li>
+ *   <li><b>Preview</b> ({@code <major>.<minor>.<patch>.<revision>}) e.g. {@code 2.27.0.0},
+ *       {@code 2.29.0.0}, {@code 2.31.0.0}. Ordering: {@code 2.27 < 2.29 < 2.31}.</li>
+ * </ul>
+ * Any trailing build identifier such as {@code -b0} is ignored.
+ *
+ * <p>The two formats are never compared against each other for feature gating; instead a caller
+ * compares against the threshold that matches the detected format (see
+ * {@link #supportsChangeReplicaIdentityPkInRelation()}).
+ *
+ * @author Shishir Sharma (ssharma@yugabyte.com)
+ */
+public class YugabyteDBVersion implements Comparable<YugabyteDBVersion> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(YugabyteDBVersion.class);
+
+    /** Matches the YugabyteDB version token inside a Postgres {@code version()} string, e.g. {@code YB-2.31.0.0-b0}. */
+    private static final Pattern YB_TOKEN_PATTERN = Pattern.compile("YB-([^\\s]+)");
+
+    /** Number of numeric components that are parsed and compared (major/year, minor, patch, revision). */
+    private static final int COMPONENTS = 4;
+
+    /**
+     * Major values at or above this boundary denote the stable / year-based release line
+     * (e.g. {@code 2024.x}, {@code 2025.x}); anything below denotes the preview line
+     * (e.g. {@code 2.27}, {@code 2.29}, {@code 2.31}).
+     */
+    private static final int YEAR_FORMAT_MAJOR_BOUNDARY = 2000;
+
+    /** Sentinel used when the version cannot be determined or parsed. */
+    public static final YugabyteDBVersion UNKNOWN = new YugabyteDBVersion("unknown", null);
+
+    /**
+     * First stable / year-based release that marks primary-key columns in the relation-message flags
+     * for {@code CHANGE} replica identity (yugabyte-db commit {@code 5de43f9c6f8c}).
+     */
+    private static final YugabyteDBVersion CHANGE_PK_FIX_STABLE = parse("2025.2.3.0");
+
+    /**
+     * First preview release that marks primary-key columns in the relation-message flags for
+     * {@code CHANGE} replica identity (yugabyte-db commit {@code 5de43f9c6f8c}).
+     */
+    private static final YugabyteDBVersion CHANGE_PK_FIX_PREVIEW = parse("2.29.0.0");
+
+    private final String raw;
+    /** Numeric version components padded to {@link #COMPONENTS}; {@code null} when the version is unknown. */
+    private final int[] components;
+
+    private YugabyteDBVersion(String raw, int[] components) {
+        this.raw = raw;
+        this.components = components;
+    }
+
+    /**
+     * Extracts and parses the YugabyteDB version from a full Postgres {@code version()} string,
+     * e.g. {@code "PostgreSQL 15.12-YB-2.31.0.0-b0 on ..."}.
+     *
+     * @param fullVersionString the value returned by {@code SELECT version()}; may be {@code null}
+     * @return the parsed version, or {@link #UNKNOWN} if no YugabyteDB token is present
+     */
+    public static YugabyteDBVersion fromVersionString(String fullVersionString) {
+        if (fullVersionString == null) {
+            return UNKNOWN;
+        }
+        final Matcher matcher = YB_TOKEN_PATTERN.matcher(fullVersionString);
+        if (!matcher.find()) {
+            LOGGER.warn("Could not find a YugabyteDB version token in '{}'", fullVersionString);
+            return UNKNOWN;
+        }
+        return parse(matcher.group(1));
+    }
+
+    /**
+     * Parses a bare YugabyteDB version token such as {@code "2.31.0.0-b0"} or {@code "2025.2.3.0"}.
+     * This is the value produced by {@code SELECT substring(version() from 'YB-([^\\s]+)')}. Any
+     * trailing build / pre-release identifier (e.g. {@code -b0}) is ignored.
+     *
+     * @param versionToken the version token; may be {@code null}
+     * @return the parsed version, or {@link #UNKNOWN} if it cannot be parsed
+     */
+    public static YugabyteDBVersion parse(String versionToken) {
+        if (versionToken == null || versionToken.trim().isEmpty()) {
+            return UNKNOWN;
+        }
+        // Drop any build / pre-release suffix: "2.31.0.0-b0" -> "2.31.0.0".
+        final String numericPart = versionToken.trim().split("-")[0];
+        final String[] parts = numericPart.split("\\.");
+        final int[] parsed = new int[COMPONENTS];
+        try {
+            for (int i = 0; i < COMPONENTS && i < parts.length; i++) {
+                parsed[i] = Integer.parseInt(parts[i].trim());
+            }
+        }
+        catch (NumberFormatException e) {
+            LOGGER.warn("Could not parse YugabyteDB version token '{}'", versionToken);
+            return UNKNOWN;
+        }
+        return new YugabyteDBVersion(versionToken, parsed);
+    }
+
+    /**
+     * @return {@code true} if this version was successfully parsed, {@code false} for {@link #UNKNOWN}.
+     */
+    public boolean isKnown() {
+        return components != null;
+    }
+
+    /**
+     * @return {@code true} if this is a stable / year-based version (e.g. {@code 2024.x},
+     *         {@code 2025.x}); {@code false} for the preview line (e.g. {@code 2.27}, {@code 2.29})
+     *         or when the version is unknown.
+     */
+    public boolean isYearBased() {
+        return isKnown() && components[0] >= YEAR_FORMAT_MAJOR_BOUNDARY;
+    }
+
+    /**
+     * Indicates whether this YugabyteDB version marks primary-key columns in the relation-message
+     * flags byte for {@code CHANGE} replica identity (yugabyte-db commit {@code 5de43f9c6f8c}).
+     *
+     * <p>When this returns {@code false} the pgoutput decoder must fall back to a DB query to
+     * resolve PKs for {@code CHANGE} replica identity, because the flags do not carry the PK on
+     * these older builds (YB#22555).
+     *
+     * <p>Thresholds: stable / year-based {@code >= 2025.2.3.0}; preview {@code >= 2.29.0.0}. An
+     * unknown version is conservatively treated as <em>not</em> having the fix, so the safe DB
+     * fallback is preserved.
+     *
+     * @return {@code true} if the flags reliably carry the PK for {@code CHANGE} replica identity.
+     */
+    public boolean supportsChangeReplicaIdentityPkInRelation() {
+        if (!isKnown()) {
+            return false;
+        }
+        return isYearBased()
+                ? compareTo(CHANGE_PK_FIX_STABLE) >= 0
+                : compareTo(CHANGE_PK_FIX_PREVIEW) >= 0;
+    }
+
+    /**
+     * Compares two versions component by component. Note that this is a purely numeric comparison,
+     * so a year-based version always sorts above a preview version (e.g. {@code 2025.x > 2.x}); for
+     * feature gating compare against a threshold of the same format instead.
+     */
+    @Override
+    public int compareTo(YugabyteDBVersion otherVersion) {
+        // Unknown sorts lowest.
+        if (!isKnown() || !otherVersion.isKnown()) {
+            return Boolean.compare(isKnown(), otherVersion.isKnown());
+        }
+        for (int i = 0; i < COMPONENTS; i++) {
+            final int cmp = Integer.compare(components[i], otherVersion.components[i]);
+            if (cmp != 0) {
+                return cmp;
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof YugabyteDBVersion)) {
+            return false;
+        }
+        final YugabyteDBVersion otherVersion = (YugabyteDBVersion) o;
+        return Arrays.equals(components, otherVersion.components);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(components);
+    }
+
+    @Override
+    public String toString() {
+        return raw;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoderContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoderContext.java
@@ -18,12 +18,11 @@ public class MessageDecoderContext {
 
     private final PostgresConnectorConfig config;
     private final PostgresSchema schema;
-    private final YugabyteDBVersion yugabyteDBVersion;
+    private volatile YugabyteDBVersion yugabyteDBVersion = YugabyteDBVersion.UNKNOWN;
 
-    public MessageDecoderContext(PostgresConnectorConfig config, PostgresSchema schema, YugabyteDBVersion yugabyteDBVersion) {
+    public MessageDecoderContext(PostgresConnectorConfig config, PostgresSchema schema) {
         this.config = config;
         this.schema = schema;
-        this.yugabyteDBVersion = yugabyteDBVersion;
     }
 
     public PostgresConnectorConfig getConfig() {
@@ -35,12 +34,22 @@ public class MessageDecoderContext {
     }
 
     /**
-     * @return the YugabyteDB server version, resolved once (with retry) when the replication
-     *         connection was created; connector start-up fails earlier if it cannot be determined.
-     *         This is per-connection (hence per-task) state, so connectors targeting different
-     *         clusters in the same JVM each see their own version.
+     * @return the YugabyteDB server version of the node serving the replication stream. It is read
+     *         from the streaming connection itself when streaming starts (and re-read on every
+     *         reconnect), because the relation-message format and {@code version()} move together
+     *         per node — so this stays correct even mid-rolling-upgrade, when the metadata
+     *         connection may be on a different-version node. Defaults to
+     *         {@link YugabyteDBVersion#UNKNOWN} until streaming starts (UNKNOWN keeps the safe
+     *         pgoutput PK fallback enabled).
      */
     public YugabyteDBVersion getYugabyteDBVersion() {
         return yugabyteDBVersion;
+    }
+
+    /**
+     * Sets the YugabyteDB server version once it has been resolved from the streaming connection.
+     */
+    public void setYugabyteDBVersion(YugabyteDBVersion yugabyteDBVersion) {
+        this.yugabyteDBVersion = yugabyteDBVersion;
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoderContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoderContext.java
@@ -7,7 +7,6 @@ package io.debezium.connector.postgresql.connection;
 
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.postgresql.PostgresSchema;
-import io.debezium.connector.postgresql.YugabyteDBVersion;
 
 /**
  * Contextual data required by {@link MessageDecoder}s.
@@ -18,7 +17,6 @@ public class MessageDecoderContext {
 
     private final PostgresConnectorConfig config;
     private final PostgresSchema schema;
-    private volatile YugabyteDBVersion yugabyteDBVersion = YugabyteDBVersion.UNKNOWN;
 
     public MessageDecoderContext(PostgresConnectorConfig config, PostgresSchema schema) {
         this.config = config;
@@ -31,25 +29,5 @@ public class MessageDecoderContext {
 
     public PostgresSchema getSchema() {
         return schema;
-    }
-
-    /**
-     * @return the YugabyteDB server version of the node serving the replication stream. It is read
-     *         from the streaming connection itself when streaming starts (and re-read on every
-     *         reconnect), because the relation-message format and {@code version()} move together
-     *         per node — so this stays correct even mid-rolling-upgrade, when the metadata
-     *         connection may be on a different-version node. Defaults to
-     *         {@link YugabyteDBVersion#UNKNOWN} until streaming starts (UNKNOWN keeps the safe
-     *         pgoutput PK fallback enabled).
-     */
-    public YugabyteDBVersion getYugabyteDBVersion() {
-        return yugabyteDBVersion;
-    }
-
-    /**
-     * Sets the YugabyteDB server version once it has been resolved from the streaming connection.
-     */
-    public void setYugabyteDBVersion(YugabyteDBVersion yugabyteDBVersion) {
-        this.yugabyteDBVersion = yugabyteDBVersion;
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoderContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoderContext.java
@@ -7,6 +7,7 @@ package io.debezium.connector.postgresql.connection;
 
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.postgresql.PostgresSchema;
+import io.debezium.connector.postgresql.YugabyteDBVersion;
 
 /**
  * Contextual data required by {@link MessageDecoder}s.
@@ -17,10 +18,12 @@ public class MessageDecoderContext {
 
     private final PostgresConnectorConfig config;
     private final PostgresSchema schema;
+    private final YugabyteDBVersion yugabyteDBVersion;
 
-    public MessageDecoderContext(PostgresConnectorConfig config, PostgresSchema schema) {
+    public MessageDecoderContext(PostgresConnectorConfig config, PostgresSchema schema, YugabyteDBVersion yugabyteDBVersion) {
         this.config = config;
         this.schema = schema;
+        this.yugabyteDBVersion = yugabyteDBVersion;
     }
 
     public PostgresConnectorConfig getConfig() {
@@ -29,5 +32,15 @@ public class MessageDecoderContext {
 
     public PostgresSchema getSchema() {
         return schema;
+    }
+
+    /**
+     * @return the YugabyteDB server version, resolved once (with retry) when the replication
+     *         connection was created; connector start-up fails earlier if it cannot be determined.
+     *         This is per-connection (hence per-task) state, so connectors targeting different
+     *         clusters in the same JVM each see their own version.
+     */
+    public YugabyteDBVersion getYugabyteDBVersion() {
+        return yugabyteDBVersion;
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -40,6 +40,7 @@ import io.debezium.connector.postgresql.PostgresType;
 import io.debezium.connector.postgresql.PostgresValueConverter;
 import io.debezium.connector.postgresql.TypeRegistry;
 import io.debezium.connector.postgresql.YugabyteDBServer;
+import io.debezium.connector.postgresql.YugabyteDBVersion;
 import io.debezium.connector.postgresql.spi.SlotState;
 import io.debezium.connector.postgresql.transforms.yugabytedb.Pair;
 import io.debezium.data.SpecialValueDecimal;
@@ -95,6 +96,9 @@ public class PostgresConnection extends JdbcConnection {
     private final TypeRegistry typeRegistry;
     private final PostgresDefaultValueConverter defaultValueConverter;
     private final JdbcConfiguration jdbcConfig;
+
+    /** Cached YugabyteDB server version for this connection (resolved once on first access). */
+    private volatile YugabyteDBVersion yugabyteDBVersion;
 
     /**
      * Creates a Postgres connection using the supplied configuration.
@@ -614,6 +618,46 @@ public class PostgresConnection extends JdbcConnection {
                     });
         }
         return serverInfo;
+    }
+
+    /**
+     * Returns the YugabyteDB server version for this connection, resolving it from the database once
+     * and caching it for the lifetime of the connection. Returns {@link YugabyteDBVersion#UNKNOWN} if
+     * it cannot be read (the connector then takes the safe DB-query path for PK resolution).
+     *
+     * @return the {@link YugabyteDBVersion}, never {@code null}
+     */
+    public YugabyteDBVersion getYugabyteDBVersion() {
+        if (yugabyteDBVersion == null) {
+            try {
+                fetchLatestYugabyteDbVersion();
+            }
+            catch (SQLException e) {
+                LOGGER.warn("Could not resolve YugabyteDB version; treating it as UNKNOWN", e);
+                yugabyteDBVersion = YugabyteDBVersion.UNKNOWN;
+            }
+        }
+        return yugabyteDBVersion;
+    }
+
+    /**
+     * Queries the database for the current YugabyteDB version via
+     * {@code SELECT substring(version() from 'YB-([^\s]+)')} and refreshes the cached value. Unlike
+     * {@link #getYugabyteDBVersion()} this always hits the database, so it can be used to re-read the
+     * version should it ever need to be updated at runtime.
+     *
+     * @return the freshly read {@link YugabyteDBVersion}, never {@code null}
+     * @throws SQLException if the query fails
+     */
+    public YugabyteDBVersion fetchLatestYugabyteDbVersion() throws SQLException {
+        final YugabyteDBVersion[] holder = new YugabyteDBVersion[]{ YugabyteDBVersion.UNKNOWN };
+        query("SELECT substring(version() from 'YB-([^\\s]+)')", rs -> {
+            if (rs.next()) {
+                holder[0] = YugabyteDBVersion.parse(rs.getString(1));
+            }
+        });
+        yugabyteDBVersion = holder[0];
+        return yugabyteDBVersion;
     }
 
     public Charset getDatabaseCharset() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -622,7 +622,7 @@ public class PostgresConnection extends JdbcConnection {
 
     /** Reads the cached YugabyteDB version with no retries; the version is normally primed at startup. */
     public YugabyteDBVersion getYugabyteDBVersion() {
-        LOGGER.info("YugabyteDB version: {}", yugabyteDBVersion);
+        LOGGER.debug("YugabyteDB version: {}", yugabyteDBVersion);
         return getYugabyteDBVersion(0);
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -97,7 +97,7 @@ public class PostgresConnection extends JdbcConnection {
     private final PostgresDefaultValueConverter defaultValueConverter;
     private final JdbcConfiguration jdbcConfig;
 
-    /** Cached YugabyteDB server version for this connection (resolved once on first access). */
+    /* Cached YugabyteDB server version for this connection */
     private volatile YugabyteDBVersion yugabyteDBVersion;
 
     /**
@@ -621,11 +621,8 @@ public class PostgresConnection extends JdbcConnection {
     }
 
     /**
-     * Returns the YugabyteDB server version for this connection, resolving it from the database once
-     * and caching it for the lifetime of the connection. Returns {@link YugabyteDBVersion#UNKNOWN} if
-     * it cannot be read (the connector then takes the safe DB-query path for PK resolution).
-     *
-     * @return the {@link YugabyteDBVersion}, never {@code null}
+     * Returns this connection's YugabyteDB version, resolving it from the database once and caching
+     * it. Returns {@link YugabyteDBVersion#UNKNOWN} if it cannot be read.
      */
     public YugabyteDBVersion getYugabyteDBVersion() {
         if (yugabyteDBVersion == null) {
@@ -641,13 +638,8 @@ public class PostgresConnection extends JdbcConnection {
     }
 
     /**
-     * Queries the database for the current YugabyteDB version via
-     * {@code SELECT substring(version() from 'YB-([^\s]+)')} and refreshes the cached value. Unlike
-     * {@link #getYugabyteDBVersion()} this always hits the database, so it can be used to re-read the
-     * version should it ever need to be updated at runtime.
-     *
-     * @return the freshly read {@link YugabyteDBVersion}, never {@code null}
-     * @throws SQLException if the query fails
+     * Queries the database for the current YugabyteDB version and refreshes the cached value. Unlike
+     * {@link #getYugabyteDBVersion()} this always hits the DB, so it can re-read the version later.
      */
     public YugabyteDBVersion fetchLatestYugabyteDbVersion() throws SQLException {
         final YugabyteDBVersion[] holder = new YugabyteDBVersion[]{ YugabyteDBVersion.UNKNOWN };

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -40,7 +40,6 @@ import io.debezium.connector.postgresql.PostgresType;
 import io.debezium.connector.postgresql.PostgresValueConverter;
 import io.debezium.connector.postgresql.TypeRegistry;
 import io.debezium.connector.postgresql.YugabyteDBServer;
-import io.debezium.connector.postgresql.YugabyteDBVersion;
 import io.debezium.connector.postgresql.spi.SlotState;
 import io.debezium.connector.postgresql.transforms.yugabytedb.Pair;
 import io.debezium.data.SpecialValueDecimal;
@@ -615,55 +614,6 @@ public class PostgresConnection extends JdbcConnection {
                     });
         }
         return serverInfo;
-    }
-
-    /**
-     * Reads the YugabyteDB server version from the database via
-     * {@code SELECT substring(version() from 'YB-([^\s]+)')} (which yields the YugabyteDB version
-     * token, e.g. {@code 2.31.0.0-b0}), retrying transient failures up to {@code maxRetries} times.
-     *
-     * <p>The version is required to gate streaming behaviour correctly, so if it cannot be
-     * obtained at connector start — the query keeps failing, the thread is interrupted, or the
-     * server returns no recognizable {@code YB-<version>} token — this throws
-     * {@link DebeziumException} to fail start-up rather than guessing.
-     *
-     * @param maxRetries the maximum number of retries on a {@link SQLException}
-     * @param retryDelay the delay between attempts
-     * @return the resolved {@link YugabyteDBVersion}, never {@link YugabyteDBVersion#UNKNOWN}
-     * @throws DebeziumException if the YugabyteDB version cannot be determined
-     */
-    public YugabyteDBVersion getYugabyteDBVersion(int maxRetries, Duration retryDelay) {
-        final Metronome metronome = Metronome.parker(retryDelay, Clock.SYSTEM);
-        int attempt = 0;
-        while (true) {
-            try {
-                final YugabyteDBVersion[] holder = new YugabyteDBVersion[]{ YugabyteDBVersion.UNKNOWN };
-                query("SELECT substring(version() from 'YB-([^\\s]+)')", rs -> {
-                    if (rs.next()) {
-                        holder[0] = YugabyteDBVersion.parse(rs.getString(1));
-                    }
-                });
-                if (!holder[0].isKnown()) {
-                    throw new DebeziumException("Could not determine the YugabyteDB server version: "
-                            + "version() did not return a recognizable 'YB-<version>' token");
-                }
-                return holder[0];
-            }
-            catch (SQLException ex) {
-                if (++attempt > maxRetries) {
-                    throw new DebeziumException("Could not read the YugabyteDB server version after " + maxRetries + " retries", ex);
-                }
-                LOGGER.warn("Error reading YugabyteDB version; will attempt retry {} of {} after {} seconds. "
-                        + "Exception message: {}", attempt, maxRetries, retryDelay.getSeconds(), ex.getMessage());
-                try {
-                    metronome.pause();
-                }
-                catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                    throw new DebeziumException("Interrupted while reading the YugabyteDB server version", ie);
-                }
-            }
-        }
     }
 
     public Charset getDatabaseCharset() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -93,9 +93,6 @@ public class PostgresConnection extends JdbcConnection {
 
     private static final Duration PAUSE_BETWEEN_REPLICATION_SLOT_RETRIEVAL_ATTEMPTS = Duration.ofSeconds(2);
 
-    /** Gap between attempts when reading the YugabyteDB version; the retry count comes from config. */
-    private static final Duration PAUSE_BETWEEN_YB_VERSION_ATTEMPTS = Duration.ofSeconds(30);
-
     private final TypeRegistry typeRegistry;
     private final PostgresDefaultValueConverter defaultValueConverter;
     private final JdbcConfiguration jdbcConfig;
@@ -623,24 +620,23 @@ public class PostgresConnection extends JdbcConnection {
         return serverInfo;
     }
 
+    /** Reads the cached YugabyteDB version with no retries; the version is normally primed at startup. */
+    public YugabyteDBVersion getYugabyteDBVersion() {
+        return getYugabyteDBVersion(0);
+    }
+
     /**
      * Returns this connection's YugabyteDB version, resolving it from the database once (retrying up to
-     * {@code maxRetries} times) and caching it. Returns {@link YugabyteDBVersion#UNKNOWN} if it cannot
-     * be read.
+     * {@code maxRetries} times) and caching it. Throws a {@link DebeziumException} if it cannot be read;
+     * returns {@link YugabyteDBVersion#UNKNOWN} only when the server reports no YugabyteDB version token.
      */
     public YugabyteDBVersion getYugabyteDBVersion(int maxRetries) {
         if (yugabyteDBVersion == null) {
             try {
                 fetchLatestYugabyteDbVersion(maxRetries);
             }
-            catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                LOGGER.warn("Interrupted while resolving YugabyteDB version; treating it as UNKNOWN", e);
-                yugabyteDBVersion = YugabyteDBVersion.UNKNOWN;
-            }
             catch (SQLException e) {
-                LOGGER.warn("Could not resolve YugabyteDB version after retries; treating it as UNKNOWN", e);
-                yugabyteDBVersion = YugabyteDBVersion.UNKNOWN;
+                throw new DebeziumException("Could not resolve YugabyteDB version", e);
             }
         }
         return yugabyteDBVersion;
@@ -651,8 +647,8 @@ public class PostgresConnection extends JdbcConnection {
      * transient failures up to {@code maxRetries} times. Unlike {@link #getYugabyteDBVersion(int)} this
      * always hits the DB, so it can re-read the version later.
      */
-    public YugabyteDBVersion fetchLatestYugabyteDbVersion(int maxRetries) throws SQLException, InterruptedException {
-        final Metronome metronome = Metronome.parker(PAUSE_BETWEEN_YB_VERSION_ATTEMPTS, Clock.SYSTEM);
+    public YugabyteDBVersion fetchLatestYugabyteDbVersion(int maxRetries) throws SQLException {
+        final Metronome metronome = Metronome.parker(Duration.ofSeconds(30), Clock.SYSTEM);
         int attempt = 0;
         while (true) {
             try {
@@ -669,9 +665,14 @@ public class PostgresConnection extends JdbcConnection {
                 if (++attempt > maxRetries) {
                     throw e;
                 }
-                LOGGER.warn("Error reading YugabyteDB version; retry {} of {} after {} s",
-                        attempt, maxRetries, PAUSE_BETWEEN_YB_VERSION_ATTEMPTS.getSeconds(), e);
-                metronome.pause();
+                LOGGER.warn("Error reading YugabyteDB version; retry {} of {} after 30 s", attempt, maxRetries, e);
+                try {
+                    metronome.pause();
+                }
+                catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw e;
+                }
             }
         }
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -93,6 +93,9 @@ public class PostgresConnection extends JdbcConnection {
 
     private static final Duration PAUSE_BETWEEN_REPLICATION_SLOT_RETRIEVAL_ATTEMPTS = Duration.ofSeconds(2);
 
+    /** Gap between attempts when reading the YugabyteDB version; the retry count comes from config. */
+    private static final Duration PAUSE_BETWEEN_YB_VERSION_ATTEMPTS = Duration.ofSeconds(30);
+
     private final TypeRegistry typeRegistry;
     private final PostgresDefaultValueConverter defaultValueConverter;
     private final JdbcConfiguration jdbcConfig;
@@ -621,16 +624,22 @@ public class PostgresConnection extends JdbcConnection {
     }
 
     /**
-     * Returns this connection's YugabyteDB version, resolving it from the database once and caching
-     * it. Returns {@link YugabyteDBVersion#UNKNOWN} if it cannot be read.
+     * Returns this connection's YugabyteDB version, resolving it from the database once (retrying up to
+     * {@code maxRetries} times) and caching it. Returns {@link YugabyteDBVersion#UNKNOWN} if it cannot
+     * be read.
      */
-    public YugabyteDBVersion getYugabyteDBVersion() {
+    public YugabyteDBVersion getYugabyteDBVersion(int maxRetries) {
         if (yugabyteDBVersion == null) {
             try {
-                fetchLatestYugabyteDbVersion();
+                fetchLatestYugabyteDbVersion(maxRetries);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                LOGGER.warn("Interrupted while resolving YugabyteDB version; treating it as UNKNOWN", e);
+                yugabyteDBVersion = YugabyteDBVersion.UNKNOWN;
             }
             catch (SQLException e) {
-                LOGGER.warn("Could not resolve YugabyteDB version; treating it as UNKNOWN", e);
+                LOGGER.warn("Could not resolve YugabyteDB version after retries; treating it as UNKNOWN", e);
                 yugabyteDBVersion = YugabyteDBVersion.UNKNOWN;
             }
         }
@@ -638,18 +647,33 @@ public class PostgresConnection extends JdbcConnection {
     }
 
     /**
-     * Queries the database for the current YugabyteDB version and refreshes the cached value. Unlike
-     * {@link #getYugabyteDBVersion()} this always hits the DB, so it can re-read the version later.
+     * Queries the database for the current YugabyteDB version and refreshes the cached value, retrying
+     * transient failures up to {@code maxRetries} times. Unlike {@link #getYugabyteDBVersion(int)} this
+     * always hits the DB, so it can re-read the version later.
      */
-    public YugabyteDBVersion fetchLatestYugabyteDbVersion() throws SQLException {
-        final YugabyteDBVersion[] holder = new YugabyteDBVersion[]{ YugabyteDBVersion.UNKNOWN };
-        query("SELECT substring(version() from 'YB-([^\\s]+)')", rs -> {
-            if (rs.next()) {
-                holder[0] = YugabyteDBVersion.parse(rs.getString(1));
+    public YugabyteDBVersion fetchLatestYugabyteDbVersion(int maxRetries) throws SQLException, InterruptedException {
+        final Metronome metronome = Metronome.parker(PAUSE_BETWEEN_YB_VERSION_ATTEMPTS, Clock.SYSTEM);
+        int attempt = 0;
+        while (true) {
+            try {
+                final YugabyteDBVersion[] holder = new YugabyteDBVersion[]{ YugabyteDBVersion.UNKNOWN };
+                query("SELECT substring(version() from 'YB-([^\\s]+)')", rs -> {
+                    if (rs.next()) {
+                        holder[0] = YugabyteDBVersion.parse(rs.getString(1));
+                    }
+                });
+                yugabyteDBVersion = holder[0];
+                return yugabyteDBVersion;
             }
-        });
-        yugabyteDBVersion = holder[0];
-        return yugabyteDBVersion;
+            catch (SQLException e) {
+                if (++attempt > maxRetries) {
+                    throw e;
+                }
+                LOGGER.warn("Error reading YugabyteDB version; retry {} of {} after {} s",
+                        attempt, maxRetries, PAUSE_BETWEEN_YB_VERSION_ATTEMPTS.getSeconds(), e);
+                metronome.pause();
+            }
+        }
     }
 
     public Charset getDatabaseCharset() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -40,6 +40,7 @@ import io.debezium.connector.postgresql.PostgresType;
 import io.debezium.connector.postgresql.PostgresValueConverter;
 import io.debezium.connector.postgresql.TypeRegistry;
 import io.debezium.connector.postgresql.YugabyteDBServer;
+import io.debezium.connector.postgresql.YugabyteDBVersion;
 import io.debezium.connector.postgresql.spi.SlotState;
 import io.debezium.connector.postgresql.transforms.yugabytedb.Pair;
 import io.debezium.data.SpecialValueDecimal;
@@ -614,6 +615,55 @@ public class PostgresConnection extends JdbcConnection {
                     });
         }
         return serverInfo;
+    }
+
+    /**
+     * Reads the YugabyteDB server version from the database via
+     * {@code SELECT substring(version() from 'YB-([^\s]+)')} (which yields the YugabyteDB version
+     * token, e.g. {@code 2.31.0.0-b0}), retrying transient failures up to {@code maxRetries} times.
+     *
+     * <p>The version is required to gate streaming behaviour correctly, so if it cannot be
+     * obtained at connector start — the query keeps failing, the thread is interrupted, or the
+     * server returns no recognizable {@code YB-<version>} token — this throws
+     * {@link DebeziumException} to fail start-up rather than guessing.
+     *
+     * @param maxRetries the maximum number of retries on a {@link SQLException}
+     * @param retryDelay the delay between attempts
+     * @return the resolved {@link YugabyteDBVersion}, never {@link YugabyteDBVersion#UNKNOWN}
+     * @throws DebeziumException if the YugabyteDB version cannot be determined
+     */
+    public YugabyteDBVersion getYugabyteDBVersion(int maxRetries, Duration retryDelay) {
+        final Metronome metronome = Metronome.parker(retryDelay, Clock.SYSTEM);
+        int attempt = 0;
+        while (true) {
+            try {
+                final YugabyteDBVersion[] holder = new YugabyteDBVersion[]{ YugabyteDBVersion.UNKNOWN };
+                query("SELECT substring(version() from 'YB-([^\\s]+)')", rs -> {
+                    if (rs.next()) {
+                        holder[0] = YugabyteDBVersion.parse(rs.getString(1));
+                    }
+                });
+                if (!holder[0].isKnown()) {
+                    throw new DebeziumException("Could not determine the YugabyteDB server version: "
+                            + "version() did not return a recognizable 'YB-<version>' token");
+                }
+                return holder[0];
+            }
+            catch (SQLException ex) {
+                if (++attempt > maxRetries) {
+                    throw new DebeziumException("Could not read the YugabyteDB server version after " + maxRetries + " retries", ex);
+                }
+                LOGGER.warn("Error reading YugabyteDB version; will attempt retry {} of {} after {} seconds. "
+                        + "Exception message: {}", attempt, maxRetries, retryDelay.getSeconds(), ex.getMessage());
+                try {
+                    metronome.pause();
+                }
+                catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new DebeziumException("Interrupted while reading the YugabyteDB server version", ie);
+                }
+            }
+        }
     }
 
     public Charset getDatabaseCharset() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -635,8 +635,6 @@ public class PostgresConnection extends JdbcConnection {
         if (yugabyteDBVersion == null) {
             try {
                 fetchLatestYugabyteDbVersion(maxRetries);
-                // TODO: REMOVE this shishir
-                LOGGER.info("Resolved YugabyteDB version: {}", yugabyteDBVersion);
             }
             catch (SQLException e) {
                 throw new DebeziumException("Could not resolve YugabyteDB version", e);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -622,6 +622,7 @@ public class PostgresConnection extends JdbcConnection {
 
     /** Reads the cached YugabyteDB version with no retries; the version is normally primed at startup. */
     public YugabyteDBVersion getYugabyteDBVersion() {
+        LOGGER.info("YugabyteDB version: {}", yugabyteDBVersion);
         return getYugabyteDBVersion(0);
     }
 
@@ -634,6 +635,8 @@ public class PostgresConnection extends JdbcConnection {
         if (yugabyteDBVersion == null) {
             try {
                 fetchLatestYugabyteDbVersion(maxRetries);
+                // TODO: REMOVE this shishir
+                LOGGER.info("Resolved YugabyteDB version: {}", yugabyteDBVersion);
             }
             catch (SQLException e) {
                 throw new DebeziumException("Could not resolve YugabyteDB version", e);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -129,7 +129,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         this.messageDecoder = plugin.messageDecoder(new MessageDecoderContext(config, schema), jdbcConnection);
         this.jdbcConnection = jdbcConnection;
         // Resolve the YugabyteDB version once, up front, when the replication connection is created
-        LOGGER.info("Detected YugabyteDB version: {}", jdbcConnection.getYugabyteDBVersion());
+        LOGGER.info("Detected YugabyteDB version: {}", jdbcConnection.getYugabyteDBVersion(connectorConfig.maxRetries()));
         this.typeRegistry = typeRegistry;
         this.streamParams = streamParams;
         this.slotCreationInfo = null;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -44,6 +44,7 @@ import io.debezium.connector.postgresql.PostgresSchema;
 import io.debezium.connector.postgresql.ReplicaIdentityMapper;
 import io.debezium.connector.postgresql.TypeRegistry;
 import io.debezium.connector.postgresql.YugabyteDBServer;
+import io.debezium.connector.postgresql.YugabyteDBVersion;
 import io.debezium.connector.postgresql.spi.SlotCreationResult;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
@@ -126,7 +127,12 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         this.plugin = plugin;
         this.dropSlotOnClose = dropSlotOnClose;
         this.statusUpdateInterval = statusUpdateInterval;
-        this.messageDecoder = plugin.messageDecoder(new MessageDecoderContext(config, schema), jdbcConnection);
+        // Resolve the YugabyteDB server version once (with retry) for this per-task connection and
+        // hand it to the decoder context, so the decoder can gate version-specific behaviour without
+        // an out-of-band query on the streaming hot path.
+        final YugabyteDBVersion yugabyteDBVersion = jdbcConnection.getYugabyteDBVersion(config.maxRetries(), config.retryDelay());
+        LOGGER.info("Detected YugabyteDB version: {}", yugabyteDBVersion);
+        this.messageDecoder = plugin.messageDecoder(new MessageDecoderContext(config, schema, yugabyteDBVersion), jdbcConnection);
         this.jdbcConnection = jdbcConnection;
         this.typeRegistry = typeRegistry;
         this.streamParams = streamParams;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -44,7 +44,6 @@ import io.debezium.connector.postgresql.PostgresSchema;
 import io.debezium.connector.postgresql.ReplicaIdentityMapper;
 import io.debezium.connector.postgresql.TypeRegistry;
 import io.debezium.connector.postgresql.YugabyteDBServer;
-import io.debezium.connector.postgresql.YugabyteDBVersion;
 import io.debezium.connector.postgresql.spi.SlotCreationResult;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
@@ -77,7 +76,6 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     private final PostgresConnectorConfig connectorConfig;
     private final Duration statusUpdateInterval;
     private final MessageDecoder messageDecoder;
-    private final MessageDecoderContext messageDecoderContext;
     private final PostgresConnection jdbcConnection;
     private final TypeRegistry typeRegistry;
     private final Properties streamParams;
@@ -128,12 +126,12 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         this.plugin = plugin;
         this.dropSlotOnClose = dropSlotOnClose;
         this.statusUpdateInterval = statusUpdateInterval;
-        // The YugabyteDB version is resolved later from the streaming connection (see startStreaming),
-        // not here: the relation-message format is decided by the node serving the stream, which may
-        // differ from the metadata connection's node during a rolling upgrade.
-        this.messageDecoderContext = new MessageDecoderContext(config, schema);
-        this.messageDecoder = plugin.messageDecoder(messageDecoderContext, jdbcConnection);
+        this.messageDecoder = plugin.messageDecoder(new MessageDecoderContext(config, schema), jdbcConnection);
         this.jdbcConnection = jdbcConnection;
+        // Resolve the YugabyteDB version once, up front, when the replication connection is created.
+        // Option 1 requires the connector not to run across the 2026.1 upgrade boundary, so this value
+        // is stable for the connector run; the pgoutput decoder reads it back via this same connection.
+        LOGGER.info("Detected YugabyteDB version: {}", jdbcConnection.getYugabyteDBVersion());
         this.typeRegistry = typeRegistry;
         this.streamParams = streamParams;
         this.slotCreationInfo = null;
@@ -481,14 +479,6 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
         connect();
 
-        // Resolve the YugabyteDB version from the node actually serving this replication stream (this
-        // connection), not the metadata connection — which may be a different-version node during a
-        // rolling upgrade. version() and the relation-message PK-for-CHANGE format move together per
-        // node, so this is the authoritative signal for the decoder's CHANGE PK gate. Re-resolved on
-        // every reconnect, so it tracks the node currently serving the stream.
-        messageDecoderContext.setYugabyteDBVersion(resolveStreamingNodeVersion());
-        LOGGER.info("Detected YugabyteDB version on streaming node: {}", messageDecoderContext.getYugabyteDBVersion());
-
         if (connectorConfig.isYSQLMajorUpgrade()) {
             try (Statement stmt = pgConnection().createStatement()) {
                 LOGGER.info("Setting yb_ignore_read_time_in_walsender for walsender session");
@@ -736,45 +726,6 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         }
         catch (SQLException ex) {
             throw new ConnectException("Unable to parse create_replication_slot response", ex);
-        }
-    }
-
-    /**
-     * Reads the YugabyteDB version from the node serving this replication stream (this connection
-     * itself, not the metadata connection), retrying transient failures with the connector's
-     * configured slot retry settings. Because the relation-message PK-for-CHANGE format is produced
-     * by this node and moves together with its {@code version()}, this is the authoritative signal
-     * for the decoder's CHANGE PK gate. Throws {@link DebeziumException} if the version cannot be
-     * determined, to fail rather than gate on a guess.
-     */
-    private YugabyteDBVersion resolveStreamingNodeVersion() throws InterruptedException {
-        final int maxRetries = connectorConfig.maxRetries();
-        final Duration retryDelay = connectorConfig.retryDelay();
-        final Metronome metronome = Metronome.parker(retryDelay, Clock.SYSTEM);
-        int attempt = 0;
-        while (true) {
-            try {
-                final YugabyteDBVersion[] holder = new YugabyteDBVersion[]{ YugabyteDBVersion.UNKNOWN };
-                query("SELECT substring(version() from 'YB-([^\\s]+)')", rs -> {
-                    if (rs.next()) {
-                        holder[0] = YugabyteDBVersion.parse(rs.getString(1));
-                    }
-                });
-                if (!holder[0].isKnown()) {
-                    throw new DebeziumException("Could not determine the YugabyteDB server version from the "
-                            + "streaming connection: version() did not return a recognizable 'YB-<version>' token");
-                }
-                return holder[0];
-            }
-            catch (SQLException ex) {
-                if (++attempt > maxRetries) {
-                    throw new DebeziumException("Could not read the YugabyteDB server version from the streaming "
-                            + "connection after " + maxRetries + " retries", ex);
-                }
-                LOGGER.warn("Error reading YugabyteDB version from streaming connection; will attempt retry {} of {} "
-                        + "after {} seconds. Exception message: {}", attempt, maxRetries, retryDelay.getSeconds(), ex.getMessage());
-                metronome.pause();
-            }
         }
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -77,6 +77,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     private final PostgresConnectorConfig connectorConfig;
     private final Duration statusUpdateInterval;
     private final MessageDecoder messageDecoder;
+    private final MessageDecoderContext messageDecoderContext;
     private final PostgresConnection jdbcConnection;
     private final TypeRegistry typeRegistry;
     private final Properties streamParams;
@@ -127,12 +128,11 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         this.plugin = plugin;
         this.dropSlotOnClose = dropSlotOnClose;
         this.statusUpdateInterval = statusUpdateInterval;
-        // Resolve the YugabyteDB server version once (with retry) for this per-task connection and
-        // hand it to the decoder context, so the decoder can gate version-specific behaviour without
-        // an out-of-band query on the streaming hot path.
-        final YugabyteDBVersion yugabyteDBVersion = jdbcConnection.getYugabyteDBVersion(config.maxRetries(), config.retryDelay());
-        LOGGER.info("Detected YugabyteDB version: {}", yugabyteDBVersion);
-        this.messageDecoder = plugin.messageDecoder(new MessageDecoderContext(config, schema, yugabyteDBVersion), jdbcConnection);
+        // The YugabyteDB version is resolved later from the streaming connection (see startStreaming),
+        // not here: the relation-message format is decided by the node serving the stream, which may
+        // differ from the metadata connection's node during a rolling upgrade.
+        this.messageDecoderContext = new MessageDecoderContext(config, schema);
+        this.messageDecoder = plugin.messageDecoder(messageDecoderContext, jdbcConnection);
         this.jdbcConnection = jdbcConnection;
         this.typeRegistry = typeRegistry;
         this.streamParams = streamParams;
@@ -481,6 +481,14 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
         connect();
 
+        // Resolve the YugabyteDB version from the node actually serving this replication stream (this
+        // connection), not the metadata connection — which may be a different-version node during a
+        // rolling upgrade. version() and the relation-message PK-for-CHANGE format move together per
+        // node, so this is the authoritative signal for the decoder's CHANGE PK gate. Re-resolved on
+        // every reconnect, so it tracks the node currently serving the stream.
+        messageDecoderContext.setYugabyteDBVersion(resolveStreamingNodeVersion());
+        LOGGER.info("Detected YugabyteDB version on streaming node: {}", messageDecoderContext.getYugabyteDBVersion());
+
         if (connectorConfig.isYSQLMajorUpgrade()) {
             try (Statement stmt = pgConnection().createStatement()) {
                 LOGGER.info("Setting yb_ignore_read_time_in_walsender for walsender session");
@@ -728,6 +736,45 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         }
         catch (SQLException ex) {
             throw new ConnectException("Unable to parse create_replication_slot response", ex);
+        }
+    }
+
+    /**
+     * Reads the YugabyteDB version from the node serving this replication stream (this connection
+     * itself, not the metadata connection), retrying transient failures with the connector's
+     * configured slot retry settings. Because the relation-message PK-for-CHANGE format is produced
+     * by this node and moves together with its {@code version()}, this is the authoritative signal
+     * for the decoder's CHANGE PK gate. Throws {@link DebeziumException} if the version cannot be
+     * determined, to fail rather than gate on a guess.
+     */
+    private YugabyteDBVersion resolveStreamingNodeVersion() throws InterruptedException {
+        final int maxRetries = connectorConfig.maxRetries();
+        final Duration retryDelay = connectorConfig.retryDelay();
+        final Metronome metronome = Metronome.parker(retryDelay, Clock.SYSTEM);
+        int attempt = 0;
+        while (true) {
+            try {
+                final YugabyteDBVersion[] holder = new YugabyteDBVersion[]{ YugabyteDBVersion.UNKNOWN };
+                query("SELECT substring(version() from 'YB-([^\\s]+)')", rs -> {
+                    if (rs.next()) {
+                        holder[0] = YugabyteDBVersion.parse(rs.getString(1));
+                    }
+                });
+                if (!holder[0].isKnown()) {
+                    throw new DebeziumException("Could not determine the YugabyteDB server version from the "
+                            + "streaming connection: version() did not return a recognizable 'YB-<version>' token");
+                }
+                return holder[0];
+            }
+            catch (SQLException ex) {
+                if (++attempt > maxRetries) {
+                    throw new DebeziumException("Could not read the YugabyteDB server version from the streaming "
+                            + "connection after " + maxRetries + " retries", ex);
+                }
+                LOGGER.warn("Error reading YugabyteDB version from streaming connection; will attempt retry {} of {} "
+                        + "after {} seconds. Exception message: {}", attempt, maxRetries, retryDelay.getSeconds(), ex.getMessage());
+                metronome.pause();
+            }
         }
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -128,9 +128,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         this.statusUpdateInterval = statusUpdateInterval;
         this.messageDecoder = plugin.messageDecoder(new MessageDecoderContext(config, schema), jdbcConnection);
         this.jdbcConnection = jdbcConnection;
-        // Resolve the YugabyteDB version once, up front, when the replication connection is created.
-        // Option 1 requires the connector not to run across the 2026.1 upgrade boundary, so this value
-        // is stable for the connector run; the pgoutput decoder reads it back via this same connection.
+        // Resolve the YugabyteDB version once, up front, when the replication connection is created
         LOGGER.info("Detected YugabyteDB version: {}", jdbcConnection.getYugabyteDBVersion());
         this.typeRegistry = typeRegistry;
         this.streamParams = streamParams;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -339,7 +339,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         // we query the database.
         // CHANGE is YugabyteDB-specific: from 2025.2.3 the RELATION message carries the PK for CHANGE,
         // so we trust the flags, on older versions it doesn't, so we resolve the PK with a DB query.
-        final boolean findPkFromRelationMessage = connection.getYugabyteDBVersion(decoderContext.getConfig().maxRetries()).pkInRelationMessage();
+        final boolean findPkFromRelationMessage = connection.getYugabyteDBVersion().pkInRelationMessage();
         boolean useFlags = (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.DEFAULT
                 || replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.INDEX
                 || (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.CHANGE && findPkFromRelationMessage));

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -333,15 +333,17 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         final TableId tableId = new TableId(null, schemaName, tableName);
         final ReplicaIdentityInfo.ReplicaIdentity replicaIdentity = parseReplicaIdentity(replicaIdentityId);
 
-        // For DEFAULT, INDEX, and CHANGE identities the relation message flags byte reliably
-        // marks Primary Key columns, so we can avoid an out-of-band DB query.
-        // For FULL (all flags=1) and NOTHING (all flags=0) the flags are not useful for
-        // distinguishing PK columns, so we query the database.
-        // CHANGE is YugabyteDB-specific: older builds may not set the PK flags (YB#22555), so when
-        // the flags yield no PK we fall back to a DB query below, gated on the server version.
+        // For DEFAULT and INDEX the relation message flags byte reliably marks Primary Key columns,
+        // so we resolve the PK from the message and avoid an out-of-band DB query.
+        // For FULL (all flags=1) and NOTHING (all flags=0) the flags can't distinguish PK columns, so
+        // we query the database.
+        // CHANGE is YugabyteDB-specific: from 2026.1 (table rewrite / add-drop PK / non-PK tables) the
+        // RELATION message is the authoritative PK source, so we trust the flags; on older versions
+        // the PK is immutable, so we resolve it with a point-in-time-correct DB query instead.
+        final boolean changePkFromRelation = connection.getYugabyteDBVersion().supportsMutablePrimaryKey();
         boolean useFlags = (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.DEFAULT
                 || replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.INDEX
-                || replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.CHANGE);
+                || (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.CHANGE && changePkFromRelation));
 
         List<String> primaryKeyColumns;
         if (useFlags) {
@@ -379,20 +381,6 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
 
             columns.add(new ColumnMetaData(columnName, postgresType, key, true, false, null, attypmod));
             columnNames.add(columnName);
-        }
-
-        // CHANGE identity is YugabyteDB-specific. Older YugabyteDB builds do not mark the primary-key
-        // columns in the relation-message flags for CHANGE replica identity (YB#22555, fixed by
-        // yugabyte-db commit 5de43f9c6f8c), so the flags yield no PK and we must fall back to a DB
-        // query to avoid emitting a null Kafka key. Versions that contain the fix mark the PK in the
-        // flags, so the fallback is skipped to avoid an out-of-band query on this hot path.
-        if (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.CHANGE
-                && primaryKeyColumns.isEmpty()
-                && !decoderContext.getYugabyteDBVersion().supportsChangeReplicaIdentityPkInRelation()) {
-            LOGGER.debug("No key columns from flags for CHANGE identity on '{}.{}' and server version predates "
-                    + "the PK-in-relation fix; falling back to DB query", schemaName, tableName);
-            primaryKeyColumns = queryPrimaryKeysFromDatabase(tableId);
-            LOGGER.debug("DB fallback resolved PKs for '{}.{}': {}", schemaName, tableName, primaryKeyColumns);
         }
 
         // Remove any PKs that do not exist as part of this this relation message. This can occur when issuing

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -338,8 +338,8 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         // For FULL (all flags=1) and NOTHING (all flags=0) the flags can't distinguish PK columns, so
         // we query the database.
         // CHANGE is YugabyteDB-specific: from 2025.2.3 the RELATION message carries the PK for CHANGE,
-        // so we trust the flags; on older versions it doesn't, so we resolve the PK with a DB query.
-        final boolean findPkFromRelationMessage = connection.getYugabyteDBVersion().pkInRelationMessage();
+        // so we trust the flags, on older versions it doesn't, so we resolve the PK with a DB query.
+        final boolean findPkFromRelationMessage = connection.getYugabyteDBVersion(decoderContext.getConfig().maxRetries()).pkInRelationMessage();
         boolean useFlags = (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.DEFAULT
                 || replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.INDEX
                 || (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.CHANGE && findPkFromRelationMessage));

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -337,10 +337,9 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         // so we resolve the PK from the message and avoid an out-of-band DB query.
         // For FULL (all flags=1) and NOTHING (all flags=0) the flags can't distinguish PK columns, so
         // we query the database.
-        // CHANGE is YugabyteDB-specific: from 2026.1 (table rewrite / add-drop PK / non-PK tables) the
-        // RELATION message is the authoritative PK source, so we trust the flags; on older versions
-        // the PK can't change, so we resolve it with a DB query instead.
-        final boolean findPkFromRelationMessage = connection.getYugabyteDBVersion().supportsMutablePrimaryKey();
+        // CHANGE is YugabyteDB-specific: from 2025.2.3 the RELATION message carries the PK for CHANGE,
+        // so we trust the flags; on older versions it doesn't, so we resolve the PK with a DB query.
+        final boolean findPkFromRelationMessage = connection.getYugabyteDBVersion().pkInRelationMessage();
         boolean useFlags = (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.DEFAULT
                 || replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.INDEX
                 || (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.CHANGE && findPkFromRelationMessage));

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -346,13 +346,11 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
 
         List<String> primaryKeyColumns;
         if (useFlags) {
-            // TODO: Change back to debug
-            LOGGER.info("Using relation message flags to resolve PKs for '{}.{}'", schemaName, tableName);
+            LOGGER.debug("Using relation message flags to resolve PKs for '{}.{}'", schemaName, tableName);
             primaryKeyColumns = new ArrayList<>();
         }
         else {
-            // TODO: Change back to debug
-            LOGGER.info("Using DB metadata query to resolve PKs for '{}.{}' (replicaIdentity={})",
+            LOGGER.debug("Using DB metadata query to resolve PKs for '{}.{}' (replicaIdentity={})",
                     schemaName, tableName, replicaIdentity);
             primaryKeyColumns = queryPrimaryKeysFromDatabase(tableId);
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -346,11 +346,13 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
 
         List<String> primaryKeyColumns;
         if (useFlags) {
-            LOGGER.debug("Using relation message flags to resolve PKs for '{}.{}'", schemaName, tableName);
+            // TODO: Change back to debug
+            LOGGER.info("Using relation message flags to resolve PKs for '{}.{}'", schemaName, tableName);
             primaryKeyColumns = new ArrayList<>();
         }
         else {
-            LOGGER.debug("Using DB metadata query to resolve PKs for '{}.{}' (replicaIdentity={})",
+            // TODO: Change back to debug
+            LOGGER.info("Using DB metadata query to resolve PKs for '{}.{}' (replicaIdentity={})",
                     schemaName, tableName, replicaIdentity);
             primaryKeyColumns = queryPrimaryKeysFromDatabase(tableId);
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -339,11 +339,11 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         // we query the database.
         // CHANGE is YugabyteDB-specific: from 2026.1 (table rewrite / add-drop PK / non-PK tables) the
         // RELATION message is the authoritative PK source, so we trust the flags; on older versions
-        // the PK is immutable, so we resolve it with a point-in-time-correct DB query instead.
-        final boolean changePkFromRelation = connection.getYugabyteDBVersion().supportsMutablePrimaryKey();
+        // the PK can't change, so we resolve it with a DB query instead.
+        final boolean findPkFromRelationMessage = connection.getYugabyteDBVersion().supportsMutablePrimaryKey();
         boolean useFlags = (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.DEFAULT
                 || replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.INDEX
-                || (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.CHANGE && changePkFromRelation));
+                || (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.CHANGE && findPkFromRelationMessage));
 
         List<String> primaryKeyColumns;
         if (useFlags) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -337,6 +337,8 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         // marks Primary Key columns, so we can avoid an out-of-band DB query.
         // For FULL (all flags=1) and NOTHING (all flags=0) the flags are not useful for
         // distinguishing PK columns, so we query the database.
+        // CHANGE is YugabyteDB-specific: older builds may not set the PK flags (YB#22555), so when
+        // the flags yield no PK we fall back to a DB query below, gated on the server version.
         boolean useFlags = (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.DEFAULT
                 || replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.INDEX
                 || replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.CHANGE);
@@ -377,6 +379,20 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
 
             columns.add(new ColumnMetaData(columnName, postgresType, key, true, false, null, attypmod));
             columnNames.add(columnName);
+        }
+
+        // CHANGE identity is YugabyteDB-specific. Older YugabyteDB builds do not mark the primary-key
+        // columns in the relation-message flags for CHANGE replica identity (YB#22555, fixed by
+        // yugabyte-db commit 5de43f9c6f8c), so the flags yield no PK and we must fall back to a DB
+        // query to avoid emitting a null Kafka key. Versions that contain the fix mark the PK in the
+        // flags, so the fallback is skipped to avoid an out-of-band query on this hot path.
+        if (replicaIdentity == ReplicaIdentityInfo.ReplicaIdentity.CHANGE
+                && primaryKeyColumns.isEmpty()
+                && !decoderContext.getYugabyteDBVersion().supportsChangeReplicaIdentityPkInRelation()) {
+            LOGGER.debug("No key columns from flags for CHANGE identity on '{}.{}' and server version predates "
+                    + "the PK-in-relation fix; falling back to DB query", schemaName, tableName);
+            primaryKeyColumns = queryPrimaryKeysFromDatabase(tableId);
+            LOGGER.debug("DB fallback resolved PKs for '{}.{}': {}", schemaName, tableName, primaryKeyColumns);
         }
 
         // Remove any PKs that do not exist as part of this this relation message. This can occur when issuing

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteDBVersionTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteDBVersionTest.java
@@ -74,37 +74,36 @@ public class YugabyteDBVersionTest {
     }
 
     @Test
-    public void previewVersionsAtOrAboveThresholdSupportMutablePk() {
+    public void previewVersionsAtOrAboveThresholdHavePkInRelationMessage() {
         // Preview threshold is 2.31.0.0.
-        assertThat(YugabyteDBVersion.parse("2.31.0.0").supportsMutablePrimaryKey()).isTrue();
-        assertThat(YugabyteDBVersion.parse("2.31.1.0").supportsMutablePrimaryKey()).isTrue();
-        assertThat(YugabyteDBVersion.parse("2.33.0.0-b0").supportsMutablePrimaryKey()).isTrue();
+        assertThat(YugabyteDBVersion.parse("2.31.0.0").pkInRelationMessage()).isTrue();
+        assertThat(YugabyteDBVersion.parse("2.31.1.0").pkInRelationMessage()).isTrue();
+        assertThat(YugabyteDBVersion.parse("2.33.0.0-b0").pkInRelationMessage()).isTrue();
     }
 
     @Test
-    public void previewVersionsBelowThresholdDoNotSupportMutablePk() {
-        assertThat(YugabyteDBVersion.parse("2.29.0.0").supportsMutablePrimaryKey()).isFalse();
-        assertThat(YugabyteDBVersion.parse("2.30.9.9").supportsMutablePrimaryKey()).isFalse();
+    public void previewVersionsBelowThresholdDoNotHavePkInRelationMessage() {
+        assertThat(YugabyteDBVersion.parse("2.29.0.0").pkInRelationMessage()).isFalse();
+        assertThat(YugabyteDBVersion.parse("2.30.9.9").pkInRelationMessage()).isFalse();
     }
 
     @Test
-    public void yearBasedVersionsAtOrAboveThresholdSupportMutablePk() {
-        // Year-based threshold is 2026.1.0.0.
-        assertThat(YugabyteDBVersion.parse("2026.1.0.0").supportsMutablePrimaryKey()).isTrue();
-        assertThat(YugabyteDBVersion.parse("2026.1.1.0").supportsMutablePrimaryKey()).isTrue();
-        assertThat(YugabyteDBVersion.parse("2026.2.0.0").supportsMutablePrimaryKey()).isTrue();
+    public void yearBasedVersionsAtOrAboveThresholdHavePkInRelationMessage() {
+        // Year-based threshold is 2025.2.3.0.
+        assertThat(YugabyteDBVersion.parse("2025.2.3.0").pkInRelationMessage()).isTrue();
+        assertThat(YugabyteDBVersion.parse("2025.2.4.0").pkInRelationMessage()).isTrue();
+        assertThat(YugabyteDBVersion.parse("2026.1.0.0").pkInRelationMessage()).isTrue();
     }
 
     @Test
-    public void yearBasedVersionsBelowThresholdDoNotSupportMutablePk() {
-        assertThat(YugabyteDBVersion.parse("2025.2.4.0").supportsMutablePrimaryKey()).isFalse();
-        assertThat(YugabyteDBVersion.parse("2025.2.3.0").supportsMutablePrimaryKey()).isFalse();
-        assertThat(YugabyteDBVersion.parse("2024.2.0.0").supportsMutablePrimaryKey()).isFalse();
+    public void yearBasedVersionsBelowThresholdDoNotHavePkInRelationMessage() {
+        assertThat(YugabyteDBVersion.parse("2025.2.2.0").pkInRelationMessage()).isFalse();
+        assertThat(YugabyteDBVersion.parse("2025.1.0.0").pkInRelationMessage()).isFalse();
+        assertThat(YugabyteDBVersion.parse("2024.2.0.0").pkInRelationMessage()).isFalse();
     }
 
     @Test
-    public void unknownVersionConservativelyDoesNotSupportMutablePk() {
-        // When the version cannot be determined we take the safe DB-query path.
-        assertThat(YugabyteDBVersion.UNKNOWN.supportsMutablePrimaryKey()).isFalse();
+    public void unknownVersionDoesNotHavePkInRelationMessage() {
+        assertThat(YugabyteDBVersion.UNKNOWN.pkInRelationMessage()).isFalse();
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteDBVersionTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteDBVersionTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright YugabyteDB Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link YugabyteDBVersion} parsing, ordering, and feature-gate thresholds.
+ *
+ * @author Shishir Sharma (ssharma@yugabyte.com)
+ */
+public class YugabyteDBVersionTest {
+
+    @Test
+    public void shouldParsePreviewTokenIgnoringBuildSuffix() {
+        YugabyteDBVersion version = YugabyteDBVersion.parse("2.31.0.0-b0");
+        assertThat(version.isKnown()).isTrue();
+        assertThat(version.isYearBased()).isFalse();
+        assertThat(version.toString()).isEqualTo("2.31.0.0-b0");
+    }
+
+    @Test
+    public void shouldParseYearBasedToken() {
+        YugabyteDBVersion version = YugabyteDBVersion.parse("2025.2.3.0");
+        assertThat(version.isKnown()).isTrue();
+        assertThat(version.isYearBased()).isTrue();
+    }
+
+    @Test
+    public void shouldExtractVersionFromFullVersionString() {
+        // The exact form returned by SELECT version() on YugabyteDB.
+        String full = "PostgreSQL 15.12-YB-2.31.0.0-b0 on aarch64-apple-darwin24.6.0, compiled by clang";
+        YugabyteDBVersion version = YugabyteDBVersion.fromVersionString(full);
+        assertThat(version.isKnown()).isTrue();
+        assertThat(version.isYearBased()).isFalse();
+        assertThat(version).isEqualTo(YugabyteDBVersion.parse("2.31.0.0"));
+    }
+
+    @Test
+    public void shouldReturnUnknownForUnparseableInput() {
+        assertThat(YugabyteDBVersion.parse(null)).isEqualTo(YugabyteDBVersion.UNKNOWN);
+        assertThat(YugabyteDBVersion.parse("")).isEqualTo(YugabyteDBVersion.UNKNOWN);
+        assertThat(YugabyteDBVersion.parse("not-a-version")).isEqualTo(YugabyteDBVersion.UNKNOWN);
+        assertThat(YugabyteDBVersion.fromVersionString("PostgreSQL 15.12 (no YB token)"))
+                .isEqualTo(YugabyteDBVersion.UNKNOWN);
+        assertThat(YugabyteDBVersion.UNKNOWN.isKnown()).isFalse();
+    }
+
+    @Test
+    public void shouldOrderYearBasedVersions() {
+        // 2024.1 < 2024.2 < 2025.1 < 2025.2
+        assertThat(YugabyteDBVersion.parse("2024.1.0.0")).isLessThan(YugabyteDBVersion.parse("2024.2.0.0"));
+        assertThat(YugabyteDBVersion.parse("2024.2.0.0")).isLessThan(YugabyteDBVersion.parse("2025.1.0.0"));
+        assertThat(YugabyteDBVersion.parse("2025.1.0.0")).isLessThan(YugabyteDBVersion.parse("2025.2.0.0"));
+    }
+
+    @Test
+    public void shouldOrderPreviewVersions() {
+        // 2.27 < 2.29 < 2.31
+        assertThat(YugabyteDBVersion.parse("2.27.0.0")).isLessThan(YugabyteDBVersion.parse("2.29.0.0"));
+        assertThat(YugabyteDBVersion.parse("2.29.0.0")).isLessThan(YugabyteDBVersion.parse("2.31.0.0"));
+    }
+
+    @Test
+    public void shouldTreatMissingComponentsAsZero() {
+        // "2.29" should be equivalent to "2.29.0.0".
+        assertThat(YugabyteDBVersion.parse("2.29")).isEqualByComparingTo(YugabyteDBVersion.parse("2.29.0.0"));
+        assertThat(YugabyteDBVersion.parse("2025.2.3")).isEqualByComparingTo(YugabyteDBVersion.parse("2025.2.3.0"));
+    }
+
+    @Test
+    public void previewVersionsAtOrAboveThresholdSupportChangePkFix() {
+        // Preview threshold is 2.29.0.0.
+        assertThat(YugabyteDBVersion.parse("2.29.0.0").supportsChangeReplicaIdentityPkInRelation()).isTrue();
+        assertThat(YugabyteDBVersion.parse("2.29.1.0").supportsChangeReplicaIdentityPkInRelation()).isTrue();
+        assertThat(YugabyteDBVersion.parse("2.31.0.0-b0").supportsChangeReplicaIdentityPkInRelation()).isTrue();
+    }
+
+    @Test
+    public void previewVersionsBelowThresholdDoNotSupportChangePkFix() {
+        assertThat(YugabyteDBVersion.parse("2.27.0.0").supportsChangeReplicaIdentityPkInRelation()).isFalse();
+        assertThat(YugabyteDBVersion.parse("2.28.9.9").supportsChangeReplicaIdentityPkInRelation()).isFalse();
+    }
+
+    @Test
+    public void yearBasedVersionsAtOrAboveThresholdSupportChangePkFix() {
+        // Year-based threshold is 2025.2.3.0.
+        assertThat(YugabyteDBVersion.parse("2025.2.3.0").supportsChangeReplicaIdentityPkInRelation()).isTrue();
+        assertThat(YugabyteDBVersion.parse("2025.2.4.0").supportsChangeReplicaIdentityPkInRelation()).isTrue();
+        assertThat(YugabyteDBVersion.parse("2026.1.0.0").supportsChangeReplicaIdentityPkInRelation()).isTrue();
+    }
+
+    @Test
+    public void yearBasedVersionsBelowThresholdDoNotSupportChangePkFix() {
+        assertThat(YugabyteDBVersion.parse("2025.2.2.0").supportsChangeReplicaIdentityPkInRelation()).isFalse();
+        assertThat(YugabyteDBVersion.parse("2025.1.0.0").supportsChangeReplicaIdentityPkInRelation()).isFalse();
+        assertThat(YugabyteDBVersion.parse("2024.2.0.0").supportsChangeReplicaIdentityPkInRelation()).isFalse();
+    }
+
+    @Test
+    public void unknownVersionConservativelyDoesNotSupportChangePkFix() {
+        // When the version cannot be determined we keep the safe DB fallback.
+        assertThat(YugabyteDBVersion.UNKNOWN.supportsChangeReplicaIdentityPkInRelation()).isFalse();
+    }
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteDBVersionTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/YugabyteDBVersionTest.java
@@ -74,37 +74,37 @@ public class YugabyteDBVersionTest {
     }
 
     @Test
-    public void previewVersionsAtOrAboveThresholdSupportChangePkFix() {
-        // Preview threshold is 2.29.0.0.
-        assertThat(YugabyteDBVersion.parse("2.29.0.0").supportsChangeReplicaIdentityPkInRelation()).isTrue();
-        assertThat(YugabyteDBVersion.parse("2.29.1.0").supportsChangeReplicaIdentityPkInRelation()).isTrue();
-        assertThat(YugabyteDBVersion.parse("2.31.0.0-b0").supportsChangeReplicaIdentityPkInRelation()).isTrue();
+    public void previewVersionsAtOrAboveThresholdSupportMutablePk() {
+        // Preview threshold is 2.31.0.0.
+        assertThat(YugabyteDBVersion.parse("2.31.0.0").supportsMutablePrimaryKey()).isTrue();
+        assertThat(YugabyteDBVersion.parse("2.31.1.0").supportsMutablePrimaryKey()).isTrue();
+        assertThat(YugabyteDBVersion.parse("2.33.0.0-b0").supportsMutablePrimaryKey()).isTrue();
     }
 
     @Test
-    public void previewVersionsBelowThresholdDoNotSupportChangePkFix() {
-        assertThat(YugabyteDBVersion.parse("2.27.0.0").supportsChangeReplicaIdentityPkInRelation()).isFalse();
-        assertThat(YugabyteDBVersion.parse("2.28.9.9").supportsChangeReplicaIdentityPkInRelation()).isFalse();
+    public void previewVersionsBelowThresholdDoNotSupportMutablePk() {
+        assertThat(YugabyteDBVersion.parse("2.29.0.0").supportsMutablePrimaryKey()).isFalse();
+        assertThat(YugabyteDBVersion.parse("2.30.9.9").supportsMutablePrimaryKey()).isFalse();
     }
 
     @Test
-    public void yearBasedVersionsAtOrAboveThresholdSupportChangePkFix() {
-        // Year-based threshold is 2025.2.3.0.
-        assertThat(YugabyteDBVersion.parse("2025.2.3.0").supportsChangeReplicaIdentityPkInRelation()).isTrue();
-        assertThat(YugabyteDBVersion.parse("2025.2.4.0").supportsChangeReplicaIdentityPkInRelation()).isTrue();
-        assertThat(YugabyteDBVersion.parse("2026.1.0.0").supportsChangeReplicaIdentityPkInRelation()).isTrue();
+    public void yearBasedVersionsAtOrAboveThresholdSupportMutablePk() {
+        // Year-based threshold is 2026.1.0.0.
+        assertThat(YugabyteDBVersion.parse("2026.1.0.0").supportsMutablePrimaryKey()).isTrue();
+        assertThat(YugabyteDBVersion.parse("2026.1.1.0").supportsMutablePrimaryKey()).isTrue();
+        assertThat(YugabyteDBVersion.parse("2026.2.0.0").supportsMutablePrimaryKey()).isTrue();
     }
 
     @Test
-    public void yearBasedVersionsBelowThresholdDoNotSupportChangePkFix() {
-        assertThat(YugabyteDBVersion.parse("2025.2.2.0").supportsChangeReplicaIdentityPkInRelation()).isFalse();
-        assertThat(YugabyteDBVersion.parse("2025.1.0.0").supportsChangeReplicaIdentityPkInRelation()).isFalse();
-        assertThat(YugabyteDBVersion.parse("2024.2.0.0").supportsChangeReplicaIdentityPkInRelation()).isFalse();
+    public void yearBasedVersionsBelowThresholdDoNotSupportMutablePk() {
+        assertThat(YugabyteDBVersion.parse("2025.2.4.0").supportsMutablePrimaryKey()).isFalse();
+        assertThat(YugabyteDBVersion.parse("2025.2.3.0").supportsMutablePrimaryKey()).isFalse();
+        assertThat(YugabyteDBVersion.parse("2024.2.0.0").supportsMutablePrimaryKey()).isFalse();
     }
 
     @Test
-    public void unknownVersionConservativelyDoesNotSupportChangePkFix() {
-        // When the version cannot be determined we keep the safe DB fallback.
-        assertThat(YugabyteDBVersion.UNKNOWN.supportsChangeReplicaIdentityPkInRelation()).isFalse();
+    public void unknownVersionConservativelyDoesNotSupportMutablePk() {
+        // When the version cannot be determined we take the safe DB-query path.
+        assertThat(YugabyteDBVersion.UNKNOWN.supportsMutablePrimaryKey()).isFalse();
     }
 }


### PR DESCRIPTION
## Problem

The connector needs a table's primary-key columns to build the Kafka record key, and how it discovers them depends on the replica identity:

- For `DEFAULT` and `INDEX` replica identity, the pgoutput/yboutput RELATION message has **always** marked the PK columns in its per-column flags, so the PK is read directly from the message.
- For YugabyteDB's `CHANGE` replica identity, **only newer releases(from 2025.2.3.0) mark the PK in the RELATION message, older releases do not carry PK information for `CHANGE` at all**, so on those versions the PK must be looked up with a database metadata query.

PR #195 added that DB-query fallback for `CHANGE`. PR #199 removed it, assuming the RELATION message always carries the PK for `CHANGE` which is only true from the release that shipped that change (stable `2025.2.3.0`, preview `2.31.0.0`). As a result, on older servers the connector resolves an **empty** primary key for `CHANGE` tables: emitted records have a `null` Kafka key, and downstream consumers break e.g: the `YBExtractNewRecordState` SMT throws a `NullPointerException` on the null key and kills the sink task.

Reported in yugabyte/yugabyte-db#22555.

## Solution

Select the PK-resolution strategy from the detected YugabyteDB server version, with the boundary at the release where the RELATION message begins carrying the PK **for `CHANGE` replica identity** (stable `2025.2.3.0`, preview `2.31.0.0`):

- **Version model** — a new `YugabyteDBVersion` value type parses the YB token from `version()` (e.g. `2025.2.0.0-b131`), ignores any build suffix, and compares format-aware: stable/year-based (`YYYY.minor.patch.rev`) and preview (`major.minor.patch.rev`) lines are only ever compared against the threshold of the same format. `pkInRelationMessage()` reports whether this version marks the PK in the RELATION message for `CHANGE`; an unknown/unparseable version is treated as "does not", so the safe DB-query path is used.
- **Version lookup**: `PostgresConnection` gains a cached `getYugabyteDBVersion()` and a `fetchLatestYugabyteDbVersion(int maxRetries)` that runs `SELECT substring(version() from 'YB-([^\s]+)')`, retrying transient failures up to the configured `slot.max.retries` with a 30s gap (mirroring the existing replication-slot retrieval retry), and throwing `DebeziumException` if the version cannot be read. The version is resolved once, up front, when the replication connection is created, so it is stable for the lifetime of the stream.
- **Decoder gating**: `PgOutputMessageDecoder.handleRelationMessage()` trusts the RELATION-message PK flags for `CHANGE` only when `pkInRelationMessage()` is true, otherwise it resolves the PK with a DB metadata query (`readPrimaryKeyNames`, falling back to unique indices). `DEFAULT`/`INDEX` continue to read the flags and `FULL`/`NOTHING` continue to query the DB — behaviour for those is unchanged.

**Operational note:** the server version is read when each replication connection is created (every connector start/restart) and cached for that connection's lifetime. A continuously-running connector keeps its strategy across an upgrade and stays correct, the one thing to avoid is starting/restarting the connector *during* a rolling upgrade at least for REPLICA IDENTITY CHANGE, when `version()` may report an already-upgraded node while the stream still carries old-format RELATION messages.

## Test Plan

`YugabyteDBVersionTest`:
- previewVersionsAtOrAboveThresholdHavePkInRelationMessage
- previewVersionsBelowThresholdDoNotHavePkInRelationMessage
- yearBasedVersionsAtOrAboveThresholdHavePkInRelationMessage
- yearBasedVersionsBelowThresholdDoNotHavePkInRelationMessage
- unknownVersionDoesNotHavePkInRelationMessage