### PR TITLE
[DBZ-PGYB][yugabyte/yugabyte-db#33126] Derive replication slot flush LSN from committed offsets instead of commitRecord callbacks

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -11,9 +11,11 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 import io.debezium.connector.postgresql.metrics.YugabyteDBMetricsFactory;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -43,7 +45,9 @@ import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.metrics.DefaultChangeEventSourceMetricsFactory;
 import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.signal.SignalProcessor;
+import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Offsets;
+import io.debezium.pipeline.spi.Partition;
 import io.debezium.relational.TableId;
 import io.debezium.schema.SchemaFactory;
 import io.debezium.schema.SchemaNameAdjuster;
@@ -72,6 +76,11 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
     private volatile PostgresSchema schema;
 
     public static boolean TEST_THROW_ERROR_BEFORE_COORDINATOR_STARTUP = false;
+
+    private Partition.Provider<PostgresPartition> partitionProvider = null;
+    private OffsetContext.Loader<PostgresOffsetContext> offsetContextLoader = null;
+
+    private final ReentrantLock commitLock = new ReentrantLock();
 
     @Override
     public ChangeEventSourceCoordinator<PostgresPartition, PostgresOffsetContext> start(Configuration config) {
@@ -125,9 +134,10 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
 
             schema = new PostgresSchema(connectorConfig, defaultValueConverter, topicNamingStrategy, valueConverter);
             this.taskContext = new PostgresTaskContext(connectorConfig, schema, topicNamingStrategy, connectorConfig.getTaskId());
-            final PostgresPartition.Provider partitionProvider = new PostgresPartition.Provider(connectorConfig, config);
+            this.partitionProvider = new PostgresPartition.Provider(connectorConfig, config);
+            this.offsetContextLoader = new PostgresOffsetContext.Loader(connectorConfig);
             final Offsets<PostgresPartition, PostgresOffsetContext> previousOffsets = getPreviousOffsets(
-                    partitionProvider, new PostgresOffsetContext.Loader(connectorConfig));
+                    this.partitionProvider, this.offsetContextLoader);
             final Clock clock = Clock.system();
             final PostgresOffsetContext previousOffset = previousOffsets.getTheOnlyOffset();
 
@@ -394,6 +404,47 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
     @Override
     protected Iterable<Field> getAllConfigurationFields() {
         return PostgresConnectorConfig.ALL_FIELDS;
+    }
+
+    @Override
+    public void commitRecord(SourceRecord record, RecordMetadata metadata) throws InterruptedException {
+        // Do nothing
+    }
+
+    @Override
+    public void commitRecord(SourceRecord record) throws InterruptedException {
+        // Do nothing
+    }
+
+    @Override
+    public void commit() throws InterruptedException {
+        boolean locked = commitLock.tryLock();
+
+        if (locked) {
+            try {
+                if (coordinator != null) {
+                    Offsets<PostgresPartition, PostgresOffsetContext> offsets = this.getPreviousOffsets(this.partitionProvider, this.offsetContextLoader);
+                    if (offsets.getOffsets() != null) {
+                        offsets.getOffsets()
+                                .entrySet()
+                                .stream()
+                                .filter(e -> e.getValue() != null)
+                                .forEach(entry -> {
+                                    Map<String, String> partition = entry.getKey().getSourcePartition();
+                                    Map<String, ?> lastOffset = entry.getValue().getOffset();
+                                    LOGGER.debug("Committing offset '{}' for partition '{}'", partition, lastOffset);
+                                    coordinator.commitOffset(partition, lastOffset);
+                                });
+                    }
+                }
+            }
+            finally {
+                commitLock.unlock();
+            }
+        }
+        else {
+            LOGGER.warn("Couldn't commit processed log positions with the source database due to a concurrent connector shutdown or restart");
+        }
     }
 
     public PostgresTaskContext getTaskContext() {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorTaskCommitTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorTaskCommitTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import io.debezium.pipeline.ChangeEventSourceCoordinator;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.pipeline.spi.Partition;
+
+/**
+ * The replication-slot flush position must be derived from offsets Kafka Connect has actually
+ * committed, never from the per-record {@code commitRecord} acknowledgement callback.
+ *
+ * Producer acknowledgements carry no ordering guarantee across topic-partitions, and records
+ * dropped by an SMT are acknowledged without ever reaching Kafka. A flush position taken from that
+ * callback can therefore move past changes that were never durably written, which is silent data
+ * loss on connector restart. See DBZ-7816.
+ */
+public class PostgresConnectorTaskCommitTest {
+
+    private static final Map<String, String> PARTITION = Collections.singletonMap("server", "srv_0_slot");
+
+    private static final long DURABLE_LSN = 100L;
+    private static final long ACKED_LSN = 999L;
+    private static final long FILTERED_LSN = 1000L;
+
+    private static Map<String, Object> offsetAt(long lsn) {
+        Map<String, Object> offset = new HashMap<>();
+        offset.put("lsn", lsn);
+        offset.put("lsn_commit", lsn);
+        return offset;
+    }
+
+    private static SourceRecord recordAt(long lsn) {
+        return new SourceRecord(PARTITION, offsetAt(lsn), "topic", null, Schema.STRING_SCHEMA, "payload");
+    }
+
+    /** A task whose offset store is a canned value, so neither Kafka nor a database is needed. */
+    private static class TestableTask extends PostgresConnectorTask {
+
+        private final Offsets<PostgresPartition, PostgresOffsetContext> committed;
+
+        TestableTask(Offsets<PostgresPartition, PostgresOffsetContext> committed,
+                     ChangeEventSourceCoordinator<PostgresPartition, PostgresOffsetContext> coordinator) {
+            this.committed = committed;
+            this.coordinator = coordinator;
+        }
+
+        @Override
+        protected Offsets<PostgresPartition, PostgresOffsetContext> getPreviousOffsets(
+                                                                                       Partition.Provider<PostgresPartition> provider,
+                                                                                       OffsetContext.Loader<PostgresOffsetContext> loader) {
+            return committed;
+        }
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void flushPositionMustComeFromCommittedOffsetsNotFromAcknowledgements() throws Exception {
+        // The offset store says everything up to DURABLE_LSN is safely in Kafka.
+        PostgresOffsetContext durable = mock(PostgresOffsetContext.class);
+        when(durable.getOffset()).thenReturn((Map) offsetAt(DURABLE_LSN));
+
+        ChangeEventSourceCoordinator<PostgresPartition, PostgresOffsetContext> coordinator = mock(ChangeEventSourceCoordinator.class);
+        TestableTask task = new TestableTask(
+                Offsets.of(new PostgresPartition("srv", "db", "0", "slot"), durable), coordinator);
+
+        // A later record is acknowledged by the broker while earlier ones are still in flight...
+        task.commitRecord(recordAt(ACKED_LSN));
+        // ...and a later one still is dropped by an SMT, so it never reaches Kafka at all.
+        task.commitRecord(recordAt(FILTERED_LSN), null);
+
+        task.commit();
+
+        ArgumentCaptor<Map<String, ?>> flushed = ArgumentCaptor.forClass(Map.class);
+        verify(coordinator).commitOffset(any(), flushed.capture());
+
+        assertThat(flushed.getValue().get("lsn"))
+                .as("flush position must be the durable committed offset, not an acknowledgement callback")
+                .isEqualTo(DURABLE_LSN);
+    }
+}


### PR DESCRIPTION
## Problem

The connector advances `confirmed_flush_lsn` based on Debezium's `commitRecord` producer-acknowledgement callback instead of what Kafka has actually committed. That callback is unsafe on two counts: acknowledgements have no ordering guarantee across topic-partitions, and a record dropped by an SMT fires the callback without ever being sent to Kafka. Since all records of an LR task share a single Kafka source partition and `updateLastOffset()` is a plain `put`, the position is last-callback-wins and an unacknowledged record leaves no trace.

The flush position can therefore move past changes never durably written to Kafka. The server then GCs the WAL behind it, so on restart those changes cannot be re-delivered, rows committed in the database never reach Kafka. Silent: the task stays RUNNING and Kafka's own offset topic remains correct, because only the connector's separate flush path is wrong.

Reported in yugabyte/yugabyte-db#33126. Upstream fixed the same defect in [DBZ-7816](https://issues.redhat.com/browse/DBZ-7816) (2.6.2.Final), our 2.5.2 base does not carry it.

## Solution

Net effect of the five upstream DBZ-7816 commits as shipped in `2.6.2.Final` ([compare view](https://github.com/debezium/debezium/compare/8477f6240bb474aff1c9f306df51e30580a2f704...29e4db6fb7080e28adb6b0e224a56b4098f5934b)), confined to `PostgresConnectorTask`:

- Both `commitRecord` overloads become no-ops. Both are needed: the Connect runtime calls the two-arg form, `EmbeddedEngine` calls the one-arg form, and 2.5.2's `BaseSourceTask` only overrides the latter.
- `commit()` reads committed offsets via `getPreviousOffsets(...)` and forwards them to `coordinator.commitOffset(...)` under a dedicated `commitLock.tryLock()`.
- The partition provider and offset loader are promoted from `start()` locals to fields.


**Operational note:** filtered records no longer advance the flush position (upstream [DBZ-9490](https://issues.redhat.com/browse/DBZ-9490)), so heartbeats must be enabled and not dropped by an SMT, or `confirmed_flush_lsn` can freeze and the server retains WAL. Streaming-phase heartbeats are already present via #198.

## Test plan

`PostgresConnectorTaskCommitTest`:
- flushPositionMustComeFromCommittedOffsetsNotFromAcknowledgements

Seeds the offset store at LSN 100, fires an acknowledged record (LSN 999) and an SMT-dropped record (LSN 1000, `metadata == null`), then asserts what `commit()` flushes. Fails pre-fix with `expected:<100L> but was:<1000L>`, passes with this change. No broker or database required.

Manual E2E, two Kafka brokers with the captured table's topic pinned RF=1 to the broker that is killed, plus an SMT dropping a second table:
- Pre-fix: `confirmed_flush_lsn` advanced `0/6` → `0/14` past the unacknowledged transaction; after restart the server resumed at `LSN{21}` and 5 committed rows were permanently missing from the topic.
- Post-fix: flush held at `0/6` for the whole outage, server resumed at `LSN{9}`, all 5 rows delivered with no duplicates.